### PR TITLE
config-backup: unique backup names + document additive restore

### DIFF
--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -95,6 +95,13 @@ permissions and ownership, runs `systemctl daemon-reload`, and does a
 `try-restart` of the CoT fleet (`charontak`, `gpstak`, `aiscot`, `lincot`,
 `adsbcot`, `dronecot`) plus `lighttpd`.
 
+!!! warning "Restore is additive"
+    Restore *overlays* the backed-up files onto the device — it brings back
+    everything in the archive but does **not** remove files created since the
+    backup (for example, a TAK certificate uploaded afterwards stays in place).
+    If you need an exact return to the backed-up state, do a
+    [factory reset](factory-reset.md) first, then restore.
+
 !!! note "Reboot after a restore"
     The restore finishes with:
 

--- a/shared_files/aryaos/aryaos-config-backup
+++ b/shared_files/aryaos/aryaos-config-backup
@@ -86,7 +86,10 @@ do_backup() {
 
 	local host stamp name root
 	host="$(hostname | tr -c 'A-Za-z0-9.-' '-')"
-	stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+	# Second-granularity stamp plus the PID, so two backups in the same second
+	# (e.g. a full then a --no-secrets from the UI) get distinct names instead
+	# of one silently overwriting the other.
+	stamp="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 	name="aryaos-config_${host}_${stamp}"
 	# 'work' is intentionally global (not local): the EXIT trap runs after this
 	# function returns, so a local would be out of scope and, under `set -u`,
@@ -173,6 +176,9 @@ do_restore() {
 	fi
 
 	# Extract everything except the manifest back into place, preserving perms.
+	# NOTE: restore is additive — it overlays the backed-up files but does not
+	# remove files created since the backup (e.g. a cert uploaded afterwards).
+	# Use a factory reset first if you need an exact return to the backed-up set.
 	tar -xzpf "${file}" -C / --numeric-owner --exclude='*/MANIFEST.txt'
 
 	# Reconcile group access to TAK certs and reload the fleet.


### PR DESCRIPTION
Two minor nits found while testing backup/restore on hardware:

- **Same-second collision**: the backup filename was second-granularity, so a full backup and a `--no-secrets` backup taken in the same second produced the same name and one silently overwrote the other. Now includes the PID for uniqueness.
- **Additive restore**: documented (code comment + a docs warning) that restore overlays the backed-up files but doesn't remove files created since the backup — use a factory reset first for an exact return.

`shellcheck -S error` and `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY