### PR TITLE
Field ops without SSH: support bundle, Node-RED password, SDR manager, device roles

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -61,6 +61,10 @@ jobs:
           shellcheck -S error \
             shared_files/aryaos/*.sh \
             shared_files/aryaos/aryaos-update \
+            shared_files/aryaos/aryaos-support-bundle \
+            shared_files/aryaos/aryaos-set-nodered-password \
+            shared_files/aryaos/aryaos-sdr \
+            shared_files/aryaos/aryaos-role \
             scripts/*.sh \
             scripts/aryaos-test/run.sh \
             scripts/aryaos-test/lib.sh \

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -1,7 +1,20 @@
-# Agent handoff — state as of 2026-06-23
+# Agent handoff — state as of 2026-07-16
 
 Working notes for agents (and humans) picking up AryaOS and the snstac fleet.
 Supersedes the 2026-05-16 handoff in [portal.md](portal.md).
+
+## 2026-07-15/16 sweep — "never SSH" + fleet dedup (11 PRs pending merge)
+
+Full review + implementation sweep. **Merge order matters**:
+
+1. [packages#1](https://github.com/snstac/packages/pull/1) — indexes **gdltak** into the apt repo. Merge & publish FIRST or the next image build fails on the manifest.
+2. [aryaos#127](https://github.com/snstac/aryaos/pull/127) — overlay helpers `aryaos-support-bundle` (redacted diagnostics), `aryaos-set-nodered-password` (rotates the fixed default; settings.js → root:node-red 0640), `aryaos-sdr` (RTL enumerate/re-serial; adds `rtl-sdr` pkg — tools were missing, only librtlsdr shipped), `aryaos-role` (runtime multi/air/maritime/cuas/relay; CoT core untouched); gdltak in manifest + air/multi roles; verify-image asserts; helpers added to CI shellcheck (no .sh suffix — globs missed them). Also [#128](https://github.com/snstac/aryaos/pull/128) SBOMs (syft, step runs BEFORE tag push on purpose) and [#130](https://github.com/snstac/aryaos/pull/130) README amd64 soften (tracking #129 — installer-script path first).
+3. [cockpit-aryaos#3](https://github.com/snstac/cockpit-aryaos/pull/3) — six cards (support bundle, Node-RED password, radios, device role, comitup hotspot password, Tailscale join). Helper-backed cards need overlay ≥ 2.2 (from #127).
+4. Any order: [cockpit-charontak#3](https://github.com/snstac/cockpit-charontak/pull/3) — React/TS rewrite + **structured lane editor** (cotUrl.ts is a differentially-tested port of charontak config.py — keep in sync!); shared-lib migrations [cockpit-aiscot#67](https://github.com/snstac/cockpit-aiscot/pull/67), [cockpit-adsbcot#2](https://github.com/snstac/cockpit-adsbcot/pull/2), [cockpit-dronecot#3](https://github.com/snstac/cockpit-dronecot/pull/3) (also deduped 7 shadowed PYTAK_TLS_* conf keys), [cockpit-lincot#8](https://github.com/snstac/cockpit-lincot/pull/8).
+
+New repos: [snstac/cockpit-shared](https://github.com/snstac/cockpit-shared) v1.1.0 (shared serviceCard/tlsCard/envDefaultFile/types; source-shipping `github:` dep, keyless `npm ci` verified; all five fleet plugins consume it) and [snstac/gdltak](https://github.com/snstac/gdltak) v1.0.0 (CoT → GDL90/ForeFlight, 48 tests incl. spec CRC known-answer; deb+rpm released).
+
+Issue tracker triaged 42 → 11 open (closures commented). **Next hardware session**: burn a dev image and exercise all six cards + verify the Cockpit expired-password first-login flow (wizard prereq); 09-security.sh candidates. Then: amd64 installer (#129), unified COP map, track record/replay (#8/#9).
 
 ## Current known-good build
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -67,6 +67,26 @@ expiry), never in posture.
   `readsb` stays on `apt-mark hold` and is reported as held.
 - Per-package operations: Cockpit → Software updates (PackageKit).
 
+## Node-RED admin password
+
+Node-RED ships with a publicly known default admin password (`aryaos415`) and
+the editor can run arbitrary code as the `node-red` user — **rotate it before
+fielding a unit**. Cockpit → AryaOS Site → *Node-RED admin password* does
+this in the browser; the backend is
+`/usr/local/sbin/aryaos-set-nodered-password` (reads the new password on
+stdin, bcrypt-hashes it with Node-RED's bundled bcryptjs, rewrites the
+`adminAuth` entry in `settings.js`, restarts Node-RED).
+
+## Support bundles
+
+Cockpit → AryaOS Site → *Support bundle* generates a downloadable diagnostics
+tarball via `/usr/local/sbin/aryaos-support-bundle`: system/package/service
+state, capped journals, network and firewall state, and sensor-gateway
+configs. Values of keys matching `PASSWORD/TOKEN/SECRET/PASSPHRASE/PSK` and
+`tak://` enrollment credentials are redacted; nothing from `/etc/aryaos/tls`
+or other private key material is included. Bundles land in
+`/var/lib/aryaos/support/` (`0600`, three newest kept).
+
 ## Enforcement
 
 `scripts/verify-image.sh` loop-mounts every built image and asserts this

--- a/manifests/aryaos-sensor-packages.yml
+++ b/manifests/aryaos-sensor-packages.yml
@@ -16,6 +16,10 @@ sensor_apt_packages:
   - dronecot
   - sikw00fcot
   - lincot
+  # gdltak — CoT to GDL90: ForeFlight/EFB display of the TAK air picture.
+  # NOTE: requires gdltak indexed in the apt repo (snstac/packages PR #1) —
+  # merge/publish that before building an image from this manifest.
+  - gdltak
   # cockpit-gps — live GNSS data from gpsd with spoof/jam integrity monitoring.
   - cockpit-gps
   # Cockpit is the AryaOS admin surface: every installed gateway ships its plugin.

--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -66,6 +66,7 @@ install_file 0755 "${SHARED}/aryaos/aryaos-update" "/usr/local/sbin/aryaos-updat
 install_file 0755 "${SHARED}/aryaos/aryaos-support-bundle" "/usr/local/sbin/aryaos-support-bundle"
 install_file 0755 "${SHARED}/aryaos/aryaos-set-nodered-password" "/usr/local/sbin/aryaos-set-nodered-password"
 install_file 0755 "${SHARED}/aryaos/aryaos-sdr" "/usr/local/sbin/aryaos-sdr"
+install_file 0755 "${SHARED}/aryaos/aryaos-role" "/usr/local/sbin/aryaos-role"
 install_file 0755 "${SHARED}/aryaos/run_comitup.sh" "/usr/local/sbin/run_comitup.sh"
 install_file 0755 "${SHARED}/aryaos/comitup-callback.sh" "/usr/local/sbin/comitup-callback.sh"
 install_file 0755 "${SHARED}/aryaos/wifi-nuke.py" "/usr/local/sbin/wifi-nuke.py"

--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -63,6 +63,8 @@ install_file 0755 "${SHARED}/aryaos/aryaos-cot-detail" "/usr/local/sbin/aryaos-c
 install_file 0755 "${SHARED}/aryaos/aryaos-neighbord" "/usr/local/sbin/aryaos-neighbord"
 install_file 0755 "${SHARED}/aryaos/get_throttled.sh" "/usr/local/sbin/get_throttled.sh"
 install_file 0755 "${SHARED}/aryaos/aryaos-update" "/usr/local/sbin/aryaos-update"
+install_file 0755 "${SHARED}/aryaos/aryaos-support-bundle" "/usr/local/sbin/aryaos-support-bundle"
+install_file 0755 "${SHARED}/aryaos/aryaos-set-nodered-password" "/usr/local/sbin/aryaos-set-nodered-password"
 install_file 0755 "${SHARED}/aryaos/run_comitup.sh" "/usr/local/sbin/run_comitup.sh"
 install_file 0755 "${SHARED}/aryaos/comitup-callback.sh" "/usr/local/sbin/comitup-callback.sh"
 install_file 0755 "${SHARED}/aryaos/wifi-nuke.py" "/usr/local/sbin/wifi-nuke.py"

--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -65,6 +65,7 @@ install_file 0755 "${SHARED}/aryaos/get_throttled.sh" "/usr/local/sbin/get_throt
 install_file 0755 "${SHARED}/aryaos/aryaos-update" "/usr/local/sbin/aryaos-update"
 install_file 0755 "${SHARED}/aryaos/aryaos-support-bundle" "/usr/local/sbin/aryaos-support-bundle"
 install_file 0755 "${SHARED}/aryaos/aryaos-set-nodered-password" "/usr/local/sbin/aryaos-set-nodered-password"
+install_file 0755 "${SHARED}/aryaos/aryaos-sdr" "/usr/local/sbin/aryaos-sdr"
 install_file 0755 "${SHARED}/aryaos/run_comitup.sh" "/usr/local/sbin/run_comitup.sh"
 install_file 0755 "${SHARED}/aryaos/comitup-callback.sh" "/usr/local/sbin/comitup-callback.sh"
 install_file 0755 "${SHARED}/aryaos/wifi-nuke.py" "/usr/local/sbin/wifi-nuke.py"

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -196,10 +196,12 @@ require_pkg readsb
 require_pkg python3-gps
 require_pkg ais-catcher
 require_pkg sikw00fcot
+require_pkg gdltak
 require_unit adsbcot.service
 require_unit aiscot.service
 require_unit dronecot.service
 require_unit sikw00fcot.service
+require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service
 require_unit readsb.service

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -238,6 +238,7 @@ require_path /etc/systemd/system/aryaos-update.service
 require_path /usr/local/sbin/aryaos-support-bundle
 require_path /usr/local/sbin/aryaos-set-nodered-password
 require_path /usr/local/sbin/aryaos-sdr
+require_path /usr/local/sbin/aryaos-role
 require_pkg rtl-sdr
 
 # Lab access must match the build flavor

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -234,9 +234,11 @@ require_grep 'web-tls-regenerated' /usr/local/sbin/aryaos-firstboot.sh "firstboo
 require_path /usr/local/sbin/aryaos-update
 require_path /etc/systemd/system/aryaos-update.service
 
-# Field support helpers (Cockpit -> AryaOS Site drives both)
+# Field support helpers (Cockpit -> AryaOS Site drives all three)
 require_path /usr/local/sbin/aryaos-support-bundle
 require_path /usr/local/sbin/aryaos-set-nodered-password
+require_path /usr/local/sbin/aryaos-sdr
+require_pkg rtl-sdr
 
 # Lab access must match the build flavor
 if [[ "${LAB_EXPECTED}" == "1" ]]; then

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -234,6 +234,10 @@ require_grep 'web-tls-regenerated' /usr/local/sbin/aryaos-firstboot.sh "firstboo
 require_path /usr/local/sbin/aryaos-update
 require_path /etc/systemd/system/aryaos-update.service
 
+# Field support helpers (Cockpit -> AryaOS Site drives both)
+require_path /usr/local/sbin/aryaos-support-bundle
+require_path /usr/local/sbin/aryaos-set-nodered-password
+
 # Lab access must match the build flavor
 if [[ "${LAB_EXPECTED}" == "1" ]]; then
 	require_path /etc/sudoers.d/aryaos-lab

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -64,7 +64,7 @@ adsb_decoder_unit() {
 role_units() {
 	local role="$1"
 	local adsb_units ais_units drone_units
-	adsb_units="$(adsb_decoder_unit) dump978-fa adsbcot"
+	adsb_units="$(adsb_decoder_unit) dump978-fa adsbcot gdltak"
 	ais_units="ais-catcher aiscot"
 	drone_units="dronecot sikw00fcot"
 	case "${role}" in
@@ -78,7 +78,7 @@ role_units() {
 }
 
 all_managed_units() {
-	echo "readsb dump1090-fa dump978-fa adsbcot ais-catcher aiscot dronecot sikw00fcot"
+	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot"
 }
 
 unit_exists() {

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -1,0 +1,147 @@
+#!/bin/bash
+# aryaos-role — switch the device's sensor role at runtime.
+#
+# Subcommands:
+#   list        JSON: available roles, their units, and the current role.
+#   set ROLE    Enable/start the role's sensor units, disable/stop the rest,
+#               and persist ARYAOS_ROLE in /etc/aryaos/aryaos-config.txt.
+#
+# Roles select which *sensor* pipelines run; the CoT core (charontak, lincot,
+# gpstak, gpsd) is never touched. The ADS-B decoder unit follows
+# ARYAOS_ADSB_DECODER (readsb | dump1090_fa). Units missing from the image
+# (e.g. optional decoders) are skipped, not errors.
+#
+# Backend for the "Device role" card in Cockpit -> AryaOS Site.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
+ROLES="multi air maritime cuas relay"
+DEFAULT_ROLE="multi"
+
+usage() {
+	echo "usage: aryaos-role {list | set ROLE}  (roles: ${ROLES})" >&2
+	exit 2
+}
+
+require_root() {
+	if [[ "$(id -u)" != "0" ]]; then
+		echo "aryaos-role: must run as root (try sudo)" >&2
+		exit 2
+	fi
+}
+
+config_get() {
+	local key="$1"
+	[[ -f "${SITE_CONFIG}" ]] || return 0
+	sed -n "s/^${key}=[\"']\?\([^\"']*\)[\"']\?$/\1/p" "${SITE_CONFIG}" | tail -1
+}
+
+config_set() {
+	local key="$1" value="$2"
+	if grep -qE "^#?\s*${key}=" "${SITE_CONFIG}"; then
+		sed -i "s|^#\?\s*${key}=.*|${key}=${value}|" "${SITE_CONFIG}"
+	else
+		printf '%s=%s\n' "${key}" "${value}" >> "${SITE_CONFIG}"
+	fi
+}
+
+adsb_decoder_unit() {
+	local decoder
+	decoder="$(config_get ARYAOS_ADSB_DECODER)"
+	if [[ "${decoder}" == "dump1090_fa" ]]; then
+		echo "dump1090-fa"
+	else
+		echo "readsb"
+	fi
+}
+
+# Sensor unit sets per role. The unused ADS-B decoder is always disabled so a
+# decoder switch in site config takes effect on the next role apply.
+role_units() {
+	local role="$1"
+	local adsb_units ais_units drone_units
+	adsb_units="$(adsb_decoder_unit) dump978-fa adsbcot"
+	ais_units="ais-catcher aiscot"
+	drone_units="dronecot sikw00fcot"
+	case "${role}" in
+		multi)    echo "${adsb_units} ${ais_units} ${drone_units}" ;;
+		air)      echo "${adsb_units}" ;;
+		maritime) echo "${ais_units}" ;;
+		cuas)     echo "${drone_units}" ;;
+		relay)    echo "" ;;
+		*)        return 1 ;;
+	esac
+}
+
+all_managed_units() {
+	echo "readsb dump1090-fa dump978-fa adsbcot ais-catcher aiscot dronecot sikw00fcot"
+}
+
+unit_exists() {
+	systemctl list-unit-files --no-legend "$1.service" 2>/dev/null | grep -q .
+}
+
+list_json() {
+	local current
+	current="$(config_get ARYAOS_ROLE)"
+	[[ -n "${current}" ]] || current="${DEFAULT_ROLE}"
+	local role units first=1
+	printf '{"current": "%s", "roles": {' "${current}"
+	for role in ${ROLES}; do
+		units="$(role_units "${role}")"
+		[[ "${first}" == "1" ]] || printf ', '
+		first=0
+		printf '"%s": {"units": [' "${role}"
+		local u sep=""
+		for u in ${units}; do
+			printf '%s"%s"' "${sep}" "${u}"
+			sep=", "
+		done
+		printf ']}'
+	done
+	printf '}}\n'
+}
+
+set_role() {
+	local role="$1"
+	local wanted
+	if ! wanted="$(role_units "${role}")"; then
+		echo "aryaos-role: unknown role '${role}' (roles: ${ROLES})" >&2
+		exit 2
+	fi
+
+	local unit
+	for unit in $(all_managed_units); do
+		unit_exists "${unit}" || continue
+		if [[ " ${wanted} " == *" ${unit} "* ]]; then
+			echo "enable  ${unit}"
+			systemctl enable --now "${unit}" >/dev/null 2>&1 || \
+				echo "aryaos-role: warning: could not start ${unit}" >&2
+		else
+			echo "disable ${unit}"
+			systemctl disable --now "${unit}" >/dev/null 2>&1 || true
+		fi
+	done
+
+	config_set ARYAOS_ROLE "${role}"
+	echo "Device role set to '${role}'."
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+	list)
+		list_json
+		;;
+	set)
+		require_root
+		[[ $# -eq 2 ]] || usage
+		set_role "$2"
+		;;
+	*)
+		usage
+		;;
+esac

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -1,0 +1,122 @@
+#!/bin/bash
+# aryaos-sdr — enumerate RTL-SDR dongles and rewrite their EEPROM serials.
+#
+# Subcommands:
+#   list                       JSON list of detected dongles (index, product, serial).
+#   set-serial INDEX SERIAL    Stop SDR consumers, write a new EEPROM serial,
+#                              restart the consumers that were running.
+#
+# Backend for the "Radios" card in Cockpit -> AryaOS Site (cockpit-aryaos).
+# AryaOS serial conventions: stx:1090:0 (readsb/dump1090), stx:978:0 (UAT,
+# ARYAOS_UAT_RTL_SERIAL). A replug or reboot is required before the new
+# serial is visible to consumers.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Units that claim RTL-SDR devices; stopped/restarted around EEPROM writes.
+SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
+SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
+
+usage() {
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL}" >&2
+	exit 2
+}
+
+require_root() {
+	if [[ "$(id -u)" != "0" ]]; then
+		echo "aryaos-sdr: must run as root (try sudo)" >&2
+		exit 2
+	fi
+}
+
+require_tools() {
+	if ! command -v rtl_test >/dev/null 2>&1 || ! command -v rtl_eeprom >/dev/null 2>&1; then
+		echo "aryaos-sdr: rtl-sdr tools not installed (apt install rtl-sdr)" >&2
+		exit 1
+	fi
+}
+
+# rtl_test with an out-of-range index prints the enumeration to stderr and
+# exits without claiming any device:
+#   Found 2 device(s):
+#     0:  Realtek, RTL2838UHIDIR, SN: stx:1090:0
+#     1:  Realtek, RTL2838UHIDIR, SN: stx:978:0
+list_devices() {
+	rtl_test -d 99 2>&1 | python3 -c '
+import json
+import re
+import sys
+
+devices = []
+for line in sys.stdin:
+    m = re.match(r"\s*(\d+):\s+([^,]*),\s*([^,]*),\s*SN:\s*(.*)$", line.rstrip())
+    if m:
+        devices.append({
+            "index": int(m.group(1)),
+            "vendor": m.group(2).strip(),
+            "product": m.group(3).strip(),
+            "serial": m.group(4).strip(),
+        })
+print(json.dumps({"devices": devices}))
+'
+}
+
+set_serial() {
+	local index="$1" serial="$2"
+	if [[ ! "${index}" =~ ^[0-9]+$ ]]; then
+		echo "aryaos-sdr: INDEX must be a number" >&2
+		exit 2
+	fi
+	if [[ ! "${serial}" =~ ${SERIAL_RE} ]]; then
+		echo "aryaos-sdr: SERIAL must be 1-32 chars of [A-Za-z0-9:._-]" >&2
+		exit 2
+	fi
+
+	# Stop only the SDR consumers that are currently active, remember them.
+	local stopped=()
+	local unit
+	for unit in ${SDR_UNITS}; do
+		if systemctl is-active --quiet "${unit}" 2>/dev/null; then
+			systemctl stop "${unit}"
+			stopped+=("${unit}")
+		fi
+	done
+	restart_stopped() {
+		local u
+		for u in "${stopped[@]:-}"; do
+			[[ -n "${u}" ]] && systemctl start "${u}" || true
+		done
+	}
+	trap restart_stopped EXIT
+
+	echo "Writing serial '${serial}' to RTL-SDR device ${index}..."
+	if ! printf 'y\n' | rtl_eeprom -d "${index}" -s "${serial}" 2>&1; then
+		echo "aryaos-sdr: rtl_eeprom failed (device busy or index gone?)" >&2
+		exit 1
+	fi
+
+	echo "Serial written. Replug the dongle (or reboot) for the new serial to take effect."
+	if [[ "${#stopped[@]}" -gt 0 ]]; then
+		echo "Restarting: ${stopped[*]}"
+	fi
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+	list)
+		require_tools
+		list_devices
+		;;
+	set-serial)
+		require_root
+		require_tools
+		[[ $# -eq 3 ]] || usage
+		set_serial "$2" "$3"
+		;;
+	*)
+		usage
+		;;
+esac

--- a/shared_files/aryaos/aryaos-set-nodered-password
+++ b/shared_files/aryaos/aryaos-set-nodered-password
@@ -1,0 +1,82 @@
+#!/bin/bash
+# aryaos-set-nodered-password — rotate the Node-RED editor admin password.
+#
+# Reads the new password from stdin (first line; never pass secrets on argv),
+# bcrypt-hashes it with Node-RED's own bundled bcryptjs, rewrites the
+# adminAuth entry in settings.js, and restarts Node-RED.
+#
+# Backend for the "Node-RED admin password" control in Cockpit -> AryaOS Site
+# (cockpit-aryaos). Direct use: `echo 'newpass' | sudo aryaos-set-nodered-password`.
+#
+# AryaOS ships Node-RED with a publicly known default admin password; rotate
+# it before fielding a unit (the editor can run arbitrary code as node-red).
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SETTINGS="/home/node-red/.node-red/settings.js"
+NODE_RED_MODULES="/usr/lib/node_modules/node-red/node_modules"
+MIN_LENGTH=8
+
+if [[ "$(id -u)" != "0" ]]; then
+	echo "aryaos-set-nodered-password: must run as root (try sudo)" >&2
+	exit 2
+fi
+
+if [[ ! -f "${SETTINGS}" ]]; then
+	echo "aryaos-set-nodered-password: ${SETTINGS} not found" >&2
+	exit 1
+fi
+if [[ ! -d "${NODE_RED_MODULES}/bcryptjs" ]]; then
+	echo "aryaos-set-nodered-password: bcryptjs not found under ${NODE_RED_MODULES}" >&2
+	exit 1
+fi
+
+IFS= read -r password || true
+if [[ "${#password}" -lt "${MIN_LENGTH}" ]]; then
+	echo "aryaos-set-nodered-password: password must be at least ${MIN_LENGTH} characters" >&2
+	exit 1
+fi
+
+hash="$(printf '%s' "${password}" | NODE_PATH="${NODE_RED_MODULES}" node -e '
+const fs = require("fs");
+const bcrypt = require("bcryptjs");
+const pw = fs.readFileSync(0, "utf8");
+process.stdout.write(bcrypt.hashSync(pw, 8));
+')"
+
+if [[ ! "${hash}" =~ ^\$2[abxy]\$ ]]; then
+	echo "aryaos-set-nodered-password: unexpected bcrypt output" >&2
+	exit 1
+fi
+
+HASH="${hash}" python3 - "${SETTINGS}" <<'EOF'
+import os
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+
+# First user entry inside adminAuth: replace its bcrypt hash only.
+pattern = re.compile(r'(adminAuth:.*?password:\s*")[^"]*(")', re.S)
+new, count = pattern.subn(lambda m: m.group(1) + os.environ["HASH"] + m.group(2), text, count=1)
+if count != 1:
+    sys.exit("no adminAuth password entry found in settings.js")
+
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    f.write(new)
+os.replace(tmp, path)
+EOF
+
+# settings.js only needs to be readable by the node-red user; keep it that way
+# after the atomic replace.
+chown root:node-red "${SETTINGS}" 2>/dev/null || true
+chmod 0640 "${SETTINGS}"
+
+systemctl try-restart nodered.service || true
+
+echo "Node-RED admin password updated; Node-RED restarted."

--- a/shared_files/aryaos/aryaos-support-bundle
+++ b/shared_files/aryaos/aryaos-support-bundle
@@ -1,0 +1,149 @@
+#!/bin/bash
+# aryaos-support-bundle — collect redacted diagnostics into a tarball.
+#
+# Backend for the "Support bundle" card in Cockpit -> AryaOS Site
+# (cockpit-aryaos); also usable directly: `sudo aryaos-support-bundle`.
+# Prints the bundle path on the last line of stdout and records it in
+# /var/lib/aryaos/support-bundle.json. Keeps the three newest bundles.
+#
+# Secrets policy: values of keys matching PASSWORD/TOKEN/SECRET/PASSPHRASE/PSK
+# and tak:// enrollment credentials are replaced with [REDACTED]. Nothing from
+# /etc/aryaos/tls, /etc/charontak/tls, or any private key material is included.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+STATE_DIR="/var/lib/aryaos"
+OUT_DIR="${STATE_DIR}/support"
+STATE_JSON="${STATE_DIR}/support-bundle.json"
+SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
+KEEP_BUNDLES=3
+JOURNAL_BOOT_LINES=4000
+JOURNAL_UNIT_LINES=500
+
+if [[ "$(id -u)" != "0" ]]; then
+	echo "aryaos-support-bundle: must run as root (try sudo)" >&2
+	exit 2
+fi
+
+now_iso() {
+	date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# Mask secret-bearing values in config-style text on stdin.
+redact() {
+	sed -E \
+		-e 's/^([[:space:]]*(export[[:space:]]+)?[A-Za-z0-9_]*(PASSWORD|TOKEN|SECRET|PASSPHRASE|PSK)[A-Za-z0-9_]*[[:space:]]*[=:][[:space:]]*).*/\1[REDACTED]/I' \
+		-e 's#(token=)[^&"[:space:]]+#\1[REDACTED]#Ig' \
+		-e 's#(username=)[^&"[:space:]]+#\1[REDACTED]#Ig'
+}
+
+# run <outfile> <cmd...> — capture a command, never fail the bundle.
+run() {
+	local out="$1"
+	shift
+	{
+		echo "\$ $*"
+		timeout 15 "$@" 2>&1 || echo "[exit $?]"
+	} >> "${out}" 2>&1 || true
+	echo >> "${out}"
+}
+
+# copy_redacted <src> <dst> — copy a config file through the redactor.
+copy_redacted() {
+	local src="$1" dst="$2"
+	[[ -f "${src}" ]] || return 0
+	redact < "${src}" > "${dst}" || true
+}
+
+HOSTNAME_SAFE="$(hostname | tr -c 'A-Za-z0-9.-' '-')"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BUNDLE_NAME="aryaos-support_${HOSTNAME_SAFE}_${STAMP}"
+WORK="$(mktemp -d)"
+ROOT="${WORK}/${BUNDLE_NAME}"
+mkdir -p "${ROOT}/configs" "${ROOT}/journals"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Service list: site config AOS_SERVICES wins, plus infrastructure units.
+AOS_SERVICES="charontak adsbcot aiscot dronecot lincot"
+if [[ -f "${SITE_CONFIG}" ]]; then
+	cfg_services="$(sed -n 's/^AOS_SERVICES=["'\'']\?\([^"'\'']*\)["'\'']\?$/\1/p' "${SITE_CONFIG}" | tail -1)"
+	[[ -n "${cfg_services}" ]] && AOS_SERVICES="${cfg_services}"
+fi
+ALL_UNITS="${AOS_SERVICES} gpstak sikw00fcot readsb dump978-fa ais-catcher gpsd nodered docker lighttpd cockpit.socket firewalld fail2ban comitup aryaos-firstboot aryaos-neighbord aryaos-tak-dp-importd aryaos-bt-pan"
+
+# --- system identity & resources ---
+SYS="${ROOT}/system.txt"
+run "${SYS}" uname -a
+run "${SYS}" cat /etc/aryaos-release /etc/aryaos-version /etc/os-release
+run "${SYS}" uptime
+run "${SYS}" date -u
+run "${SYS}" free -h
+run "${SYS}" df -h
+[[ -x /usr/local/sbin/get_throttled.sh ]] && run "${SYS}" /usr/local/sbin/get_throttled.sh
+if command -v vcgencmd >/dev/null 2>&1; then
+	run "${SYS}" vcgencmd measure_temp
+	run "${SYS}" vcgencmd get_throttled
+fi
+
+# --- packages ---
+run "${ROOT}/packages.txt" bash -c "dpkg-query -W -f '\${Package} \${Version} \${db:Status-Abbrev}\n' | grep -E 'pytak|takproto|aircot|adsbcot|aiscot|dronecot|djicot|lincot|charontak|gpstak|sikw00fcot|cockpit|readsb|dump1090|dump978|ais-catcher|aryaos|gpsd|node-red|nodered|comitup|firewalld|fail2ban' || true"
+
+# --- services & journals ---
+SVC="${ROOT}/services.txt"
+run "${SVC}" systemctl --failed --no-pager
+for unit in ${ALL_UNITS}; do
+	run "${SVC}" systemctl status "${unit}" --no-pager -l -n 20
+done
+journalctl -b --no-pager -n "${JOURNAL_BOOT_LINES}" > "${ROOT}/journals/boot.txt" 2>&1 || true
+for unit in ${AOS_SERVICES} gpstak sikw00fcot readsb gpsd; do
+	journalctl -b -u "${unit}" --no-pager -n "${JOURNAL_UNIT_LINES}" \
+		> "${ROOT}/journals/${unit}.txt" 2>&1 || true
+done
+
+# --- network ---
+NET="${ROOT}/network.txt"
+run "${NET}" ip -br addr
+run "${NET}" ip route
+run "${NET}" cat /etc/resolv.conf
+command -v nmcli >/dev/null 2>&1 && run "${NET}" nmcli -t device status
+if command -v firewall-cmd >/dev/null 2>&1; then
+	run "${NET}" firewall-cmd --state
+	run "${NET}" firewall-cmd --list-all-zones
+fi
+run "${NET}" ss -tulnp
+
+# --- configs (redacted) ---
+copy_redacted "${SITE_CONFIG}" "${ROOT}/configs/aryaos-config.txt"
+copy_redacted /etc/charontak.ini "${ROOT}/configs/charontak.ini"
+copy_redacted /etc/default/gpsd "${ROOT}/configs/default-gpsd"
+for svc in ${AOS_SERVICES} gpstak sikw00fcot charontak; do
+	copy_redacted "/etc/default/${svc}" "${ROOT}/configs/default-${svc}"
+done
+
+# --- sensor snapshots ---
+if [[ -f /run/adsb/aircraft.json ]]; then
+	head -c 16384 /run/adsb/aircraft.json > "${ROOT}/adsb-aircraft.json" 2>/dev/null || true
+fi
+[[ -f /run/aryaos/neighbors.json ]] && cp /run/aryaos/neighbors.json "${ROOT}/neighbors.json"
+if command -v gpspipe >/dev/null 2>&1; then
+	timeout 5 gpspipe -w -n 5 > "${ROOT}/gpsd.json" 2>&1 || true
+fi
+
+# --- pack, rotate, record ---
+mkdir -p "${OUT_DIR}"
+chmod 0700 "${OUT_DIR}"
+BUNDLE_PATH="${OUT_DIR}/${BUNDLE_NAME}.tar.gz"
+tar -C "${WORK}" -czf "${BUNDLE_PATH}" "${BUNDLE_NAME}"
+chmod 0600 "${BUNDLE_PATH}"
+
+ls -1t "${OUT_DIR}"/aryaos-support_*.tar.gz 2>/dev/null | tail -n "+$((KEEP_BUNDLES + 1))" | xargs -r rm -f
+
+SIZE="$(stat -c %s "${BUNDLE_PATH}")"
+printf '{"generated_at": "%s", "path": "%s", "size": %s}\n' \
+	"$(now_iso)" "${BUNDLE_PATH}" "${SIZE}" > "${STATE_JSON}"
+
+echo "Bundle ready (${SIZE} bytes; secrets redacted)."
+echo "${BUNDLE_PATH}"

--- a/stages/stage-adsbcot/03-install-packages/00-packages
+++ b/stages/stage-adsbcot/03-install-packages/00-packages
@@ -5,6 +5,7 @@ git wget unzip curl build-essential python3-dev socat python3-venv ncurses-dev n
 python3-websockets
 librtlsdr0
 librtlsdr-dev
+rtl-sdr
 libsoapysdr-dev
 soapysdr-tools
 soapysdr-module-airspy

--- a/stages/stage-adsbcot/tasks/readsb.yml
+++ b/stages/stage-adsbcot/tasks/readsb.yml
@@ -27,6 +27,7 @@
     name:
       - librtlsdr0
       - librtlsdr-dev
+      - rtl-sdr
       - libsoapysdr-dev
       - soapysdr-tools
       - soapysdr-module-airspy

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -123,6 +123,10 @@ install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-update" "${ROOTFS_DIR}/usr/loc
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-update.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-update.service"
 
+## Field support helpers (driven by Cockpit -> AryaOS Site)
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-support-bundle" "${ROOTFS_DIR}/usr/local/sbin/aryaos-support-bundle"
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-set-nodered-password" "${ROOTFS_DIR}/usr/local/sbin/aryaos-set-nodered-password"
+
 ## gpsd: USB GNSS defaults (see shared_files/aryaos/gpsd.default)
 install -v -m 0644 "${SHARED_FILES}/aryaos/gpsd.default" "${ROOTFS_DIR}/etc/default/gpsd"
 

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -126,6 +126,7 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-update.service" \
 ## Field support helpers (driven by Cockpit -> AryaOS Site)
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-support-bundle" "${ROOTFS_DIR}/usr/local/sbin/aryaos-support-bundle"
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-set-nodered-password" "${ROOTFS_DIR}/usr/local/sbin/aryaos-set-nodered-password"
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-sdr" "${ROOTFS_DIR}/usr/local/sbin/aryaos-sdr"
 
 ## gpsd: USB GNSS defaults (see shared_files/aryaos/gpsd.default)
 install -v -m 0644 "${SHARED_FILES}/aryaos/gpsd.default" "${ROOTFS_DIR}/etc/default/gpsd"

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -127,6 +127,7 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-update.service" \
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-support-bundle" "${ROOTFS_DIR}/usr/local/sbin/aryaos-support-bundle"
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-set-nodered-password" "${ROOTFS_DIR}/usr/local/sbin/aryaos-set-nodered-password"
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-sdr" "${ROOTFS_DIR}/usr/local/sbin/aryaos-sdr"
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-role" "${ROOTFS_DIR}/usr/local/sbin/aryaos-role"
 
 ## gpsd: USB GNSS defaults (see shared_files/aryaos/gpsd.default)
 install -v -m 0644 "${SHARED_FILES}/aryaos/gpsd.default" "${ROOTFS_DIR}/etc/default/gpsd"

--- a/stages/stage-aryaos/tasks/hardening.yml
+++ b/stages/stage-aryaos/tasks/hardening.yml
@@ -91,6 +91,12 @@
     dest: /usr/local/sbin/aryaos-set-nodered-password
     mode: "0755"
 
+- name: Install aryaos-sdr helper
+  ansible.builtin.copy:
+    src: "{{ shared_files }}/aryaos/aryaos-sdr"
+    dest: /usr/local/sbin/aryaos-sdr
+    mode: "0755"
+
 - name: Enable firewalld and fail2ban
   ansible.builtin.systemd_service:
     name: "{{ item }}"

--- a/stages/stage-aryaos/tasks/hardening.yml
+++ b/stages/stage-aryaos/tasks/hardening.yml
@@ -79,6 +79,18 @@
     dest: /etc/systemd/system/aryaos-update.service
     mode: "0644"
 
+- name: Install aryaos-support-bundle helper
+  ansible.builtin.copy:
+    src: "{{ shared_files }}/aryaos/aryaos-support-bundle"
+    dest: /usr/local/sbin/aryaos-support-bundle
+    mode: "0755"
+
+- name: Install aryaos-set-nodered-password helper
+  ansible.builtin.copy:
+    src: "{{ shared_files }}/aryaos/aryaos-set-nodered-password"
+    dest: /usr/local/sbin/aryaos-set-nodered-password
+    mode: "0755"
+
 - name: Enable firewalld and fail2ban
   ansible.builtin.systemd_service:
     name: "{{ item }}"

--- a/stages/stage-aryaos/tasks/hardening.yml
+++ b/stages/stage-aryaos/tasks/hardening.yml
@@ -97,6 +97,12 @@
     dest: /usr/local/sbin/aryaos-sdr
     mode: "0755"
 
+- name: Install aryaos-role helper
+  ansible.builtin.copy:
+    src: "{{ shared_files }}/aryaos/aryaos-role"
+    dest: /usr/local/sbin/aryaos-role
+    mode: "0755"
+
 - name: Enable firewalld and fail2ban
   ansible.builtin.systemd_service:
     name: "{{ item }}"


### PR DESCRIPTION
Four new overlay helpers closing "requires SSH" gaps from the 2026-07-15 project review, all driven by new cockpit-aryaos cards (companion PR snstac/cockpit-aryaos#3):

- **`aryaos-support-bundle`** — one-command redacted diagnostics tarball for field reports: system/package/service state, capped journals, network + firewall state, and sensor-gateway configs. `PASSWORD/TOKEN/SECRET/PASSPHRASE/PSK` values and `tak://` enrollment credentials are `[REDACTED]`; nothing from `/etc/aryaos/tls` or other key material is included. Bundles land in `/var/lib/aryaos/support/` (0600, three newest kept).
- **`aryaos-set-nodered-password`** — rotates the Node-RED editor admin password (publicly known `aryaos415` default; the editor runs arbitrary code as `node-red`). Password on stdin, bcrypt via Node-RED's bundled bcryptjs, atomic `settings.js` rewrite, `try-restart nodered`; `settings.js` tightened to `root:node-red 0640`.
- **`aryaos-sdr`** (closes #21) — `list` enumerates RTL-SDR dongles as JSON without claiming them; `set-serial` stops active SDR consumers, writes the EEPROM serial via `rtl_eeprom`, restarts exactly what it stopped. Adds the `rtl-sdr` package (tools were absent — only librtlsdr shipped).
- **`aryaos-role`** — runtime device-role switching (**multi / air / maritime / cuas / relay**): enables the role's sensor units at boot, disables the rest; CoT core (charontak/lincot/gpstak/gpsd) untouched; ADS-B decoder follows `ARYAOS_ADSB_DECODER`. Generalizes the build-time rpi/uas profile split and adds the missing maritime role.

Wiring: `build-aryaos-overlay-deb.sh`, `stage-aryaos` chroot install, Ansible `hardening.yml`, `verify-image.sh` asserts (four helper paths + `require_pkg rtl-sdr`), and the four helpers added to the CI shellcheck list (no `.sh` suffix — the existing globs missed them). Docs in `docs/security.md`.

Verified: `bash -n` all scripts; redaction sed + settings.js patcher exercised against the real shipped `settings.js`; rtl_test parser and `aryaos-role list` JSON exercised standalone (`python3 -m json.tool` clean); `ansible-playbook --syntax-check` passes.

Not verified on hardware: bundle generation, Node-RED restart, EEPROM writes, and role switching need a live image — suggest exercising all cards on the next dev-image burn (`09-security.sh` candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY