### PR TITLE
Add the missing workflow_dispatch release input

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      release:
+        description: "Release build: disable dev mode (no lab SSH key/sudo, first-boot password expiry enforced)"
+        type: boolean
+        default: false
 
 # Per-ref group: main image builds serialize against each other, but PR validate
 # jobs don't queue behind (or get cancelled by) multi-hour main builds.


### PR DESCRIPTION
PR #89's edit for the `workflow_dispatch` inputs block silently no-oped on an anchor mismatch — dev builds work (the env default landed) but `gh workflow run -f release=true` 422s. Adds the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)