### PR TITLE
Cockpit as the master admin surface: AryaOS Site plugin + full plugin fleet

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -166,3 +166,16 @@ An AryaOS Web Dashboard method of doing this is under development. See Issue [#2
 ``sudo systemctl daemon-reload``
 
 ``sudo systemctl restart dump978-fa``
+
+## Cockpit: the AryaOS admin surface
+
+All administration happens in Cockpit at `https://<host>/admin/`:
+
+- **AryaOS Site** (this repo, `shared_files/aryaos/cockpit-aryaos/`) — site-wide settings in
+  `/etc/aryaos/aryaos-config.txt`: the site `COT_URL`, ADS-B decoder selection, UAT serial,
+  and **site-wide TAK TLS certificates** (PEM upload to `/etc/aryaos/tls/`, wired to
+  `PYTAK_TLS_CLIENT_CERT/KEY/CAFILE`; the key is group-readable via `tak-certs`). Every
+  gateway unit inherits the site config via `EnvironmentFile=`; per-service values override it.
+- **Per-tool plugins** (from the snstac apt repo) — cockpit-adsbcot, cockpit-aiscot,
+  cockpit-lincot, cockpit-dronecot, cockpit-aiscatcher, cockpit-gps: service control plus
+  per-service config (`/etc/default/<svc>`) and per-service TLS overrides.

--- a/manifests/aryaos-sensor-packages.yml
+++ b/manifests/aryaos-sensor-packages.yml
@@ -16,6 +16,10 @@ sensor_apt_packages:
   - lincot
   # cockpit-gps — live GNSS data from gpsd with spoof/jam integrity monitoring.
   - cockpit-gps
+  # Cockpit is the AryaOS admin surface: every installed gateway ships its plugin.
+  - cockpit-lincot
+  - cockpit-aiscatcher
+  - cockpit-dronecot
   # dhbridge — DroneHone Bluetooth sensor bridge (public since v0.3.2).
   - dhbridge
 # cockpit-adsbcot is installed by stage-adsbcot (same apt repo).

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -126,6 +126,10 @@ require_path /var/www/html/index.html
 require_path /usr/lib/cgi-bin/aryaos-portal-status
 require_path /etc/lighttpd/conf-enabled/95-aryaos-cockpit-https.conf
 
+# AryaOS Site cockpit plugin (site-wide TAK config + TLS)
+require_path /usr/share/cockpit/aryaos/manifest.json
+require_path /usr/share/cockpit/aryaos/aryaos.js
+
 # GNSS (stage-aryaos)
 require_path /etc/default/gpsd
 
@@ -137,6 +141,9 @@ require_path /etc/apt/sources.list.d/snstac.sources
 require_pkg dhbridge
 require_pkg cockpit-gps
 require_pkg cockpit-adsbcot
+require_pkg cockpit-lincot
+require_pkg cockpit-aiscatcher
+require_pkg cockpit-dronecot
 require_pkg readsb
 require_pkg ais-catcher
 require_unit adsbcot.service

--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -68,6 +68,19 @@ if getent group node-red >/dev/null 2>&1 && [[ -d /etc/aryaos ]]; then
 	chown -R node-red /etc/aryaos
 fi
 
+# Site-wide TAK TLS: gateways read /etc/aryaos/tls/client.key via the tak-certs
+# group (installed from the "AryaOS Site" Cockpit plugin). Service users are
+# created by their debs, so membership is reconciled here on every boot.
+getent group tak-certs >/dev/null 2>&1 || groupadd --system tak-certs
+for svc_user in adsbcot aiscot dronecot lincot charontak dhbridge; do
+	if getent passwd "$svc_user" >/dev/null 2>&1; then
+		usermod -aG tak-certs "$svc_user" 2>/dev/null || true
+	fi
+done
+if [[ -d /etc/aryaos/tls ]]; then
+	chgrp -R tak-certs /etc/aryaos/tls 2>/dev/null || true
+fi
+
 # Images ship with a published default password — force a change at first login.
 # Skipped on lab builds (ARYAOS_LAB_ACCESS=1: /etc/sudoers.d/aryaos-lab) and on
 # hosts that already trust the aryaos-dev-lab key (images built before the gate).

--- a/shared_files/aryaos/cockpit-aryaos/aryaos.css
+++ b/shared_files/aryaos/cockpit-aryaos/aryaos.css
@@ -1,0 +1,24 @@
+/* AryaOS Site cockpit plugin. SPDX-License-Identifier: Apache-2.0 */
+body { font-family: "RedHatText", "Open Sans", Helvetica, Arial, sans-serif; margin: 0; background: #f2f2f2; }
+.aos-main { max-width: 56rem; margin: 0 auto; padding: 1rem 1.5rem 3rem; }
+.aos-sub { color: #4d5258; }
+.aos-card { background: #fff; border: 1px solid #d2d2d2; border-radius: 6px; padding: 1rem 1.25rem; margin: 1rem 0; }
+.aos-card h2 { margin-top: 0; font-size: 1.1rem; }
+.aos-card label { display: block; margin: 0.6rem 0; font-weight: 600; }
+.aos-card input[type="text"], .aos-card select, .aos-card textarea {
+  display: block; width: 100%; box-sizing: border-box; margin-top: 0.25rem;
+  font-weight: 400; font-family: monospace; padding: 0.4rem; border: 1px solid #8a8d90; border-radius: 3px; }
+.aos-row { display: flex; flex-wrap: wrap; gap: 1rem; }
+.aos-row label { flex: 1 1 14rem; }
+.aos-check { font-weight: 400 !important; }
+.aos-hint { color: #4d5258; font-size: 0.85rem; }
+.aos-btn { padding: 0.45rem 1rem; border-radius: 3px; border: 1px solid #06c; background: #fff; color: #06c; cursor: pointer; }
+.aos-btn.aos-primary { background: #06c; color: #fff; }
+.aos-btn:disabled { opacity: 0.5; cursor: default; }
+.aos-actions { margin: 1.25rem 0; display: flex; gap: 0.75rem; align-items: center; }
+.aos-status { font-size: 0.9rem; }
+.aos-status.ok { color: #3e8635; } .aos-status.err { color: #c9190b; }
+.aos-table { width: 100%; border-collapse: collapse; }
+.aos-table td { padding: 0.3rem 0.5rem; border-bottom: 1px solid #ededed; font-family: monospace; }
+.aos-dot { display: inline-block; width: 0.7rem; height: 0.7rem; border-radius: 50%; margin-right: 0.4rem; }
+.aos-dot.active { background: #3e8635; } .aos-dot.inactive { background: #c9190b; } .aos-dot.unknown { background: #8a8d90; }

--- a/shared_files/aryaos/cockpit-aryaos/aryaos.js
+++ b/shared_files/aryaos/cockpit-aryaos/aryaos.js
@@ -1,0 +1,198 @@
+/*
+ * AryaOS Site — site-wide TAK configuration Cockpit plugin.
+ * Edits /etc/aryaos/aryaos-config.txt (inherited by every PyTAK gateway via
+ * EnvironmentFile), installs site-wide TLS certs, restarts the sensor fleet.
+ *
+ * Copyright Sensors & Signals LLC https://www.snstac.com/
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* global cockpit */
+"use strict";
+
+const CONFIG_PATH = "/etc/aryaos/aryaos-config.txt";
+const TLS_DIR = "/etc/aryaos/tls";
+const TLS_GROUP = "tak-certs";
+// Gateways shown in the services card and restarted on save. AOS_SERVICES in
+// the site config wins when set.
+const DEFAULT_SERVICES = ["charontak", "adsbcot", "aiscot", "dronecot", "lincot", "dhbridge", "readsb", "ais-catcher"];
+
+const $ = (id) => document.getElementById(id);
+const configFile = cockpit.file(CONFIG_PATH, { superuser: "try" });
+let configText = "";
+
+function setStatus(el, msg, ok) {
+    el.textContent = msg;
+    el.className = "aos-status " + (ok ? "ok" : "err");
+    if (ok) setTimeout(() => { el.textContent = ""; }, 6000);
+}
+
+/* --- KEY=VALUE editing that preserves comments and unknown lines --- */
+function getKey(text, key) {
+    const m = text.match(new RegExp("^" + key + "=(.*)$", "m"));
+    if (!m) return null;
+    return m[1].replace(/^["']|["']$/g, "");
+}
+
+function setKey(text, key, value) {
+    const line = key + "=" + value;
+    const re = new RegExp("^#?\\s*" + key + "=.*$", "m");
+    if (re.test(text)) return text.replace(re, line);
+    return text.replace(/\n*$/, "\n") + line + "\n";
+}
+
+function serviceList(text) {
+    const raw = getKey(text || "", "AOS_SERVICES");
+    if (!raw) return DEFAULT_SERVICES;
+    return raw.trim().split(/\s+/);
+}
+
+/* --- Config card --- */
+function renderForm(text) {
+    $("cot-url").value = getKey(text, "COT_URL") || "";
+    const dec = getKey(text, "ARYAOS_ADSB_DECODER");
+    if (dec) $("adsb-decoder").value = dec;
+    $("uat-serial").value = getKey(text, "ARYAOS_UAT_RTL_SERIAL") || "";
+    $("tls-dont-verify").checked = (getKey(text, "PYTAK_TLS_DONT_VERIFY") || "") === "1";
+    $("raw-config").value = text;
+}
+
+function collectForm(text) {
+    let out = $("raw-config").value !== configText ? $("raw-config").value : text;
+    out = setKey(out, "COT_URL", $("cot-url").value.trim());
+    if ($("adsb-decoder").value) out = setKey(out, "ARYAOS_ADSB_DECODER", $("adsb-decoder").value);
+    if ($("uat-serial").value.trim()) out = setKey(out, "ARYAOS_UAT_RTL_SERIAL", $("uat-serial").value.trim());
+    if ($("tls-dont-verify").checked) out = setKey(out, "PYTAK_TLS_DONT_VERIFY", "1");
+    else if (getKey(out, "PYTAK_TLS_DONT_VERIFY") !== null) out = setKey(out, "PYTAK_TLS_DONT_VERIFY", "0");
+    return out;
+}
+
+function saveConfig(restart) {
+    const next = collectForm(configText);
+    const el = $("save-status");
+    cockpit.file(CONFIG_PATH, { superuser: "require" }).replace(next)
+        .then(() => {
+            configText = next;
+            renderForm(next);
+            if (!restart) {
+                setStatus(el, "Saved.", true);
+                return;
+            }
+            const units = serviceList(next);
+            return cockpit.spawn(["systemctl", "try-restart", "--"].concat(units),
+                { superuser: "require", err: "message" })
+                .then(() => setStatus(el, "Saved; sensor services restarted.", true))
+                .then(refreshServices);
+        })
+        .catch((ex) => setStatus(el, "Failed: " + (ex.message || ex), false));
+}
+
+/* --- TLS card --- */
+function readPem(input, label) {
+    return new Promise((resolve, reject) => {
+        const f = input.files && input.files[0];
+        if (!f) return resolve(null);
+        const r = new FileReader();
+        r.onerror = () => reject(new Error("could not read " + label));
+        r.onload = () => {
+            const text = String(r.result);
+            if (!text.includes("-----BEGIN"))
+                return reject(new Error(label + " is not PEM (convert .p12 with openssl pkcs12 first)"));
+            resolve(text);
+        };
+        r.readAsText(f);
+    });
+}
+
+function installTls() {
+    const el = $("tls-status");
+    Promise.all([
+        readPem($("tls-cert"), "client certificate"),
+        readPem($("tls-key"), "client key"),
+        readPem($("tls-ca"), "CA chain"),
+    ]).then(([cert, key, ca]) => {
+        if (!cert && !key && !ca)
+            throw new Error("choose at least one PEM file");
+        if ((cert && !key && !tlsConfigured("KEY")) || (key && !cert && !tlsConfigured("CERT")))
+            throw new Error("client certificate and key must both be present");
+
+        const writes = [];
+        const put = (name, content, mode) => {
+            const path = TLS_DIR + "/" + name;
+            writes.push(() =>
+                cockpit.file(path, { superuser: "require" }).replace(content)
+                    .then(() => cockpit.spawn(
+                        ["/bin/sh", "-c",
+                         "chmod " + mode + " '" + path + "'; " +
+                         "chgrp " + TLS_GROUP + " '" + path + "' 2>/dev/null || true"],
+                        { superuser: "require", err: "message" })));
+            return path;
+        };
+
+        let next = configText;
+        if (cert) next = setKey(next, "PYTAK_TLS_CLIENT_CERT", put("client.pem", cert, "0644"));
+        if (key) next = setKey(next, "PYTAK_TLS_CLIENT_KEY", put("client.key", key, "0640"));
+        if (ca) next = setKey(next, "PYTAK_TLS_CLIENT_CAFILE", put("ca.pem", ca, "0644"));
+
+        return cockpit.spawn(["mkdir", "-p", TLS_DIR], { superuser: "require", err: "message" })
+            .then(() => writes.reduce((p, w) => p.then(w), Promise.resolve()))
+            .then(() => cockpit.file(CONFIG_PATH, { superuser: "require" }).replace(next))
+            .then(() => {
+                configText = next;
+                renderForm(next);
+                setStatus(el, "Certificates installed. Save & restart sensors to apply.", true);
+                showCurrentTls();
+            });
+    }).catch((ex) => setStatus(el, "Failed: " + (ex.message || ex), false));
+}
+
+function tlsConfigured(which) {
+    return getKey(configText, "PYTAK_TLS_CLIENT_" + which) !== null;
+}
+
+function showCurrentTls() {
+    cockpit.spawn(["ls", "-l", TLS_DIR], { superuser: "try", err: "ignore" })
+        .then((out) => {
+            const files = out.split("\n").filter((l) => l.includes(".pem") || l.includes(".key"));
+            $("tls-current").textContent = files.length
+                ? "Installed: " + files.map((l) => l.trim().split(/\s+/).pop()).join(", ")
+                : "";
+        })
+        .catch(() => { $("tls-current").textContent = ""; });
+}
+
+/* --- Services card --- */
+function refreshServices() {
+    const units = serviceList(configText);
+    const tbody = $("svc-table").querySelector("tbody");
+    tbody.innerHTML = "";
+    units.forEach((u) => {
+        const tr = document.createElement("tr");
+        const dot = document.createElement("span");
+        dot.className = "aos-dot unknown";
+        const tdDot = document.createElement("td");
+        tdDot.appendChild(dot);
+        tdDot.appendChild(document.createTextNode(u));
+        const tdState = document.createElement("td");
+        tr.appendChild(tdDot);
+        tr.appendChild(tdState);
+        tbody.appendChild(tr);
+        cockpit.spawn(["systemctl", "is-active", u + ".service"], { err: "ignore" })
+            .then((out) => { dot.className = "aos-dot active"; tdState.textContent = out.trim(); })
+            .catch((ex) => {
+                const state = (ex.message || "").trim() || "not installed";
+                dot.className = state === "inactive" || state === "failed" ? "aos-dot inactive" : "aos-dot unknown";
+                tdState.textContent = state;
+            });
+    });
+}
+
+/* --- init --- */
+configFile.watch((content) => {
+    configText = content || "";
+    renderForm(configText);
+    refreshServices();
+    showCurrentTls();
+});
+$("btn-save").addEventListener("click", () => saveConfig(true));
+$("btn-save-only").addEventListener("click", () => saveConfig(false));
+$("btn-tls-upload").addEventListener("click", installTls);

--- a/shared_files/aryaos/cockpit-aryaos/index.html
+++ b/shared_files/aryaos/cockpit-aryaos/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<!--
+AryaOS Site — site-wide TAK configuration for all PyTAK sensor gateways.
+Copyright Sensors & Signals LLC https://www.snstac.com/
+SPDX-License-Identifier: Apache-2.0
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AryaOS Site</title>
+  <link rel="stylesheet" href="aryaos.css">
+  <script src="../base1/cockpit.js"></script>
+</head>
+<body class="pf-v5-m-tabular-nums">
+  <main class="aos-main">
+    <h1>AryaOS Site Configuration</h1>
+    <p class="aos-sub">Site-wide settings in <code>/etc/aryaos/aryaos-config.txt</code>,
+      inherited by every sensor gateway (per-service overrides live in each tool's own
+      Cockpit page). Changes apply on <em>Save &amp; restart sensors</em>.</p>
+
+    <section class="aos-card" id="card-config">
+      <h2>TAK destination</h2>
+      <label>Site COT_URL
+        <input type="text" id="cot-url" placeholder="udp+wo://127.0.0.1:28087">
+      </label>
+      <p class="aos-hint">Default feeds the local Charontak hub; Charontak forwards to Mesh SA
+        and/or a TAK Server (see Charontak lanes). Direct examples:
+        <code>tls://takserver.example.com:8089</code>, <code>udp+wo://239.2.3.1:6969</code>.</p>
+      <label>ADS-B decoder
+        <select id="adsb-decoder">
+          <option value="readsb">readsb (RTL-SDR / SoapySDR / HackRF)</option>
+          <option value="dump1090_fa">dump1090-fa (FlightAware)</option>
+        </select>
+      </label>
+      <label>UAT (978 MHz) RTL-SDR serial
+        <input type="text" id="uat-serial" placeholder="stx:978:0">
+      </label>
+    </section>
+
+    <section class="aos-card" id="card-tls">
+      <h2>Site-wide TAK TLS certificates</h2>
+      <p class="aos-hint">Upload once; every PyTAK gateway inherits
+        <code>PYTAK_TLS_CLIENT_CERT/KEY/CAFILE</code> from the site config. PEM format
+        (for .p12 bundles, convert first: <code>openssl pkcs12 -in bundle.p12 -out client.pem
+        -clcerts -nokeys</code> / <code>-nocerts -nodes</code>).</p>
+      <div class="aos-row">
+        <label>Client certificate (PEM) <input type="file" id="tls-cert" accept=".pem,.crt,.cert"></label>
+        <label>Client key (PEM) <input type="file" id="tls-key" accept=".pem,.key"></label>
+        <label>CA chain (PEM, optional) <input type="file" id="tls-ca" accept=".pem,.crt"></label>
+      </div>
+      <div class="aos-row">
+        <label class="aos-check"><input type="checkbox" id="tls-dont-verify"> Don't verify server certificate
+          (<code>PYTAK_TLS_DONT_VERIFY</code> — lab only)</label>
+      </div>
+      <button class="aos-btn" id="btn-tls-upload">Install certificates</button>
+      <span id="tls-status" class="aos-status"></span>
+      <div id="tls-current" class="aos-hint"></div>
+    </section>
+
+    <section class="aos-card" id="card-services">
+      <h2>Sensor services</h2>
+      <table class="aos-table" id="svc-table"><tbody></tbody></table>
+    </section>
+
+    <div class="aos-actions">
+      <button class="aos-btn aos-primary" id="btn-save">Save &amp; restart sensors</button>
+      <button class="aos-btn" id="btn-save-only">Save only</button>
+      <span id="save-status" class="aos-status"></span>
+    </div>
+
+    <details class="aos-card">
+      <summary>Raw site config (advanced)</summary>
+      <textarea id="raw-config" rows="18" spellcheck="false"></textarea>
+      <p class="aos-hint">Saving the form updates known keys in place and preserves
+        everything else, including comments.</p>
+    </details>
+  </main>
+  <script src="aryaos.js"></script>
+</body>
+</html>

--- a/shared_files/aryaos/cockpit-aryaos/manifest.json
+++ b/shared_files/aryaos/cockpit-aryaos/manifest.json
@@ -1,0 +1,16 @@
+{
+  "version": 0,
+  "menu": {
+    "index": {
+      "label": "AryaOS Site",
+      "order": 5,
+      "docs": [
+        {
+          "label": "AryaOS documentation",
+          "url": "https://aryaos.readthedocs.io/"
+        }
+      ]
+    }
+  },
+  "content-security-policy": "default-src 'self'; style-src 'self' 'unsafe-inline'"
+}

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -89,6 +89,10 @@ chmod 0655 "${ROOTFS_DIR}/var/www/html"
 install -d -m 0755 "${ROOTFS_DIR}/usr/lib/cgi-bin"
 install -v -m 0755 "${SHARED_FILES}/aryaos/cgi-bin/aryaos-portal-status" "${ROOTFS_DIR}/usr/lib/cgi-bin/aryaos-portal-status"
 
+## "AryaOS Site" Cockpit plugin: site-wide TAK config + TLS certs + fleet restart
+install -d -m 0755 "${ROOTFS_DIR}/usr/share/cockpit/aryaos"
+install -v -m 0644 "${SHARED_FILES}/aryaos/cockpit-aryaos/"* "${ROOTFS_DIR}/usr/share/cockpit/aryaos/"
+
 ## Lab access (ARYAOS_LAB_ACCESS=1 only): trust aryaos-dev-lab.pub for user pi and
 ## grant pi passwordless sudo. Release builds (default) get neither — see
 ## shared_files/aryaos/ssh/README.md and docs/build.md.

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -31,5 +31,12 @@ rsync -va "${SHARED_FILES}/dronecot/docker-uas-sensor" "${ROOTFS_DIR}/usr/src/"
 # Script to reset wlan interfaces when restarting dronecot
 # FIXME: Add to DroneCOT deb package installer.
 install -v -m 755 "${SHARED_FILES}/dronecot/reset_wlan.sh" "${ROOTFS_DIR}/usr/local/sbin/"
-mkdir -p "${ROOTFS_DIR}/etc/systemd/service/dronecot.service.d"
-install -v -m 0644 "${SHARED_FILES}/dronecot/execprestart.conf" "${ROOTFS_DIR}/etc/systemd/service/dronecot.service.d"
+mkdir -p "${ROOTFS_DIR}/etc/systemd/system/dronecot.service.d"
+install -v -m 0644 "${SHARED_FILES}/dronecot/execprestart.conf" "${ROOTFS_DIR}/etc/systemd/system/dronecot.service.d"
+
+# Inherit site-wide config (COT_URL, PYTAK_TLS_*) from /etc/aryaos; the unit's own
+# EnvironmentFile=/etc/default/dronecot loads later, so per-service values override.
+if [[ -f "${ROOTFS_DIR}/lib/systemd/system/dronecot.service" ]]; then
+	grep -qF "EnvironmentFile=-/etc/aryaos/aryaos-config.txt" "${ROOTFS_DIR}/lib/systemd/system/dronecot.service" || \
+		sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=-/etc/aryaos/aryaos-config.txt" "${ROOTFS_DIR}/lib/systemd/system/dronecot.service"
+fi

--- a/stages/stage-lincot/00-install/01-run-chroot.sh
+++ b/stages/stage-lincot/00-install/01-run-chroot.sh
@@ -10,3 +10,8 @@ fi
 
 systemctl daemon-reload || true
 systemctl enable lincot.service 2>/dev/null || true
+
+# Inherit site-wide config (COT_URL, PYTAK_TLS_*) from /etc/aryaos; the unit's own
+# EnvironmentFile=/etc/default/lincot loads later, so per-service values override.
+grep -qF "EnvironmentFile=-/etc/aryaos/aryaos-config.txt" /lib/systemd/system/lincot.service || \
+	sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=-/etc/aryaos/aryaos-config.txt" /lib/systemd/system/lincot.service


### PR DESCRIPTION
Makes Cockpit the single admin surface for the PyTAK stack:

- **New "AryaOS Site" Cockpit plugin** (vanilla cockpit.js, no build step) — the missing site-wide layer: edit `/etc/aryaos/aryaos-config.txt` (site COT_URL, ADS-B decoder, UAT serial) with comment-preserving writes; **upload site-wide TAK TLS certs once** (PEM → `/etc/aryaos/tls`, auto-wires `PYTAK_TLS_CLIENT_CERT/KEY/CAFILE`; client key 0640 root:`tak-certs`, group reconciled by firstboot); sensor fleet status + one-click restart (uses `AOS_SERVICES`).
- **Complete per-tool plugin coverage**: adds cockpit-lincot, cockpit-aiscatcher, cockpit-dronecot from the apt repo (adsbcot/aiscot/gps already shipped) — every installed gateway now has its Cockpit page for service control + `/etc/default/<svc>` editing + per-service TLS overrides.
- **Site-config inheritance completed**: lincot and dronecot units now load `/etc/aryaos/aryaos-config.txt` like adsbcot/aiscot/charontak/dhbridge (injected after `[Service]` so per-service values override site defaults).
- **Bug fix**: stage-dronecot installed its drop-in to `/etc/systemd/service/` (bogus, never applied).
- verify-image asserts the plugin fleet + site plugin files.

Known limitations noted in-UI: PEM-only upload (p12 conversion hint shown); per-service plugins remain the place for service-specific overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)