### PR TITLE
Add cockpit-gps Cockpit plugin (live GNSS + spoof/jam integrity)

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -12,8 +12,10 @@ on:
       - main
   workflow_dispatch:
 
+# Per-ref group: main image builds serialize against each other, but PR validate
+# jobs don't queue behind (or get cancelled by) multi-hour main builds.
 concurrency:
-  group: aryaos-pi-gen-${{ github.repository }}
+  group: aryaos-pi-gen-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/manifests/aryaos-sensor-packages.yml
+++ b/manifests/aryaos-sensor-packages.yml
@@ -15,3 +15,5 @@ sensor_deb_urls:
   - https://github.com/snstac/aiscot/releases/latest/download/aiscot_latest_all.deb
   # cockpit-aiscot publishes versioned .deb names only (no cockpit-aiscot.deb on latest); bump when tagging upstream.
   - https://github.com/snstac/cockpit-aiscot/releases/download/v1.1.0/cockpit-aiscot_1.1.0_all.deb
+  # cockpit-gps — live GNSS data from gpsd with spoof/jam integrity monitoring; pinned, bump when tagging upstream.
+  - https://github.com/snstac/cockpit-gps/releases/download/v0.2.0/cockpit-gps_0.2.0-1_all.deb

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -128,6 +128,7 @@ require_path /etc/default/gpsd
 
 # Sensor / CoT stack
 require_pkg dhbridge
+require_pkg cockpit-gps
 require_unit adsbcot.service
 require_unit aiscot.service
 require_unit dronecot.service


### PR DESCRIPTION
Adds [snstac/cockpit-gps](https://github.com/snstac/cockpit-gps) v0.2.0 (pinned) to `manifests/aryaos-sensor-packages.yml`, following the cockpit-aiscot pattern — installed in-image by stage-pytak and on existing hosts via Ansible. Dependencies (`cockpit-bridge`, `gpsd-clients`) already ship. `scripts/verify-image.sh` now asserts the package is present in built images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)