### PR TITLE
README: add SEO-optimized Software Suite section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ AryaOS ships with the full [Sensors & Signals](https://www.snstac.com) open-sour
 | [INRCOT — Garmin inReach to TAK gateway](https://github.com/snstac/inrcot) | Displays Garmin inReach satellite tracker positions in TAK. |
 | [SiKW00FCOT — MAVLink drone telemetry to TAK](https://github.com/snstac/sikw00fcot) | Converts SiK-radio MAVLink drone telemetry to Cursor on Target. |
 | [CharonTAK — Cursor on Target ferryman](https://github.com/snstac/charontak) | Bridges & relays CoT between networks and TAK servers. |
-| [COTProxy — CoT transformation proxy](https://github.com/snstac/cotproxy) | Tactical ETL: in-flight transformation of Cursor on Target messages. |
 | [QRTAK — TAK onboarding with QR codes](https://github.com/snstac/qrtak) | Onboard devices to TAK Server by scanning a QR code. |
 
 Every gateway on AryaOS is managed from a touch-friendly browser UI built on [Cockpit](https://cockpit-project.org/), including [cockpit-aryaos](https://github.com/snstac/cockpit-aryaos), [cockpit-adsbcot](https://github.com/snstac/cockpit-adsbcot), [cockpit-aiscot](https://github.com/snstac/cockpit-aiscot), [cockpit-dronecot](https://github.com/snstac/cockpit-dronecot), [cockpit-gpstak](https://github.com/snstac/cockpit-gpstak) & [cockpit-lincot](https://github.com/snstac/cockpit-lincot).

--- a/README.md
+++ b/README.md
@@ -6,12 +6,35 @@ AryaOS is a Linux-based operating system with a suite of situational awareness t
 
 Features of AryaOS:
 
-* Includes decoders and gateways for AIS, ADS-B & Drone Remote ID.
+* Includes decoders and gateways for [AIS](https://github.com/snstac/aiscot), [ADS-B](https://github.com/snstac/adsbcot) & [Drone Remote ID](https://github.com/snstac/dronecot).
 * Works with all TAK Products, including ATAK, WinTAK, iTAK, TAKX & TAK Server.
 * Facilitates rapid test & evaluation of edge node sensors.
 * Browser based low-code development tool for visual programming & open API.
 * Runs on inexpensive COTS & low SWaP-C small board computers, including the Raspberry Pi.
 * Compatible with Intel & Arm (amd64 & arm64) architectures.
+
+## AryaOS Software Suite
+
+AryaOS ships with the full [Sensors & Signals](https://www.snstac.com) open-source suite of Team Awareness Kit (TAK) gateways and Cursor on Target (CoT) tools:
+
+| Project | What it does |
+|---------|--------------|
+| [PyTAK — Python Team Awareness Kit (TAK) library](https://github.com/snstac/pytak) | Python framework for building TAK & Cursor on Target (CoT) integrations. ([PyTAK documentation](https://pytak.readthedocs.io/)) |
+| [ADSBCOT — ADS-B to TAK gateway](https://github.com/snstac/adsbcot) | Displays live aircraft from ADS-B receivers in ATAK, WinTAK & iTAK. ([ADSBCOT documentation](https://adsbcot.readthedocs.io/)) |
+| [AISCOT — AIS to TAK gateway](https://github.com/snstac/aiscot) | Displays ships & maritime vessel traffic from AIS in TAK. ([AISCOT documentation](https://aiscot.readthedocs.io/)) |
+| [DroneCOT — Drone Remote ID to TAK gateway](https://github.com/snstac/dronecot) | Detects & tracks drones (Remote ID / Open Drone ID) in TAK for counter-UAS awareness. |
+| [AIRCOT — aircraft classification for TAK](https://github.com/snstac/aircot) | Classifies aircraft into TAK/CoT types from ADS-B & Mode S data. ([AIRCOT documentation](https://aircot.readthedocs.io/)) |
+| [DJICOT — DJI drone detection for TAK](https://github.com/snstac/djicot) | Detects & tracks DJI drones (DroneID) in TAK. ([DJICOT documentation](https://djicot.readthedocs.io/)) |
+| [GPSTAK — network GPS for TAK](https://github.com/snstac/gpstak) | Streams gpsd position data to TAK as CoT, with NMEA fan-out for WinTAK. |
+| [LINCOT — Linux GPS to TAK gateway](https://github.com/snstac/lincot) | Sends Linux device position (GPS) to TAK. |
+| [APRSCOT — APRS to TAK gateway](https://github.com/snstac/aprscot) | Displays amateur radio APRS stations in TAK. ([APRSCOT documentation](https://aprscot.readthedocs.io/)) |
+| [INRCOT — Garmin inReach to TAK gateway](https://github.com/snstac/inrcot) | Displays Garmin inReach satellite tracker positions in TAK. |
+| [SiKW00FCOT — MAVLink drone telemetry to TAK](https://github.com/snstac/sikw00fcot) | Converts SiK-radio MAVLink drone telemetry to Cursor on Target. |
+| [CharonTAK — Cursor on Target ferryman](https://github.com/snstac/charontak) | Bridges & relays CoT between networks and TAK servers. |
+| [COTProxy — CoT transformation proxy](https://github.com/snstac/cotproxy) | Tactical ETL: in-flight transformation of Cursor on Target messages. |
+| [QRTAK — TAK onboarding with QR codes](https://github.com/snstac/qrtak) | Onboard devices to TAK Server by scanning a QR code. |
+
+Every gateway on AryaOS is managed from a touch-friendly browser UI built on [Cockpit](https://cockpit-project.org/), including [cockpit-aryaos](https://github.com/snstac/cockpit-aryaos), [cockpit-adsbcot](https://github.com/snstac/cockpit-adsbcot), [cockpit-aiscot](https://github.com/snstac/cockpit-aiscot), [cockpit-dronecot](https://github.com/snstac/cockpit-dronecot), [cockpit-gpstak](https://github.com/snstac/cockpit-gpstak) & [cockpit-lincot](https://github.com/snstac/cockpit-lincot).
 
 ## Development (contributors & agents)
 


### PR DESCRIPTION
The aryaos landing page had no links to any of the ecosystem sub-projects. This adds an **AryaOS Software Suite** section with SEO-optimized, keyword-rich anchor text ("ADSBCOT - ADS-B to TAK gateway", "DroneCOT - Drone Remote ID to TAK gateway", ...) for all 14 public snstac projects, verified readthedocs links (the 6 that are live), inline links in the feature bullets, and a paragraph linking the cockpit-* management plugins.

Private repos (dhbridge, kraktak) are deliberately excluded, consistent with #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY