### PR TITLE
verify-image: accept symlinks whose absolute targets live in the image

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -86,11 +86,14 @@ FAIL=0
 ok()   { PASS=$((PASS + 1)); echo "ok:   $*"; }
 fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*"; }
 
+# -L as well as -e: symlinks in the image often point at absolute paths
+# (e.g. /etc/lighttpd/conf-available/...), which -e would wrongly resolve
+# against the build host's root instead of the mounted image.
 require_path() {
-	if [[ -e "${MNT}$1" ]]; then ok "$1"; else fail "$1 missing"; fi
+	if [[ -e "${MNT}$1" || -L "${MNT}$1" ]]; then ok "$1"; else fail "$1 missing"; fi
 }
 forbid_path() {
-	if [[ ! -e "${MNT}$1" ]]; then ok "$1 absent"; else fail "$1 present (must not ship)"; fi
+	if [[ ! -e "${MNT}$1" && ! -L "${MNT}$1" ]]; then ok "$1 absent"; else fail "$1 present (must not ship)"; fi
 }
 require_unit() {
 	local u="$1" d


### PR DESCRIPTION
Run [27287253891](https://github.com/snstac/aryaos/actions/runs/27287253891) verified 21/22 checks on a correct image — including cockpit-gps installed and no lab access shipped — but failed on `95-aryaos-cockpit-https.conf`: it's a symlink to an absolute path inside the image, which `[[ -e ]]` wrongly resolves against the build host. Also test `-L`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)