### PR TITLE
CI: fix root-owned deploy/ left by SBOM step

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -277,9 +277,14 @@ jobs:
           SYFT_VERSION="v1.18.1"
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
             | sudo sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
+          # Pre-create as the runner user, and chown after the sudo run:
+          # root-owned deploy/ broke the later unprivileged overlay-deb step
+          # (build 29590562438).
+          mkdir -p deploy/sbom
           sudo bash ./scripts/generate-sbom.sh \
             "${{ steps.build_aryaos.outputs.image-path }}" \
             "deploy/sbom/aryaos-${{ steps.reltag.outputs.tag }}"
+          sudo chown -R "$(id -u):$(id -g)" deploy
           ls -l deploy/sbom/
 
       - name: Upload SBOM artifact


### PR DESCRIPTION
The SBOM step (from #128) ran generate-sbom.sh under sudo, leaving `deploy/` root-owned; the later unprivileged **Build overlay deb** step then failed `mkdir deploy/debs` ([run 29590562438](https://github.com/snstac/aryaos/actions/runs/29590562438)), stranding tag `v2026.07.17.155549-aff68ba3af13-dev` (now deleted per release-hygiene rules). Pre-creates `deploy/sbom` as the runner user and chowns `deploy/` back after the sudo run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY