### PR TITLE
Pin snstac apt repo above distro archives (995)

### DIFF
--- a/shared_files/aryaos/install-sensor-debs.sh
+++ b/shared_files/aryaos/install-sensor-debs.sh
@@ -23,6 +23,16 @@ done
 install -m 0644 "${KEYRING}" /usr/share/keyrings/snstac.gpg
 install -m 0644 "${SOURCES}" /etc/apt/sources.list.d/snstac.sources
 
+# Outrank distro archives for packages the snstac repo carries: stage-adsbcot
+# pins trixie at 990, which otherwise beats this repo (500) — Debian trixie
+# ships an SDR-less readsb that must never win over snstac's SDR build.
+install -d /etc/apt/preferences.d
+cat > /etc/apt/preferences.d/99-snstac-repo.pref <<'PREF'
+Package: *
+Pin: release o=snstac
+Pin-Priority: 995
+PREF
+
 export _ARYAOS_SENSOR_MANIFEST="${MANIFEST}"
 mapfile -t PKGS < <(python3 - <<'PY'
 import os


### PR DESCRIPTION
Build [27315585242](https://github.com/snstac/aryaos/actions/runs/27315585242): stage-adsbcot's trixie pin (990) outranked the snstac repo (default 500), so apt installed **Debian's SDR-less readsb 3.14.1630** instead of snstac's 3.16.15 SDR build — and the in-chroot SDR asserts failed the build, exactly the failure mode they exist to catch. Pins `release o=snstac` at 995 in `install-sensor-debs.sh` (covers both image and Ansible paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)