### PR TITLE
SECURITY: Node-RED runs as root with no auth — pin to node-red user + randomize default password

### DIFF
--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -85,6 +85,9 @@ install_file 0644 "${SHARED}/aryaos/systemd/aryaos-update.service" "/etc/systemd
 install_file 0644 "${SHARED}/aryaos/systemd/aryaos-factory-reset.service" "/etc/systemd/system/aryaos-factory-reset.service"
 install_file 0644 "${SHARED}/aryaos/systemd/aryaos-zeroize.service" "/etc/systemd/system/aryaos-zeroize.service"
 install_file 0644 "${SHARED}/aryaos/systemd/aryaos-radio-silence.service" "/etc/systemd/system/aryaos-radio-silence.service"
+# Pin nodered.service to the node-red user (upstream unit runs as root out of
+# /root/.node-red with no adminAuth = unauthenticated root-privileged admin API).
+install_file 0644 "${SHARED}/aryaos/systemd/nodered.service.d/aryaos.conf" "/etc/systemd/system/nodered.service.d/aryaos.conf"
 install_file 0644 "${SHARED}/aryaos/zram-generator.conf" "/etc/systemd/zram-generator.conf"
 install_file 0644 "${SHARED}/aryaos/systemd/gpsd.socket.d/socket-group.conf" "/etc/systemd/system/gpsd.socket.d/socket-group.conf"
 install_file 0644 "${SHARED}/aryaos/systemd/lighttpd.service.d/aryaos-netlink.conf" "/etc/systemd/system/lighttpd.service.d/aryaos-netlink.conf"

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -216,6 +216,13 @@ require_grep '^EnvironmentFile=/etc/default/sikw00fcot$' /lib/systemd/system/sik
 
 # Node-RED (stage-node-red)
 require_path /home/node-red/.node-red/flows.json
+# Node-RED must NOT run as root: the upstream unit ships User=root out of
+# /root/.node-red (no adminAuth = unauthenticated root-privileged admin API).
+# AryaOS pins it to the node-red user via a drop-in.
+require_path /etc/systemd/system/nodered.service.d/aryaos.conf
+require_grep '^[[:space:]]*User=node-red' /etc/systemd/system/nodered.service.d/aryaos.conf "nodered runs as node-red (not root)"
+# The hardened settings.js (the one node-red now uses) must carry adminAuth.
+require_grep 'adminAuth' /home/node-red/.node-red/settings.js "node-red adminAuth configured"
 
 # Hardening (stage-aryaos): firewall, brute-force protection, auto security
 # updates, per-device web TLS, sysctl/sshd tightening

--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -138,6 +138,22 @@ if [[ ! -f /etc/sudoers.d/aryaos-lab && ! -f "$PASS_EXPIRED_MARKER" ]] \
 	fi
 fi
 
+# Node-RED ships a publicly known default admin password, and the editor runs
+# arbitrary code as the node-red user. Randomize it once at first boot so the
+# admin API on :1880 is not reachable with the published credential; the operator
+# sets their own via Cockpit -> AryaOS Site. Skipped on lab builds (known creds
+# for dev), matching the pi-password gate above.
+NR_PASS_MARKER="/etc/aryaos/.nodered-pass-randomized"
+if [[ ! -f /etc/sudoers.d/aryaos-lab && ! -f "$NR_PASS_MARKER" ]] \
+	&& [[ -f /home/node-red/.node-red/settings.js ]] \
+	&& [[ -x /usr/local/sbin/aryaos-set-nodered-password ]]; then
+	if head -c 18 /dev/urandom | base64 | /usr/local/sbin/aryaos-set-nodered-password >/dev/null 2>&1; then
+		touch "$NR_PASS_MARKER"
+		echo "Node-RED admin password randomized; set your own in Cockpit -> AryaOS Site."
+		CHANGED=1
+	fi
+fi
+
 if [[ "$CHANGED" -eq 0 ]]; then
 	echo "AryaOS firstboot: no changes needed."
 	exit 0

--- a/shared_files/aryaos/systemd/nodered.service.d/aryaos.conf
+++ b/shared_files/aryaos/systemd/nodered.service.d/aryaos.conf
@@ -1,0 +1,13 @@
+# AryaOS override for the upstream nodered.service.
+#
+# The node-red linux-installer ships the unit with User=root / WorkingDirectory=/root,
+# which makes Node-RED run AS ROOT out of /root/.node-red — a stock settings.js with
+# NO adminAuth. The result is an unauthenticated, root-privileged admin API (anyone who
+# can reach :1880 can overwrite flows = RCE as root). AryaOS installs the hardened
+# config (adminAuth + the palette/flows) into /home/node-red/.node-red, so pin the
+# service to the node-red user and that home directory.
+[Service]
+User=node-red
+Group=node-red
+WorkingDirectory=/home/node-red
+Environment="HOME=/home/node-red"

--- a/stages/stage-node-red/00-install/00-run.sh
+++ b/stages/stage-node-red/00-install/00-run.sh
@@ -42,3 +42,9 @@ install -v -m 644 "${SHARED_FILES}/node-red/package.json" "${ROOTFS_DIR}/home/no
 install -v -m 644 "${SHARED_FILES}/node-red/package-lock.json" "${ROOTFS_DIR}/home/node-red/.node-red/package-lock.json"
 install -v -m 644 "${SHARED_FILES}/node-red/aryaos_flows.json" "${ROOTFS_DIR}/home/node-red/.node-red/"
 cat "${ROOTFS_DIR}/home/node-red/.node-red/aryaos_flows.json" > "${ROOTFS_DIR}/home/node-red/.node-red/flows.json"
+
+# Pin nodered.service to the node-red user + /home/node-red (the upstream unit runs
+# as root out of /root/.node-red, whose stock settings.js has no adminAuth — that
+# would expose an unauthenticated, root-privileged Node-RED admin API on :1880).
+install -v -D -m 644 "${SHARED_FILES}/aryaos/systemd/nodered.service.d/aryaos.conf" \
+	"${ROOTFS_DIR}/etc/systemd/system/nodered.service.d/aryaos.conf"


### PR DESCRIPTION
## 🔴 Critical — unauthenticated remote root RCE via Node-RED

Found during hardware integration testing of the current dev image.

The upstream `nodered.service` (from the node-red linux-installer) ships **`User=root`, `WorkingDirectory=/root`**, so Node-RED runs **as root** out of `/root/.node-red` — a stock `settings.js` with **no `adminAuth`**. The hardened config AryaOS installs (adminAuth + the palette and the real 195-node flows) at `/home/node-red/.node-red` is **never used**.

**Result:** any client that can reach `1880/tcp` can read/overwrite flows **with no credentials**, running **as root**. A flow with an `exec` node = root shell. `1880` is open on the LAN and (until the hotspot-zone hardening) to `aryaos-xxxx` clients.

**Confirmed on hardware (remote, not localhost):**
```
GET  http://<box>:1880/flows    -> 200   (unauth)
GET  http://<box>:1880/settings -> 200   (unauth)
POST /flows (unauth)            -> 204   (my injected flow tab landed)
service User=                   -> root
```

## Fix (both layers verified on hardware)

1. **Run as the `node-red` user.** Drop-in `/etc/systemd/system/nodered.service.d/aryaos.conf` pins `User=node-red` + `HOME=/home/node-red`, so Node-RED runs unprivileged and loads the `adminAuth`-protected `settings.js`.
   → after fix: `User=node-red`, unauth `GET`/`POST /flows` → **401**.
2. **Randomize the default admin password at first boot.** The bcrypt hash of the publicly-known `aryaos415` ships in `settings.js`; `aryaos-firstboot` now randomizes it once on release images (operator sets their own via Cockpit → AryaOS Site). Skipped on lab builds, mirroring the existing pi-password gate.
   → after fix: known credential no longer works; hash rotates, API stays `401`.

`verify-image.sh` fails the build if the drop-in is missing, doesn't pin `User=node-red`, or `settings.js` lacks `adminAuth`.

## Wired in
`shared_files/aryaos/systemd/nodered.service.d/aryaos.conf` installed by both stage-node-red (`00-run.sh`) and the overlay deb; firstboot rotation via the existing `aryaos-set-nodered-password` helper (already targets `/home/node-red/.node-red/settings.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)