### PR TITLE
CI: trim stale stage rootfs trees to fit 72GB arm64 runners

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -170,6 +170,7 @@ jobs:
             -v ${{ github.workspace }}/manifests:${{ github.workspace }}/manifests:ro
             -v ${{ github.workspace }}/pi-gen-src:${{ github.workspace }}/pi-gen-src
             -e GITHUB_WORKSPACE=${{ github.workspace }}
+            -e ARYAOS_CI_TRIM_WORK=1
 
       - name: Show deploy output
         if: success()

--- a/stages/stage-adsbcot/prerun.sh
+++ b/stages/stage-adsbcot/prerun.sh
@@ -13,6 +13,18 @@
 # limitations under the License.
 #
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi

--- a/stages/stage-aiscot/prerun.sh
+++ b/stages/stage-aiscot/prerun.sh
@@ -1,5 +1,17 @@
 #!/bin/bash -e
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi

--- a/stages/stage-aryaos/prerun.sh
+++ b/stages/stage-aryaos/prerun.sh
@@ -14,6 +14,18 @@
 # limitations under the License.
 #
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi

--- a/stages/stage-base/prerun.sh
+++ b/stages/stage-base/prerun.sh
@@ -14,6 +14,18 @@
 # limitations under the License.
 #
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi

--- a/stages/stage-charontak/prerun.sh
+++ b/stages/stage-charontak/prerun.sh
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Sensors & Signals LLC https://www.snstac.com/
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -f "${ROOTFS_DIR}/etc/os-release" ]; then
 	copy_previous
 fi

--- a/stages/stage-dhbridge/prerun.sh
+++ b/stages/stage-dhbridge/prerun.sh
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Sensors & Signals LLC https://www.snstac.com/
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -f "${ROOTFS_DIR}/etc/os-release" ]; then
 	copy_previous
 fi

--- a/stages/stage-docker/prerun.sh
+++ b/stages/stage-docker/prerun.sh
@@ -1,5 +1,17 @@
 #!/bin/bash -e
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi

--- a/stages/stage-dronecot/prerun.sh
+++ b/stages/stage-dronecot/prerun.sh
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Sensors & Signals LLC https://www.snstac.com/
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -f "${ROOTFS_DIR}/etc/os-release" ]; then
 	copy_previous
 fi

--- a/stages/stage-lincot/prerun.sh
+++ b/stages/stage-lincot/prerun.sh
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Sensors & Signals LLC https://www.snstac.com/
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -f "${ROOTFS_DIR}/etc/os-release" ]; then
 	copy_previous
 fi

--- a/stages/stage-node-red/prerun.sh
+++ b/stages/stage-node-red/prerun.sh
@@ -14,6 +14,18 @@
 # limitations under the License.
 #
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi

--- a/stages/stage-pytak/prerun.sh
+++ b/stages/stage-pytak/prerun.sh
@@ -14,6 +14,18 @@
 # limitations under the License.
 #
 
+# CI only (ARYAOS_CI_TRIM_WORK=1): pi-gen full-copies the rootfs per stage and
+# 72GB hosted arm64 runners can't hold ~15 copies. Each stage needs only its
+# predecessor, so drop older trees. Never set locally — breaks make skip reuse.
+if [[ "${ARYAOS_CI_TRIM_WORK:-0}" == "1" && -n "${WORK_DIR:-}" ]]; then
+	for d in "${WORK_DIR}"/*/rootfs; do
+		[[ -d "$d" ]] || continue
+		[[ "$d" -ef "${ROOTFS_DIR}" || "$d" -ef "${PREV_ROOTFS_DIR}" ]] && continue
+		echo "trim-work: removing stale $d"
+		rm -rf "$d"
+	done
+fi
+
 if [ ! -d "${ROOTFS_DIR}" ]; then
 	copy_previous
 fi


### PR DESCRIPTION
pi-gen full-copies the rootfs into every stage's work dir (its `copy_previous` has no `--link-dest`), so 15 stages need ~50–70GB. GitHub's arm64 fleet is heterogeneous: run [27287253891](https://github.com/snstac/aryaos/actions/runs/27287253891) drew a **145GB** VM and passed; runs [27284908891](https://github.com/snstac/aryaos/actions/runs/27284908891) and [27288899990](https://github.com/snstac/aryaos/actions/runs/27288899990) drew **72GB** VMs and died ENOSPC (the latter took the runner agent down with it).

Each stage only reads its predecessor, and only the last stage exports — so each custom stage's `prerun.sh` now deletes older rootfs trees when `ARYAOS_CI_TRIM_WORK=1`, passed via `docker-opts` in CI only. Local builds are unaffected (the flag would break `make skip` cached-stage reuse). Peak drops to ~3 rootfs copies (~20GB), fitting the small runners deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)