### PR TITLE
Install the overlay deb after the snstac repo exists

### DIFF
--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -17,11 +17,10 @@
 #
 
 
-# Register the AryaOS appliance overlay package in dpkg when stage-aryaos/00-run.sh
-# built it. Legacy file copies remain in 00-run.sh for now as a fallback.
-if [[ -f /usr/src/aryaos-overlay.deb ]]; then
-	DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/src/aryaos-overlay.deb || dpkg -i /usr/src/aryaos-overlay.deb
-fi
+# The AryaOS overlay deb is built into /usr/src by stage-aryaos/00-run.sh but
+# INSTALLED in stage-pytak/00-install/01-run-chroot.sh: it Depends on pytak,
+# which only becomes installable once stage-pytak configures the snstac apt
+# repo. Legacy file copies remain in 00-run.sh for now as a fallback.
 
 # RFC UUID
 systemctl enable aryaos-firstboot

--- a/stages/stage-pytak/00-install/01-run-chroot.sh
+++ b/stages/stage-pytak/00-install/01-run-chroot.sh
@@ -8,4 +8,14 @@
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 /usr/src/install-sensor-debs.sh /usr/src/aryaos-sensor-packages.yml
+
+# Register the AryaOS appliance overlay package (built by stage-aryaos into
+# /usr/src). Installed here, not in stage-aryaos: it Depends on pytak, which
+# is only resolvable once install-sensor-debs.sh has configured the snstac
+# apt repo above. No dpkg -i fallback — an unresolvable dependency must fail
+# the build, not leave the package unconfigured.
+if [[ -f /usr/src/aryaos-overlay.deb ]]; then
+	DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/src/aryaos-overlay.deb
+fi
+
 /usr/src/patch-cockpit-aryaos-dp


### PR DESCRIPTION
Third and final piece of the aryaos-overlay chain. With the container mounts fixed (#111) the deb now builds, but installing it in stage-aryaos fails: it `Depends: pytak`, and the snstac apt repo only exists once stage-pytak's `install-sensor-debs.sh` has run. The `|| dpkg -i` fallback then left the package unconfigured and failed the build (run 28645157940).

- Keep building the deb in stage-aryaos (`/usr/src/aryaos-overlay.deb`).
- Install it in `stage-pytak/00-install/01-run-chroot.sh` immediately after the sensor debs, before `patch-cockpit-aryaos-dp`.
- Drop the `dpkg -i` fallback — unresolvable deps should fail loudly.

`require_pkg aryaos-overlay` in verify-image gates the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY