### PR TITLE
Harden release images, verify build artifacts in CI, fix Node-RED installer 404

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -49,7 +49,37 @@ jobs:
           test -f stages/stage-pytak/00-install/01-run-chroot.sh
           test -f shared_files/adsbcot/cockpit-adsbcot_1.0.8_all.deb
           test -f shared_files/dhbridge/dhbridge_0.2.0-3_all.deb
+          test -f shared_files/aryaos/aryaos-lab.sudoers
           test -f config
+
+      - name: Verify image export point
+        # stage-patch strips stage2's EXPORT_IMAGE, so exactly one custom stage must
+        # carry it and be last in every STAGE_LIST — otherwise no image is exported.
+        run: |
+          set -euo pipefail
+          mapfile -t exports < <(ls stages/*/EXPORT_IMAGE)
+          if [ "${#exports[@]}" -ne 1 ]; then
+            echo "Expected exactly one stages/*/EXPORT_IMAGE, found: ${exports[*]:-none}" >&2
+            exit 1
+          fi
+          export_stage="$(basename "$(dirname "${exports[0]}")")"
+          echo "Export stage: ${export_stage}"
+          for cfg in config config.docker .github/workflows/pi-gen.yml; do
+            last="$(grep -E "^[[:space:]]*(stage-list:|STAGE_LIST=)" "$cfg" | head -n1 | awk '{print $NF}' | tr -d '"')"
+            if [[ "$(basename "$last")" != "$export_stage" ]]; then
+              echo "${cfg}: STAGE_LIST does not end with ${export_stage} (ends with ${last})" >&2
+              exit 1
+            fi
+          done
+
+      - name: Verify pinned download URLs are reachable
+        # Catches upstream release renames before they break a 6-hour main build
+        # (e.g. node-red/linux-installers v2.0.0 renamed the deb installer asset).
+        run: |
+          set -euo pipefail
+          url="$(grep -Eo "https://github.com/node-red/linux-installers/[^']+" stages/stage-node-red/00-install/00-run.sh)"
+          curl -fsSIL --max-time 30 -o /dev/null "$url"
+          echo "ok: $url"
 
   build:
     if: github.event_name != 'pull_request'
@@ -144,6 +174,16 @@ jobs:
           path: ${{ steps.build_aryaos.outputs.image-path }}
           retention-days: 30
           if-no-files-found: error
+
+      - name: Verify image contents
+        # Loop-mounts the image and asserts key files, packages, and units exist —
+        # and that no lab access (dev SSH key / NOPASSWD sudo) ships in release images.
+        # Runs after artifact upload so a failure blocks the release but keeps the
+        # artifact for debugging.
+        if: success() && steps.build_aryaos.outputs.image-path != ''
+        run: |
+          set -euo pipefail
+          sudo ./scripts/verify-image.sh "${{ steps.build_aryaos.outputs.image-path }}"
 
       - name: Compute release tag
         id: reltag

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@
 # Proxy URL must match where the pi-gen container reaches the cache. Default uses
 # Docker's host-gateway alias so the inner build container hits a cache published on the host.
 ARYAOS_APT_CACHE ?= 0
+# 1 = lab image: aryaos-dev-lab SSH key + passwordless sudo for pi, no first-boot
+# password expiry. Default 0 — release images carry no lab access.
+ARYAOS_LAB_ACCESS ?= 0
 ARYAOS_APT_CACHER_PORT ?= 3142
 ARYAOS_APT_PROXY_URL ?= http://host.docker.internal:$(ARYAOS_APT_CACHER_PORT)
 
@@ -39,6 +42,7 @@ help:
 	@echo "  apt-cacher-up/down      apt-cacher-ng (docker compose); cache persists in Docker volume"
 	@echo "  apt-cacher-ping         Curl cache UI on http://127.0.0.1:<ARYAOS_APT_CACHER_PORT>"
 	@echo "  ARYAOS_APT_CACHE=1      Prefix for build-docker to use APT_PROXY (after apt-cacher-up)"
+	@echo "  ARYAOS_LAB_ACCESS=1     Prefix for build/build-docker: bake lab SSH key + pi NOPASSWD sudo"
 	@echo "  build-docker-clean      Remove pigen_* containers and .aryaos-pigen-work|deploy only"
 	@echo "  clean                   build-docker-clean + pi-gen/work|deploy + deploy/ + build-*.log"
 	@echo "  clean-logs              Remove repo-root build-*.log only"
@@ -81,7 +85,7 @@ build-docker: pi-gen
 	cd pi-gen && \
 	export GIT_HASH=$$(git -C $(CURDIR) rev-parse HEAD) && \
 	export NUM_CORES=$${NUM_CORES:-$$(nproc)} && \
-	PIGEN_DOCKER_OPTS="-v $(CURDIR):/aryaos:ro -v $(CURDIR)/.aryaos-pigen-work:/pi-gen/work -v $(CURDIR)/.aryaos-pigen-deploy:/pi-gen/deploy -e NUM_CORES=$$NUM_CORES $(PIGEN_APT_CACHE_FLAGS)" \
+	PIGEN_DOCKER_OPTS="-v $(CURDIR):/aryaos:ro -v $(CURDIR)/.aryaos-pigen-work:/pi-gen/work -v $(CURDIR)/.aryaos-pigen-deploy:/pi-gen/deploy -e NUM_CORES=$$NUM_CORES -e ARYAOS_LAB_ACCESS=$(ARYAOS_LAB_ACCESS) $(PIGEN_APT_CACHE_FLAGS)" \
 	./build-docker.sh -c "$(CURDIR)/config.docker"
 
 apt-cacher-up:

--- a/config
+++ b/config
@@ -34,4 +34,9 @@ ENABLE_SSH=1
 # APT_PROXY="http://172.17.2.88:3142"
 SHARED_FILES="$(pwd)/../shared_files"
 export SHARED_FILES
+# Lab access: 1 installs the aryaos-dev-lab SSH key + passwordless sudo for pi and
+# skips the first-boot password expiry. Default 0 — release images must not carry lab access.
+# Native builds: sudo ARYAOS_LAB_ACCESS=1 ./build.sh; Docker: ARYAOS_LAB_ACCESS=1 make build-docker.
+ARYAOS_LAB_ACCESS="${ARYAOS_LAB_ACCESS:-0}"
+export ARYAOS_LAB_ACCESS
 # Optional: export PI_GEN_ROOT for stage-patch if pi-gen dir is not ../pi-gen or ../pi-gen-src relative to repo root.

--- a/config.docker
+++ b/config.docker
@@ -27,5 +27,10 @@ ENABLE_SSH=1
 #APT_PROXY="http://127.0.0.1:3142"
 SHARED_FILES=/aryaos/shared_files
 export SHARED_FILES
+# Lab access: 1 installs the aryaos-dev-lab SSH key + passwordless sudo for pi and
+# skips the first-boot password expiry. Default 0 — release images must not carry lab access.
+# The Makefile forwards ARYAOS_LAB_ACCESS into the build container (ARYAOS_LAB_ACCESS=1 make build-docker).
+ARYAOS_LAB_ACCESS="${ARYAOS_LAB_ACCESS:-0}"
+export ARYAOS_LAB_ACCESS
 PI_GEN_ROOT=/pi-gen
 export PI_GEN_ROOT

--- a/docs/build.md
+++ b/docs/build.md
@@ -33,7 +33,9 @@ Use this checklist when building an **arm64** Raspberry Pi OS–based image on y
 4. After a successful base exists, use **`make skip`** / **`make unskip`** to skip or restore pi-gen **`stage0`–`stage2`** while iterating on AryaOS-only stages (see Makefile).
 5. Optional **apt cache for Docker builds:** `make apt-cacher-up`, then `ARYAOS_APT_CACHE=1 make build-docker` (see Makefile targets **`apt-cacher-*`**; compose file **`docker-compose.apt-cacher.yml`** at repo root).
 6. Optional **logged Docker build:** `./scripts/agent-build-docker.sh` mirrors output to `build-YYYYMMDD-HHMMSS.log`.
-7. Lightweight validation without an image: **`make ansible-syntax`** (requires Ansible / `ansible-galaxy` per Makefile).
+7. **Lab vs release builds:** by default images carry **no lab access** and **expire the default `pi` password at first login**. For a lab image (aryaos-dev-lab SSH key + passwordless sudo for `pi`, no password expiry) build with **`ARYAOS_LAB_ACCESS=1 make build-docker`** (or `sudo ARYAOS_LAB_ACCESS=1 ./build.sh` native). See `shared_files/aryaos/ssh/README.md`.
+8. **Verify a built image:** `sudo scripts/verify-image.sh [--lab] <image>.img|.img.xz|.zip` loop-mounts the image and asserts key files, packages, units — and that release images ship no lab access. CI runs this on every `main` build before publishing a release.
+9. Lightweight validation without an image: **`make ansible-syntax`** (requires Ansible / `ansible-galaxy` per Makefile).
 
 ### Cleanup / retry
 
@@ -80,8 +82,8 @@ To refresh the embedded pi-gen clone after `make pi-gen`, run `cd pi-gen && git 
 
 The workflow `.github/workflows/pi-gen.yml`:
 
-1. **Pull requests** — Runs Ansible collection install, `ansible-playbook --syntax-check`, and checks that key paths (`config`, `manifests/aryaos-sensor-packages.yml`, custom stages) exist. No image is built (GitHub-hosted `ubuntu-latest`).
-2. **Push to `main` or `workflow_dispatch`** — Builds the full pi-gen image on GitHub’s hosted **`ubuntu-24.04-arm`** runner (native **aarch64**) via [usimd/pi-gen-action](https://github.com/usimd/pi-gen-action) (`compression: xz`). No QEMU/`binfmt_misc` emulation step — debootstrap/chroot run natively. Before **`pi-gen-action`**, the workflow frees disk (`dotnet`, Android NDK, hosted toolcache, etc.) because default runner images are tight on space. After a successful build, the workflow creates an annotated tag `v<UTC-datetime>-<12-char-sha>`, pushes it, uploads the image as a **workflow artifact** (30-day retention), and publishes a **GitHub Release** with the image attached (`generate_release_notes`). Builds for the same repo are serialized (`concurrency`, no cancel-in-progress).
+1. **Pull requests** — Runs Ansible collection install, `ansible-playbook --syntax-check`, checks that key paths (`config`, `manifests/aryaos-sensor-packages.yml`, custom stages) exist, validates that exactly **one stage carries `EXPORT_IMAGE`** and is **last in every `STAGE_LIST`**, and HEAD-checks pinned download URLs (catches upstream release renames before they break a 6-hour `main` build). No image is built (GitHub-hosted `ubuntu-latest`).
+2. **Push to `main` or `workflow_dispatch`** — Builds the full pi-gen image on GitHub’s hosted **`ubuntu-24.04-arm`** runner (native **aarch64**) via [usimd/pi-gen-action](https://github.com/usimd/pi-gen-action) (`compression: xz`). No QEMU/`binfmt_misc` emulation step — debootstrap/chroot run natively. Before **`pi-gen-action`**, the workflow frees disk (`dotnet`, Android NDK, hosted toolcache, etc.) because default runner images are tight on space. After a successful build, the workflow uploads the image as a **workflow artifact** (30-day retention), then runs **`scripts/verify-image.sh`** (loop-mounts the image; asserts key files/packages/units and that no lab access ships) — a verification failure keeps the artifact but **blocks the release**. On success it creates an annotated tag `v<UTC-datetime>-<12-char-sha>`, pushes it, and publishes a **GitHub Release** with the image attached (`generate_release_notes`). Builds for the same repo are serialized (`concurrency`, no cancel-in-progress).
 
 **Hosted arm64 notes**
 

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# verify-image.sh — loop-mount a built AryaOS image and assert expected contents.
+#
+# Usage: sudo scripts/verify-image.sh [--lab] <image>.img|.img.xz|.zip
+#
+#   --lab   Expect lab access (ARYAOS_LAB_ACCESS=1 build): dev SSH key and
+#           aryaos-lab sudoers PRESENT. Default expects a release image where
+#           both are ABSENT.
+#
+# Catches a class of regressions the build itself can't: a stage that silently
+# skipped an install (bad SHARED_FILES, missing deb, sed no-op) still exits 0,
+# but the artifact is broken. Run from CI after the image build, or locally
+# against pi-gen deploy output.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+LAB_EXPECTED=0
+if [[ "${1:-}" == "--lab" ]]; then
+	LAB_EXPECTED=1
+	shift
+fi
+
+IMAGE="${1:-}"
+if [[ -z "${IMAGE}" || ! -f "${IMAGE}" ]]; then
+	echo "Usage: sudo $0 [--lab] <image>.img|.img.xz|.zip" >&2
+	exit 2
+fi
+if [[ "$(id -u)" != "0" ]]; then
+	echo "Must run as root (loop-mounts the image)." >&2
+	exit 2
+fi
+
+WORK="$(mktemp -d /tmp/aryaos-verify.XXXXXX)"
+MNT="${WORK}/mnt"
+LOOP=""
+cleanup() {
+	set +e
+	mountpoint -q "${MNT}/boot/firmware" && umount "${MNT}/boot/firmware"
+	mountpoint -q "${MNT}" && umount "${MNT}"
+	[[ -n "${LOOP}" ]] && losetup -d "${LOOP}"
+	rm -rf "${WORK}"
+}
+trap cleanup EXIT
+
+case "${IMAGE}" in
+	*.zip)
+		# python3 zipfile: unzip is not installed everywhere (e.g. minimal build hosts)
+		python3 -m zipfile -e "${IMAGE}" "${WORK}/extract"
+		IMG="$(find "${WORK}/extract" -name '*.img' -print -quit)"
+		;;
+	*.img.xz | *.xz)
+		IMG="${WORK}/image.img"
+		xz -dkc "${IMAGE}" > "${IMG}"
+		;;
+	*.img)
+		IMG="${IMAGE}"
+		;;
+	*)
+		echo "Unsupported image format: ${IMAGE}" >&2
+		exit 2
+		;;
+esac
+if [[ -z "${IMG:-}" || ! -f "${IMG}" ]]; then
+	echo "No .img found in ${IMAGE}" >&2
+	exit 2
+fi
+
+LOOP="$(losetup -Pf --show "${IMG}")"
+# Partition nodes can lag losetup -P briefly.
+for _ in 1 2 3 4 5; do
+	[[ -b "${LOOP}p2" ]] && break
+	sleep 1
+done
+mkdir -p "${MNT}"
+mount -o ro "${LOOP}p2" "${MNT}"
+if [[ -b "${LOOP}p1" ]]; then
+	mkdir -p "${MNT}/boot/firmware" 2>/dev/null || true
+	mount -o ro "${LOOP}p1" "${MNT}/boot/firmware" 2>/dev/null || true
+fi
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS + 1)); echo "ok:   $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*"; }
+
+require_path() {
+	if [[ -e "${MNT}$1" ]]; then ok "$1"; else fail "$1 missing"; fi
+}
+forbid_path() {
+	if [[ ! -e "${MNT}$1" ]]; then ok "$1 absent"; else fail "$1 present (must not ship)"; fi
+}
+require_unit() {
+	local u="$1" d
+	for d in etc/systemd/system lib/systemd/system usr/lib/systemd/system; do
+		if [[ -f "${MNT}/${d}/${u}" ]]; then ok "unit ${u} (${d})"; return; fi
+	done
+	fail "unit ${u} not found in any systemd unit dir"
+}
+require_pkg() {
+	if awk -v pkg="$1" 'BEGIN{RS=""} $0 ~ "Package: "pkg"\n" && /Status: install ok installed/ {found=1} END{exit !found}' \
+		"${MNT}/var/lib/dpkg/status" 2>/dev/null; then
+		ok "package $1 installed"
+	else
+		fail "package $1 not installed"
+	fi
+}
+
+echo "== AryaOS image content checks: ${IMG##*/} (lab=${LAB_EXPECTED}) =="
+
+# Core identity and config (stage-aryaos)
+require_path /etc/aryaos-release
+require_path /etc/aryaos-version
+require_path /etc/aryaos/aryaos-config.txt
+require_path /etc/sudoers.d/aryaos
+require_path /usr/local/sbin/aryaos-firstboot.sh
+require_path /etc/systemd/system/aryaos-firstboot.service
+
+# Portal (stage-aryaos)
+require_path /var/www/html/index.html
+require_path /usr/lib/cgi-bin/aryaos-portal-status
+require_path /etc/lighttpd/conf-enabled/95-aryaos-cockpit-https.conf
+
+# GNSS (stage-aryaos)
+require_path /etc/default/gpsd
+
+# Sensor / CoT stack
+require_pkg dhbridge
+require_unit adsbcot.service
+require_unit aiscot.service
+require_unit dronecot.service
+require_unit lincot.service
+require_unit charontak.service
+require_unit readsb.service
+
+# Node-RED (stage-node-red)
+require_path /home/node-red/.node-red/flows.json
+
+# Lab access must match the build flavor
+if [[ "${LAB_EXPECTED}" == "1" ]]; then
+	require_path /etc/sudoers.d/aryaos-lab
+	if grep -qs 'aryaos-dev-lab' "${MNT}/home/pi/.ssh/authorized_keys"; then
+		ok "aryaos-dev-lab key present (lab build)"
+	else
+		fail "aryaos-dev-lab key missing from authorized_keys (lab build)"
+	fi
+else
+	forbid_path /etc/sudoers.d/aryaos-lab
+	if grep -qs 'aryaos-dev-lab' "${MNT}/home/pi/.ssh/authorized_keys"; then
+		fail "aryaos-dev-lab key present in authorized_keys (release build must not ship lab access)"
+	else
+		ok "no aryaos-dev-lab key in authorized_keys"
+	fi
+	if grep -qs 'NOPASSWD' "${MNT}/etc/sudoers.d/aryaos"; then
+		fail "NOPASSWD rule in /etc/sudoers.d/aryaos (release build)"
+	else
+		ok "no NOPASSWD rule in /etc/sudoers.d/aryaos"
+	fi
+fi
+
+echo "== ${PASS} ok, ${FAIL} failed =="
+[[ "${FAIL}" -eq 0 ]]

--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -68,6 +68,20 @@ if getent group node-red >/dev/null 2>&1 && [[ -d /etc/aryaos ]]; then
 	chown -R node-red /etc/aryaos
 fi
 
+# Images ship with a published default password — force a change at first login.
+# Skipped on lab builds (ARYAOS_LAB_ACCESS=1: /etc/sudoers.d/aryaos-lab) and on
+# hosts that already trust the aryaos-dev-lab key (images built before the gate).
+PASS_EXPIRED_MARKER="/etc/aryaos/.default-pass-expired"
+if [[ ! -f /etc/sudoers.d/aryaos-lab && ! -f "$PASS_EXPIRED_MARKER" ]] \
+	&& ! grep -qs 'aryaos-dev-lab' /home/pi/.ssh/authorized_keys \
+	&& getent passwd pi >/dev/null 2>&1; then
+	if chage -d 0 pi; then
+		touch "$PASS_EXPIRED_MARKER"
+		echo "Default password for user pi expired; a new password is required at next login."
+		CHANGED=1
+	fi
+fi
+
 if [[ "$CHANGED" -eq 0 ]]; then
 	exit 64
 fi

--- a/shared_files/aryaos/aryaos-lab.sudoers
+++ b/shared_files/aryaos/aryaos-lab.sudoers
@@ -1,11 +1,12 @@
-#!/bin/bash -e
-# AryaOS prerun.sh
+# aryaos-lab.sudoers — LAB BUILDS ONLY (installed when ARYAOS_LAB_ACCESS=1).
 #
 # Copyright Sensors & Signals LLC https://www.snstac.com/
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +15,6 @@
 # limitations under the License.
 #
 
-if [ ! -d "${ROOTFS_DIR}" ]; then
-	copy_previous
-fi
-
+# Lab / remote debugging: passwordless sudo for pi (same profile as aryaos-dev-lab SSH key).
+# Anyone with the lab private key can become root; never ship this on field deployments.
+pi ALL=(ALL) NOPASSWD: ALL

--- a/shared_files/aryaos/aryaos.sudoers
+++ b/shared_files/aryaos/aryaos.sudoers
@@ -36,6 +36,5 @@ Defaults!/usr/bin/sudoreplay !log_output
 # Node-RED no longer writes system config from Dashboard (portal + Cockpit + Comitup).
 # node-red runs without sudo group membership; no targeted sudoers entries here.
 
-# Lab / remote debugging: passwordless sudo for pi (same profile as aryaos-dev-lab SSH key).
-# Anyone with the lab private key can become root; restrict network access on field deployments.
-pi ALL=(ALL) NOPASSWD: ALL
+# Lab / remote debugging sudo rules live in aryaos-lab.sudoers, installed as
+# /etc/sudoers.d/aryaos-lab only on lab builds (ARYAOS_LAB_ACCESS=1).

--- a/shared_files/aryaos/ssh/README.md
+++ b/shared_files/aryaos/ssh/README.md
@@ -1,6 +1,6 @@
 # Lab development SSH key (`aryaos-dev-lab`)
 
-- **`aryaos-dev-lab.pub`** — committed; installed into **`pi`**’s **`authorized_keys`** on new AryaOS images (see `stages/stage-aryaos/00-install/00-run.sh`). New images also grant **`pi`** passwordless sudo via **`shared_files/aryaos/aryaos.sudoers`** for lab remote debugging.
+- **`aryaos-dev-lab.pub`** — committed; installed into **`pi`**'s **`authorized_keys`** **only on lab builds** (`ARYAOS_LAB_ACCESS=1`; see `stages/stage-aryaos/00-install/00-run.sh`). Lab builds also grant **`pi`** passwordless sudo via **`shared_files/aryaos/aryaos-lab.sudoers`** (installed as `/etc/sudoers.d/aryaos-lab`). Release builds (the default, including CI) ship **neither**, and expire the default password at first login (`shared_files/aryaos/aryaos-firstboot.sh`).
 - **`aryaos-dev-lab`** — **private** key; **gitignored**. Generate with:
 
   ```bash
@@ -8,6 +8,15 @@
   ```
 
   Keep the private key only on trusted workstations (or a team secrets store). Anyone with the private key can log in as **`pi`** on any host that trusts this public key.
+
+## Building a lab image
+
+```bash
+ARYAOS_LAB_ACCESS=1 make build-docker     # Docker
+sudo ARYAOS_LAB_ACCESS=1 ./build.sh       # native
+```
+
+Verify which flavor an image is with `sudo scripts/verify-image.sh [--lab] <image>`.
 
 ## Local use
 

--- a/shared_files/cloudtak/.env.example
+++ b/shared_files/cloudtak/.env.example
@@ -1,0 +1,6 @@
+# CloudTAK shim credentials — copy to .env next to docker-compose.yml and edit.
+# Used for both the CloudTAK web login and Marti Basic-auth enrollment.
+# Without a .env file the stack falls back to the lab defaults (cloudtak/cloudtak415);
+# never deploy those on a network you don't control.
+CLOUDTAK_USER=cloudtak
+CLOUDTAK_PASSWORD=change-me

--- a/shared_files/cloudtak/README.md
+++ b/shared_files/cloudtak/README.md
@@ -6,7 +6,9 @@ REST calls **`/cloudtak/api/...`** (or **`/api/...`** behind lighttpd’s prefix
 
 ## Default credentials
 
-These are intentionally simple for labs; override in Compose or environment for deployments.
+These are intentionally simple for labs. **Override them on any real deployment**: copy
+`.env.example` to `.env` next to `docker-compose.yml` and set `CLOUDTAK_USER` /
+`CLOUDTAK_PASSWORD` — Compose substitutes them into the shim environment automatically.
 
 Use the **same username and password** for:
 

--- a/shared_files/cloudtak/docker-compose.yml
+++ b/shared_files/cloudtak/docker-compose.yml
@@ -1,13 +1,16 @@
 # CloudTAK-SA shim + web UI for AryaOS (/cloudtak/ via lighttpd).
 # SPDX-License-Identifier: Apache-2.0
 
+# Credentials: set CLOUDTAK_USER / CLOUDTAK_PASSWORD in a .env file next to this
+# compose file (see .env.example). The defaults below are lab-only — override them
+# on any deployment reachable by untrusted networks.
 services:
   shim:
     environment:
-      SA_SHIM_LOGIN_USER: cloudtak
-      SA_SHIM_LOGIN_PASSWORD: cloudtak415
-      SA_SHIM_BASIC_USER: cloudtak
-      SA_SHIM_BASIC_PASSWORD: cloudtak415
+      SA_SHIM_LOGIN_USER: ${CLOUDTAK_USER:-cloudtak}
+      SA_SHIM_LOGIN_PASSWORD: ${CLOUDTAK_PASSWORD:-cloudtak415}
+      SA_SHIM_BASIC_USER: ${CLOUDTAK_USER:-cloudtak}
+      SA_SHIM_BASIC_PASSWORD: ${CLOUDTAK_PASSWORD:-cloudtak415}
     build:
       context: ./shim
       dockerfile: Dockerfile

--- a/stages/stage-adsbcot/prerun.sh
+++ b/stages/stage-adsbcot/prerun.sh
@@ -17,4 +17,3 @@ if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi
 
-export SHARED_FILES=../shared_files

--- a/stages/stage-aiscot/prerun.sh
+++ b/stages/stage-aiscot/prerun.sh
@@ -4,4 +4,3 @@ if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi
 
-export SHARED_FILES=../shared_files

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -89,9 +89,15 @@ chmod 0655 "${ROOTFS_DIR}/var/www/html"
 install -d -m 0755 "${ROOTFS_DIR}/usr/lib/cgi-bin"
 install -v -m 0755 "${SHARED_FILES}/aryaos/cgi-bin/aryaos-portal-status" "${ROOTFS_DIR}/usr/lib/cgi-bin/aryaos-portal-status"
 
-## Lab dev SSH: trust shared_files/aryaos/ssh/aryaos-dev-lab.pub for user pi (passwordless from workstations with the matching private key)
+## Lab access (ARYAOS_LAB_ACCESS=1 only): trust aryaos-dev-lab.pub for user pi and
+## grant pi passwordless sudo. Release builds (default) get neither — see
+## shared_files/aryaos/ssh/README.md and docs/build.md.
+if [[ "${ARYAOS_LAB_ACCESS:-0}" == "1" ]]; then
+	install -v -m 0400 "${SHARED_FILES}/aryaos/aryaos-lab.sudoers" "${ROOTFS_DIR}/etc/sudoers.d/aryaos-lab"
+fi
+
 LAB_PUB="${SHARED_FILES}/aryaos/ssh/aryaos-dev-lab.pub"
-if [[ -f "${LAB_PUB}" ]]; then
+if [[ "${ARYAOS_LAB_ACCESS:-0}" == "1" && -f "${LAB_PUB}" ]]; then
 	install -d -m 0700 "${ROOTFS_DIR}/home/pi/.ssh"
 	AK="${ROOTFS_DIR}/home/pi/.ssh/authorized_keys"
 	touch "${AK}"

--- a/stages/stage-base/00-install/00-run.sh
+++ b/stages/stage-base/00-install/00-run.sh
@@ -16,5 +16,14 @@
 # limitations under the License.
 #
 
-# SHARED_FILES is exported from repo config when building with pi-gen.
-install -v -m 755 "${SHARED_FILES:-../../../shared_files}/base/install_tailscale.sh" "${ROOTFS_DIR}/usr/src/"
+# Same pattern as stage-aryaos: pi-gen does not always export SHARED_FILES into NN-run.sh.
+if [[ -z "${SHARED_FILES:-}" || ! -d "${SHARED_FILES}" ]]; then
+	if [[ -d "/aryaos/shared_files" ]]; then
+		SHARED_FILES="/aryaos/shared_files"
+	else
+		SHARED_FILES="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/shared_files"
+	fi
+fi
+export SHARED_FILES
+
+install -v -m 755 "${SHARED_FILES}/base/install_tailscale.sh" "${ROOTFS_DIR}/usr/src/"

--- a/stages/stage-base/prerun.sh
+++ b/stages/stage-base/prerun.sh
@@ -18,4 +18,3 @@ if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi
 
-export SHARED_FILES=../shared_files

--- a/stages/stage-dhbridge/prerun.sh
+++ b/stages/stage-dhbridge/prerun.sh
@@ -7,12 +7,3 @@
 if [ ! -f "${ROOTFS_DIR}/etc/os-release" ]; then
 	copy_previous
 fi
-
-if [[ -z "${SHARED_FILES:-}" || ! -d "${SHARED_FILES}" ]]; then
-	if [[ -d "/aryaos/shared_files" ]]; then
-		SHARED_FILES="/aryaos/shared_files"
-	else
-		SHARED_FILES="$(cd "$(dirname "$0")/../.." && pwd)/shared_files"
-	fi
-fi
-export SHARED_FILES

--- a/stages/stage-docker/prerun.sh
+++ b/stages/stage-docker/prerun.sh
@@ -4,4 +4,3 @@ if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi
 
-export SHARED_FILES=../shared_files

--- a/stages/stage-node-red/00-install/00-run.sh
+++ b/stages/stage-node-red/00-install/00-run.sh
@@ -14,7 +14,11 @@
 # limitations under the License.
 #
 
-NODE_RED_LINUX_INSTALLER_URL='https://github.com/node-red/linux-installers/releases/latest/download/update-nodejs-and-nodered-deb'
+# Pinned release + checksum: "latest" broke when upstream v2.0.0 renamed the deb asset
+# (update-nodejs-and-nodered-deb → install-update-nodered-deb). v1.1.2 is the last release
+# with the script this stage and 01-run-chroot.sh expect. Bump tag and sha256 together.
+NODE_RED_LINUX_INSTALLER_URL='https://github.com/node-red/linux-installers/releases/download/v1.1.2/update-nodejs-and-nodered-deb'
+NODE_RED_LINUX_INSTALLER_SHA256='ccea2dc0c21046182fdac9101e1578793f83b00479e9688f283ced8ce2db5093'
 
 # Same pattern as stage-aryaos: pi-gen does not always export SHARED_FILES into NN-run.sh.
 if [[ -z "${SHARED_FILES:-}" || ! -d "${SHARED_FILES}" ]]; then
@@ -28,6 +32,7 @@ export SHARED_FILES
 
 mkdir -p "${ROOTFS_DIR}/usr/src"
 curl -fsSL "${NODE_RED_LINUX_INSTALLER_URL}" -o "${ROOTFS_DIR}/usr/src/update-nodejs-and-nodered-deb"
+echo "${NODE_RED_LINUX_INSTALLER_SHA256}  ${ROOTFS_DIR}/usr/src/update-nodejs-and-nodered-deb" | sha256sum -c -
 chmod +x "${ROOTFS_DIR}/usr/src/update-nodejs-and-nodered-deb"
 
 # Node-RED sudoers: consolidated in stage-aryaos (/etc/sudoers.d/aryaos). No node-red fragment.

--- a/stages/stage-node-red/prerun.sh
+++ b/stages/stage-node-red/prerun.sh
@@ -18,4 +18,3 @@ if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi
 
-export SHARED_FILES=../shared_files

--- a/stages/stage-pytak/prerun.sh
+++ b/stages/stage-pytak/prerun.sh
@@ -18,4 +18,3 @@ if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi
 
-export SHARED_FILES=../shared_files

--- a/vars.yml
+++ b/vars.yml
@@ -53,8 +53,9 @@ charontak_ingress_cot_url: udp+ro://127.0.0.1:28087
 charontak_egress_cot_url: udp+wo://239.2.3.1:6969
 charontak_feeder_cot_url: udp+wo://127.0.0.1:28087
 
-# DroneHone Bluetooth sensor bridge — vendored .deb (snstac/dhbridge is private; bump shared_files/dhbridge/).
-dhbridge_version: "0.2.2"
+# DroneHone Bluetooth sensor bridge — vendored .deb (snstac/dhbridge is private; bump
+# shared_files/dhbridge/ and keep dhbridge_version in sync with the vendored deb).
+dhbridge_version: "0.2.0-3"
 dhbridge_deb: "dhbridge_0.2.0-3_all.deb"
 dhbridge_mqtt_broker: localhost
 dhbridge_mqtt_port: 1883


### PR DESCRIPTION
## Summary

- **Gate lab access behind `ARYAOS_LAB_ACCESS=1`** — the `aryaos-dev-lab` SSH key and `pi` NOPASSWD sudo (split into a new `aryaos-lab.sudoers` fragment) no longer ship in default/release builds. Lab images: `ARYAOS_LAB_ACCESS=1 make build-docker`.
- **Expire the published default password at first login** on non-lab images (`aryaos-firstboot.sh`, marker-guarded; hosts already trusting the dev-lab key are exempt, so existing lab Pis are unaffected).
- **CloudTAK shim credentials overridable** via `.env` (`CLOUDTAK_USER` / `CLOUDTAK_PASSWORD`, see `.env.example`).
- **Fix a live build breakage**: node-red/linux-installers v2.0.0 renamed the deb installer asset, so the `releases/latest/...` URL now 404s. Pinned to v1.1.2 with sha256 verification; PR validation now HEAD-checks pinned URLs to catch this class early.
- **Remove dead `export SHARED_FILES=../shared_files`** from stage preruns (pi-gen executes them in subshells, so the export never reached run scripts) and standardize the fallback block in `stage-base`.
- **New `scripts/verify-image.sh`** loop-mounts a built image and asserts key files, dpkg packages, gateway systemd units — and that release images carry no lab access. Runs in CI on `main` builds after artifact upload; a failure keeps the artifact but blocks tag/release.
- **PR validation additions**: exactly one stage carries `EXPORT_IMAGE` and is last in every `STAGE_LIST`.
- Fix `dhbridge_version` in `vars.yml` to match the vendored deb (`0.2.0-3`); remove empty leftover `stages/stage-dronehone-bridge` dirs.

## Test plan

- [x] `bash -n` on all modified shell scripts; YAML parse on workflow/vars/compose
- [x] `verify-image.sh` exercised locally against the 2026-05-12 deploy artifact (mount/dpkg/unit/cleanup mechanics verified; content failures expected on that pre-charontak/dhbridge image)
- [x] New validate-job logic (export-point + URL checks) run locally and passing
- [ ] PR validate job green (watching)
- [ ] First `main` build: confirm `Verify image contents` passes on a fresh image

🤖 Generated with [Claude Code](https://claude.com/claude-code)