### PR TITLE
Drop cotproxy from PYTAK_TOOLS: project retired

### DIFF
--- a/shared_files/aryaos/install-sensor-debs.sh
+++ b/shared_files/aryaos/install-sensor-debs.sh
@@ -44,7 +44,6 @@ PYTAK_TOOLS = {
     "aiscot",
     "aprscot",
     "charontak",
-    "cotproxy",
     "djicot",
     "dronecot",
     "gpstak",


### PR DESCRIPTION
COTProxy has been retired: repo archived, deprecation notice added, open PR/issues closed. Remove it from the takproto classifier set (it was never in the sensor manifest, so images are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY