### PR TITLE
Generate SPDX + CycloneDX SBOMs for every image build

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -264,6 +264,29 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Computed release tag ${TAG}"
 
+      - name: Generate SBOMs (SPDX + CycloneDX)
+        # Runs before the tag is pushed so an SBOM failure cannot leave a tag
+        # with no published release behind (see release-hygiene notes).
+        if: success() && steps.build_aryaos.outputs.image-path != ''
+        run: |
+          set -euo pipefail
+          SYFT_VERSION="v1.18.1"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sudo sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
+          sudo bash ./scripts/generate-sbom.sh \
+            "${{ steps.build_aryaos.outputs.image-path }}" \
+            "deploy/sbom/aryaos-${{ steps.reltag.outputs.tag }}"
+          ls -l deploy/sbom/
+
+      - name: Upload SBOM artifact
+        if: success() && steps.build_aryaos.outputs.image-path != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: aryaos-sbom-${{ github.sha }}
+          path: deploy/sbom/
+          retention-days: 90
+          if-no-files-found: error
+
       - name: Create and push release tag
         if: success() && steps.build_aryaos.outputs.image-path != ''
         run: |
@@ -292,6 +315,9 @@ jobs:
           args=(release create "$TAG" "${{ steps.build_aryaos.outputs.image-path }}" --title "$TAG" --generate-notes --notes "$BODY" --verify-tag)
           for deb in deploy/debs/aryaos-overlay_*_all.deb; do
             [ -f "$deb" ] && args+=("$deb")
+          done
+          for sbom in deploy/sbom/aryaos-*.json; do
+            [ -f "$sbom" ] && args+=("$sbom")
           done
           if [ "${ARYAOS_LAB_ACCESS}" = "1" ]; then
             args+=(--prerelease)

--- a/docs/build.md
+++ b/docs/build.md
@@ -92,6 +92,19 @@ The workflow `.github/workflows/pi-gen.yml`:
 - **`usimd/pi-gen-action`** mounts **stage directories** into the pi-gen Docker container, but not the whole repo. This workflow passes **`docker-opts`** so **`shared_files/`**, **`manifests/`**, and the checkout **`pi-gen-src/`** appear at the same **`${{ github.workspace }}` paths** inside the container (needed for `../../../shared_files`, **`REPO_ROOT`/manifests**, and **`stage-patch`** edits under **`pi-gen-src`**).
 - If disk pressure persists on hosted runners, consider enabling **`increase-runner-disk-size`** on **`pi-gen-action`** or trimming stages; pi-gen **work/** trees are large.
 
+### SBOMs
+
+Every image build also produces a **Software Bill of Materials** in both
+SPDX 2.3 and CycloneDX JSON (`aryaos-<tag>.spdx.json` / `.cdx.json`), attached
+to the GitHub Release beside the image and kept as a 90-day workflow artifact.
+The generator is `scripts/generate-sbom.sh` (loop-mounts the image, runs a
+pinned [syft](https://github.com/anchore/syft) over the rootfs — covers dpkg,
+Python site-packages, and the Node-RED npm tree). Run it locally with:
+
+```bash
+sudo SYFT_BIN=syft ./scripts/generate-sbom.sh deploy/<image>.img.xz /tmp/aryaos-sbom
+```
+
 ### Manual `v*` tags (optional)
 
 The workflow no longer triggers on `push` of version tags (that avoided rebuilding when the workflow itself pushes a release tag). Use **`workflow_dispatch`** in the Actions UI to rebuild from `main`, or adjust the workflow `on:` section if you want tag-triggered builds again.

--- a/scripts/generate-sbom.sh
+++ b/scripts/generate-sbom.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# generate-sbom.sh — loop-mount a built AryaOS image and produce SBOMs.
+#
+# Usage: sudo scripts/generate-sbom.sh <image>.img|.img.xz|.zip <out-prefix>
+#
+# Writes <out-prefix>.spdx.json (SPDX 2.3) and <out-prefix>.cdx.json
+# (CycloneDX) covering the full rootfs: dpkg packages, Python site-packages,
+# and the Node-RED npm tree. Requires syft (override binary with SYFT_BIN).
+#
+# Mount handling mirrors scripts/verify-image.sh.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+OUT_PREFIX="${2:-}"
+SYFT_BIN="${SYFT_BIN:-syft}"
+
+if [[ -z "${IMAGE}" || ! -f "${IMAGE}" || -z "${OUT_PREFIX}" ]]; then
+	echo "Usage: sudo $0 <image>.img|.img.xz|.zip <out-prefix>" >&2
+	exit 2
+fi
+if [[ "$(id -u)" != "0" ]]; then
+	echo "Must run as root (loop-mounts the image)." >&2
+	exit 2
+fi
+if ! command -v "${SYFT_BIN}" >/dev/null 2>&1; then
+	echo "syft not found (install it or set SYFT_BIN)." >&2
+	exit 2
+fi
+
+WORK="$(mktemp -d /tmp/aryaos-sbom.XXXXXX)"
+MNT="${WORK}/mnt"
+LOOP=""
+cleanup() {
+	set +e
+	mountpoint -q "${MNT}" && umount "${MNT}"
+	[[ -n "${LOOP}" ]] && losetup -d "${LOOP}"
+	rm -rf "${WORK}"
+}
+trap cleanup EXIT
+
+case "${IMAGE}" in
+	*.zip)
+		python3 -m zipfile -e "${IMAGE}" "${WORK}/extract"
+		IMG="$(find "${WORK}/extract" -name '*.img' -print -quit)"
+		;;
+	*.img.xz | *.xz)
+		IMG="${WORK}/image.img"
+		xz -dkc "${IMAGE}" > "${IMG}"
+		;;
+	*.img)
+		IMG="${IMAGE}"
+		;;
+	*)
+		echo "Unsupported image format: ${IMAGE}" >&2
+		exit 2
+		;;
+esac
+if [[ -z "${IMG:-}" || ! -f "${IMG}" ]]; then
+	echo "No .img found in ${IMAGE}" >&2
+	exit 2
+fi
+
+LOOP="$(losetup -Pf --show "${IMG}")"
+# Partition nodes can lag losetup -P briefly.
+for _ in 1 2 3 4 5; do
+	[[ -b "${LOOP}p2" ]] && break
+	sleep 1
+done
+mkdir -p "${MNT}"
+mount -o ro "${LOOP}p2" "${MNT}"
+
+mkdir -p "$(dirname "${OUT_PREFIX}")"
+echo "== Generating SBOMs from ${IMG##*/} =="
+"${SYFT_BIN}" scan "dir:${MNT}" \
+	--source-name aryaos \
+	-o "spdx-json=${OUT_PREFIX}.spdx.json" \
+	-o "cyclonedx-json=${OUT_PREFIX}.cdx.json"
+
+for f in "${OUT_PREFIX}.spdx.json" "${OUT_PREFIX}.cdx.json"; do
+	if [[ ! -s "${f}" ]]; then
+		echo "SBOM output missing or empty: ${f}" >&2
+		exit 1
+	fi
+	echo "wrote ${f} ($(stat -c %s "${f}") bytes)"
+done


### PR DESCRIPTION
Closes #51.

`scripts/generate-sbom.sh` loop-mounts the built image (same format/mount handling as `verify-image.sh`) and runs a **pinned syft v1.18.1** over the rootfs — covering dpkg packages, Python site-packages, and the Node-RED npm tree. The workflow:

- generates `aryaos-<tag>.spdx.json` (SPDX 2.3) and `aryaos-<tag>.cdx.json` (CycloneDX) **after** image verification but **before** the tag is pushed, so an SBOM failure can't strand a tag with no release (per the release-hygiene notes in the handoff doc);
- uploads both as a 90-day workflow artifact;
- attaches both to the GitHub Release beside the image and overlay deb.

Verified: workflow YAML parses; `bash -n` on the script; the pinned syft arm64 release asset HEAD-checks reachable (matches the runner arch). The full path exercises on the next `main` image build.

Docs: new *SBOMs* subsection in `docs/build.md` including a local-run one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY