### PR TITLE
Fix SIGPIPE-under-pipefail bugs: config-backup restore + aryaos-role (hardware burn-in)

### DIFF
--- a/shared_files/aryaos/aryaos-config-backup
+++ b/shared_files/aryaos/aryaos-config-backup
@@ -155,8 +155,14 @@ do_restore() {
 		echo "aryaos-config-backup: restore needs an existing archive path" >&2
 		exit 2
 	fi
-	# Validate it is one of our archives.
-	if ! tar -tzf "${file}" 2>/dev/null | grep -q '/MANIFEST.txt$'; then
+	# Validate it is one of our archives. Read the listing into a variable and
+	# match with a here-string rather than `tar ... | grep -q`: under
+	# `set -o pipefail`, grep -q closes the pipe on its first match, tar gets
+	# SIGPIPE, and the pipeline reports failure — which rejected every valid
+	# backup.
+	local listing
+	listing="$(tar -tzf "${file}" 2>/dev/null || true)"
+	if ! grep -q '/MANIFEST.txt$' <<<"${listing}"; then
 		echo "aryaos-config-backup: ${file} is not an AryaOS config backup" >&2
 		exit 1
 	fi

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -82,7 +82,13 @@ all_managed_units() {
 }
 
 unit_exists() {
-	systemctl list-unit-files --no-legend "$1.service" 2>/dev/null | grep -q .
+	# Capture and test rather than `systemctl ... | grep -q .`: under
+	# `set -o pipefail`, grep -q closes the pipe on its first match, systemctl
+	# gets SIGPIPE, and the pipeline reports failure — which would make this
+	# return false for units that exist, so `set` would enable nothing.
+	local out
+	out="$(systemctl list-unit-files --no-legend "$1.service" 2>/dev/null || true)"
+	[[ -n "${out}" ]]
 }
 
 list_json() {


### PR DESCRIPTION
Two bugs with the same root cause, both found and **verified fixed on real hardware** (`aryaos-7081`, the freshly-flashed burn-in box).

## The root cause
`set -o pipefail` + a pipeline whose consumer exits early (`grep -q`, which closes the pipe on its first match). The producer then gets SIGPIPE, and pipefail makes the whole pipeline report failure — inverting the intended logic. This is the same class the handoff doc warns about (`dpkg-deb -c | grep | head`).

## Bug 1 — `aryaos-config-backup restore` rejected every valid backup
`tar -tzf "$file" | grep -q '/MANIFEST.txt$'` → grep -q matched and closed the pipe, tar got SIGPIPE, pipeline "failed", so restore printed *"is not an AryaOS config backup"* and exited — **restore was completely broken**. (Backup was fine; the archive is valid — `grep -c` matches.) Fixed by reading the listing into a variable and matching with a here-string.

## Bug 2 — `aryaos-role` enabled nothing on `set`
`unit_exists()` used `systemctl list-unit-files … | grep -q .` — same SIGPIPE flaw, so it returned false for units that exist and `aryaos-role set` would skip enabling them (role switching silently a no-op). Only `list` was exercised in the first burn-in, so this was latent. Fixed by capturing output and testing for non-empty.

## Verified on hardware (post-fix)
- Restore round-trip: added a marker to the site config, restored a backup, marker correctly gone.
- `aryaos-role set multi`: correctly enabled readsb/dump978-fa/adsbcot/gdltak/ais-catcher/aiscot/dronecot/sikw00fcot and disabled dump1090-fa.

`shellcheck -S error` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY