### PR TITLE
Set COT_HOST_ID=aryaos-<suffix> on first boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## AryaOS (Unreleased)
+
+- Set `COT_HOST_ID` to `aryaos-<suffix>` on first boot (in `aryaos-config.txt`,
+  alongside `DEVICE_SUFFIX`) so the PyTAK *cot tools stamp a functional source id
+  into their CoT `_flow-tags_` and remarks.
+
 ## AryaOS 2.0.0
 
 Complete re-write of AryaOS to support both Ansible and Pi-Gen.

--- a/shared_files/aryaos/aryaos-config.txt
+++ b/shared_files/aryaos/aryaos-config.txt
@@ -53,3 +53,7 @@ ARYAOS_UAT_RTL_SERIAL=stx:978:0
 # Device identity — set on first boot by aryaos-firstboot.sh; do not modify. NO STEP.
 # DEVICE_SUFFIX: last 4 hex of machine-id (or MAC); hostname aryaos-xxxx and WiFi AryaOS-xxxx.
 DEVICE_SUFFIX=""
+
+# COT_HOST_ID: functional source id stamped into the CoT _flow-tags_ and remarks by
+# the PyTAK *cot tools. Set on first boot to aryaos-<suffix>; override for a custom name.
+COT_HOST_ID=""

--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -48,6 +48,18 @@ if [[ -z "${DEVICE_SUFFIX}" ]]; then
 	CHANGED=1
 fi
 
+grep -qs -e 'COT_HOST_ID' "$AOS_CONFIG" || echo 'COT_HOST_ID=""' >>"$AOS_CONFIG"
+
+# COT_HOST_ID — functional source id stamped into CoT _flow-tags_/remarks by the
+# PyTAK tools. Defaults to aryaos-<suffix> (matches the hostname).
+if [[ -z "${COT_HOST_ID}" && -n "${DEVICE_SUFFIX}" ]]; then
+	NEW_HOST_ID="aryaos-${DEVICE_SUFFIX}"
+	sed --follow-symlinks -i -E -e "s/^COT_HOST_ID=.*/COT_HOST_ID=${NEW_HOST_ID}/" "$AOS_CONFIG"
+	echo "AryaOS COT_HOST_ID is now set to: $NEW_HOST_ID"
+	COT_HOST_ID="$NEW_HOST_ID"
+	CHANGED=1
+fi
+
 # Hostname — factory image uses "aryaos"; personalize once to aryaos-xxxx.
 CURRENT_HOST="$(hostnamectl hostname 2>/dev/null || hostname -s)"
 if [[ "$CURRENT_HOST" == aryaos && -n "${DEVICE_SUFFIX}" ]]; then


### PR DESCRIPTION
## Summary

The PyTAK `*cot` tools stamp the CoT `_flow-tags_` and remarks from `COT_HOST_ID`,
but AryaOS never set it — so sensors fell back to pytak's `DEFAULT_HOST_ID`
(`pytak@<hostname>`).

This sets `COT_HOST_ID` once on first boot to `aryaos-<suffix>` (matching the
hostname), written into `/etc/aryaos/aryaos-config.txt` right where
`DEVICE_SUFFIX` is derived. Since all `*cot` services already source that env
file, every sensor now advertises a functional source identity in its CoT.

### Changes
- `shared_files/aryaos/aryaos-config.txt`: add `COT_HOST_ID=""` (documented, in the device-identity block).
- `shared_files/aryaos/aryaos-firstboot.sh`: set `COT_HOST_ID=aryaos-${DEVICE_SUFFIX}` when unset, mirroring `DEVICE_SUFFIX`. Idempotent and user-overridable.

> Requires the tool versions that stamp the flow tag from `COT_HOST_ID`
> (adsbcot and dronecot already do; aiscot via snstac/aiscot#14).

## Testing
- `bash -n` clean.
- Simulated the config-write logic: empty config → `COT_HOST_ID=aryaos-<suffix>`; re-run is a no-op when already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)