### PR TITLE
zeroize: leave a reserve when overwriting free space (don't wedge on full disk)

### DIFF
--- a/shared_files/aryaos/aryaos-zeroize
+++ b/shared_files/aryaos/aryaos-zeroize
@@ -143,13 +143,20 @@ echo "cleared device identity"
 # 11. Regenerate SSH host keys so remote access works after reboot.
 ssh-keygen -A >/dev/null 2>&1 || true
 
-# 12. Overwrite free space (best effort) then TRIM. Fill each writable fs with
-#     zeros until full, delete, then return blocks to the flash controller.
+# 12. Overwrite free space (best effort) then TRIM. Fill the root filesystem
+#     with zeros, delete, and return the blocks to the flash controller.
+#     Leave a small reserve free rather than filling to 100%: on a live system
+#     a full disk wedges running services (and, if this step is interrupted,
+#     a partially-written fill would strand the box), so stop short of full.
+RESERVE_MB=512
 echo "overwriting free space (this can take a while)..."
 sync
 zf="/var/lib/aryaos/.zerofill"
 mkdir -p /var/lib/aryaos
-dd if=/dev/zero of="${zf}" bs=4M status=none 2>/dev/null || true
+avail_mb="$(df -PBM /var/lib/aryaos 2>/dev/null | awk 'NR==2 { gsub(/M/, "", $4); print $4 }')"
+if [[ -n "${avail_mb}" && "${avail_mb}" -gt "${RESERVE_MB}" ]]; then
+	dd if=/dev/zero of="${zf}" bs=1M count="$((avail_mb - RESERVE_MB))" status=none 2>/dev/null || true
+fi
 sync
 rm -f "${zf}"
 if command -v fstrim >/dev/null 2>&1; then


### PR DESCRIPTION
Robustness fix for `aryaos-zeroize`, found during the hardware burn-in.

## Problem
The free-space overwrite did `dd if=/dev/zero of=.zerofill bs=4M` — filling the root filesystem to **100%** before deleting the fill. On a live system a full disk wedges running services, and if the step is interrupted the partially-written fill strands the box with no free space.

## Fix
Fill to within **`RESERVE_MB` (512 MB)** of full instead of to the brim: read available space from `df` and cap the `dd` with an explicit `count`, then delete and `fstrim` as before. Still a best-effort overwrite (the flash wear-leveling caveat is unchanged) — it just no longer self-wedges.

## Status
`shellcheck -S error` + `bash -n` clean. **Not yet re-tested on hardware** — the burn-in box wedged during testing (a self-inflicted `fallocate` interaction, separate from this) and needs a reflash. Verify via the Cockpit **Zeroize** card / `aryaos-zeroize.service` on the reflashed box, which is also the correct trigger path (a manually-backgrounded `sudo` hit an unrelated ENOSYS-on-detach quirk on the Pi 5 / kernel 6.18 box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVibvSyvPsUXRXRYaFsWjY