### PR TITLE
Fix aryaos-config-backup EXIT-trap unbound-variable bug (found in hardware burn-in)

### DIFF
--- a/shared_files/aryaos/aryaos-config-backup
+++ b/shared_files/aryaos/aryaos-config-backup
@@ -84,14 +84,17 @@ do_backup() {
 	local include_secrets=1
 	[[ "${1:-}" == "--no-secrets" ]] && include_secrets=0
 
-	local host stamp name work root
+	local host stamp name root
 	host="$(hostname | tr -c 'A-Za-z0-9.-' '-')"
 	stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 	name="aryaos-config_${host}_${stamp}"
+	# 'work' is intentionally global (not local): the EXIT trap runs after this
+	# function returns, so a local would be out of scope and, under `set -u`,
+	# error ("work: unbound variable") instead of cleaning up the temp dir.
 	work="$(mktemp -d)"
 	root="${work}/${name}"
 	mkdir -p "${root}"
-	trap 'rm -rf "${work}"' EXIT
+	trap 'rm -rf "${work:-}"' EXIT
 
 	# Build the list of existing paths (relative to /).
 	local -a paths=()


### PR DESCRIPTION
Found during a hardware burn-in on the lab box `aryaos-e3bb` (Pi 5, overlay 2.1).

## The bug
`aryaos-config-backup backup` printed `line 1: work: unbound variable` and left a temp dir behind. Root cause: `do_backup` declares `work` with `local`, but the cleanup `trap 'rm -rf "${work}"' EXIT` runs **after the function returns**, where the local is out of scope — and under `set -u` that aborts with the unbound-variable error. The archive was actually written correctly first, so the backup *worked* but the script exited non-cleanly (a **spurious failure toast in the Cockpit Backup card**) and leaked `/tmp/tmp.*`.

## Fix
Make `work` global (so the EXIT trap can see it) and guard the trap with `${work:-}`. One-line-ish change.

## Verified on hardware
- **Before:** `work: unbound variable`, temp dir leaked.
- **After:** clean `exit 0`, `Backup written (15137 bytes).`, a valid 19-entry archive (MANIFEST + `/etc/aryaos` config & TLS + `charontak.ini` + `comitup.conf` + every `/etc/default/<svc>` + NetworkManager Wi-Fi connections + Node-RED settings), and **no temp-dir leak**.

`shellcheck -S error` clean. Only `aryaos-config-backup` was affected — `factory-reset`/`zeroize` use no temp dir, and `support-bundle`'s `WORK` is already global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY