### PR TITLE
verify-image: accept held packages (hold ok installed)

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -103,7 +103,7 @@ require_unit() {
 	fail "unit ${u} not found in any systemd unit dir"
 }
 require_pkg() {
-	if awk -v pkg="$1" 'BEGIN{RS=""} $0 ~ "Package: "pkg"\n" && /Status: install ok installed/ {found=1} END{exit !found}' \
+	if awk -v pkg="$1" 'BEGIN{RS=""} $0 ~ "Package: "pkg"\n" && /Status: (install|hold) ok installed/ {found=1} END{exit !found}' \
 		"${MNT}/var/lib/dpkg/status" 2>/dev/null; then
 		ok "package $1 installed"
 	else


### PR DESCRIPTION
Run [27318102704](https://github.com/snstac/aryaos/actions/runs/27318102704) verified 26/27 — readsb IS installed (3.16.15-2 from the snstac repo; the in-chroot SDR asserts passed), but it's `apt-mark hold`-ed by design and held packages report `Status: hold ok installed`, which `require_pkg` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)