### PR TITLE
Mount scripts/ and packaging/ into the pi-gen container

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -181,9 +181,13 @@ jobs:
           verbose-output: true
           # pi-gen-action bind-mounts stage dirs only; custom scripts resolve repo paths like
           # ${GITHUB_WORKSPACE}/shared_files — bind those trees into the pi-gen Docker container too.
+          # scripts/ + packaging/ are needed by stage-aryaos to build the aryaos-overlay deb
+          # (without them the [[ -x ]] guard silently skipped it; verify-image now asserts it).
           docker-opts: >-
             -v ${{ github.workspace }}/shared_files:${{ github.workspace }}/shared_files:ro
             -v ${{ github.workspace }}/manifests:${{ github.workspace }}/manifests:ro
+            -v ${{ github.workspace }}/scripts:${{ github.workspace }}/scripts:ro
+            -v ${{ github.workspace }}/packaging:${{ github.workspace }}/packaging:ro
             -v ${{ github.workspace }}/pi-gen-src:${{ github.workspace }}/pi-gen-src
             -e GITHUB_WORKSPACE=${{ github.workspace }}
             -e ARYAOS_CI_TRIM_WORK=1


### PR DESCRIPTION
Second half of the aryaos-overlay fix. `stage-aryaos/00-run.sh` builds the overlay deb via `${REPO_ROOT}/scripts/build-aryaos-overlay-deb.sh`, but the pi-gen container only had `shared_files/` and `manifests/` bind-mounted — the script never existed inside the container, so the `[[ -x ]]` guard skipped the deb silently in every CI image. The exec-bit fix (#109) was necessary but not sufficient; the new `require_pkg aryaos-overlay` assert caught it (run 28642661675: 79 ok, 1 failed).

Adds read-only mounts for `scripts/` and `packaging/` (the deb build also reads `packaging/aryaos-overlay/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY