### PR TITLE
README: soften amd64 claim (tracking: #129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Features of AryaOS:
 * Facilitates rapid test & evaluation of edge node sensors.
 * Browser based low-code development tool for visual programming & open API.
 * Runs on inexpensive COTS & low SWaP-C small board computers, including the Raspberry Pi.
-* Compatible with Intel & Arm (amd64 & arm64) architectures.
+* Built for Arm (arm64) single-board computers today; Intel/amd64 support is planned ([#129](https://github.com/snstac/aryaos/issues/129)) — the full gateway suite already installs on any Debian host from the [signed apt repository](https://snstac.github.io/packages).
 
 ## AryaOS Software Suite
 


### PR DESCRIPTION
One-liner: the README claimed Intel & amd64 compatibility but the pipeline is arm64-only pi-gen. Softened to arm64-today / amd64-planned, pointing at #129 (installer-script path first) and the apt repo that already works on any Debian host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY