### PR TITLE
Put sbin on PATH for remote integration tests

### DIFF
--- a/scripts/aryaos-test/lib.sh
+++ b/scripts/aryaos-test/lib.sh
@@ -2,6 +2,10 @@
 # Shared helpers for remote AryaOS integration tests.
 # SPDX-License-Identifier: Apache-2.0
 
+# Non-interactive SSH sessions get a PATH without sbin, hiding tools like
+# sysctl and turning real checks into silent warns.
+export PATH="${PATH}:/usr/sbin:/sbin"
+
 ARYAOS_TEST_PASSED=0
 ARYAOS_TEST_FAILED=0
 ARYAOS_TEST_WARNED=0


### PR DESCRIPTION
Non-interactive SSH sessions on the Pi get a PATH without /usr/sbin, so the 09-security sysctl check could never find the sysctl binary — `sysctl -n ... 2>/dev/null` returned empty and the check warned "sysctl hardening not applied" even on hardened images (observed on a freshly flashed v2026.07.07.232423 dev image where /etc/sysctl.d/90-aryaos-hardening.conf is present and all redirect sysctls are 0).

Fix: export sbin dirs onto PATH in scripts/aryaos-test/lib.sh so all test modules see sbin tools.

Verified against the lab dev box (aryaos-de37, fresh 2026-07-07 image): 09-security went from 14 passed / 1 warned to 15 passed / 0 warned; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY