### PR TITLE
Enable increase-runner-disk-size: hosted arm64 runners hit ENOSPC

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -132,7 +132,9 @@ jobs:
           PI_GEN_ROOT: ${{ env.PI_GEN_ROOT }}
           RELEASE: ${{ env.RELEASE }}
         with:
-          increase-runner-disk-size: false
+          # Hosted runners sit at the margin: build 27284908891 died ENOSPC in
+          # stage-dronecot, and the post-build verify step decompresses the image.
+          increase-runner-disk-size: true
           export-last-stage-only: true
           compression: xz
           compression-level: 4


### PR DESCRIPTION
Build [27284908891](https://github.com/snstac/aryaos/actions/runs/27284908891) (the #76 merge) died with `No space left on device` while copying the stage-dronecot rootfs — the June 5 build passed with the same config, so the hosted runner was already at the margin. The new post-build `verify-image.sh` step also needs room to decompress the image. `increase-runner-disk-size: true` is pi-gen-action's purpose-built cleanup (the remedy already noted in docs/build.md).

The in-flight build of the current tip will likely fail the same way; this supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)