### PR TITLE
Fix /etc/hosts hostname mapping: typo + factory-reset survivability (burn-in)

### DIFF
--- a/shared_files/aryaos/aryaos-factory-reset
+++ b/shared_files/aryaos/aryaos-factory-reset
@@ -98,7 +98,11 @@ rm -f /etc/machine-id /var/lib/dbus/machine-id
 if command -v hostnamectl >/dev/null 2>&1; then
 	hostnamectl set-hostname aryaos 2>/dev/null || true
 fi
-sed -i -E 's/^(127\.0\.1\.1|::1)[[:space:]]+aryaos-[0-9a-f]{4}.*/\1\taryaos/' /etc/hosts 2>/dev/null || true
+# Reset the hostname mapping back to factory "aryaos" so firstboot re-derives
+# it. Drop any stale aryaos-xxxx entry (match both 127.0.1.1 and legacy
+# 127.0.0.1), then ensure a clean 127.0.1.1 aryaos line for firstboot to pick up.
+sed -i -E '/^127\.0\.[01]\.1[[:space:]]+aryaos(-[0-9a-f]{4})?([[:space:]]|$)/d;/^::1[[:space:]]+aryaos(-[0-9a-f]{4})?([[:space:]]|$)/d' /etc/hosts 2>/dev/null || true
+grep -qE '^127\.0\.1\.1[[:space:]]+aryaos([[:space:]]|$)' /etc/hosts 2>/dev/null || printf '127.0.1.1\taryaos\n' >> /etc/hosts
 echo "cleared device identity (regenerates on next boot)"
 
 # 5. State: drop backups/support bundles/update state that reference this identity.

--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -65,12 +65,12 @@ CURRENT_HOST="$(hostnamectl hostname 2>/dev/null || hostname -s)"
 if [[ "$CURRENT_HOST" == aryaos && -n "${DEVICE_SUFFIX}" ]]; then
 	NEW_HOST="aryaos-${DEVICE_SUFFIX}"
 	hostnamectl set-hostname "$NEW_HOST"
-	if grep -qE '^127\.0\.1\.1[[:space:]]+aryaos([[:space:]]|$)' /etc/hosts; then
-		sed -i -E "s/^127\.0\.1\.1[[:space:]]+aryaos/127.0.0.1 ${NEW_HOST}/" /etc/hosts
-	fi
-	if grep -qE '^::1[[:space:]]+aryaos([[:space:]]|$)' /etc/hosts; then
-		sed -i -E "s/^::1[[:space:]]+aryaos/::1 ${NEW_HOST}/" /etc/hosts
-	fi
+	# Ensure the canonical Debian 127.0.1.1 hostname mapping. Drop any stale
+	# aryaos / aryaos-xxxx entry first (match both 127.0.1.1 and a legacy
+	# 127.0.0.1 line), then add the correct one. Robust to whatever state
+	# /etc/hosts was left in — e.g. after a factory reset — and idempotent.
+	sed -i -E '/^127\.0\.[01]\.1[[:space:]]+aryaos(-[0-9a-f]{4})?([[:space:]]|$)/d;/^::1[[:space:]]+aryaos(-[0-9a-f]{4})?([[:space:]]|$)/d' /etc/hosts
+	printf '127.0.1.1\t%s\n' "${NEW_HOST}" >> /etc/hosts
 	systemctl try-restart avahi-daemon.service 2>/dev/null || true
 	echo "AryaOS hostname is now: $NEW_HOST"
 	CHANGED=1


### PR DESCRIPTION
Found and **verified fixed on hardware** during the burn-in of the reflashed box.

## Symptom
After `aryaos-factory-reset`, every `sudo` printed `unable to resolve host aryaos-xxxx` — the new hostname didn't resolve.

## Root cause
`aryaos-firstboot.sh` wrote the hostname line as **`127.0.0.1 aryaos-xxxx`** — a typo; the Debian convention is `127.0.1.1`. It happened to work on a normal boot (127.0.0.1 also resolves), but:
- `aryaos-factory-reset`'s `/etc/hosts` sed only matched `127.0.1.1 aryaos-xxxx`, so it never touched the typo'd `127.0.0.1` line;
- firstboot's post-reset re-match also expected `127.0.1.1`;
- so after a factory reset the mapping stayed on the **old** hostname, and the newly-derived one had no entry.

Observed on the box: `/etc/hosts` still had `127.0.0.1 aryaos-7081` while the running hostname was `aryaos-5ca1`.

## Fix
Both scripts now delete any stale `aryaos`/`aryaos-xxxx` mapping (matching both `127.0.1.1` and legacy `127.0.0.1`) and write a clean, canonical `127.0.1.1 <hostname>` — idempotent and robust to prior state.

## Verified on hardware
Fixed factory reset -> reboot -> firstboot produced `127.0.1.1 aryaos-65a9`, the hostname resolves (`getent hosts`), and **`sudo` runs with no warning**.

`shellcheck -S error` clean. (Also fixes the non-standard 127.0.0.1 mapping on *all* freshly-flashed devices, not just the factory-reset case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY