### PR TITLE
wifi: tighten onboarding hotspot INPUT surface (no ssh/node-red/mesh)

### DIFF
--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -125,7 +125,9 @@ install_file 0644 "${SHARED}/aryaos/apt/52unattended-upgrades-aryaos" "/etc/apt/
 for svc_xml in "${SHARED}/aryaos/firewalld/services/"*.xml; do
 	install_file 0644 "${svc_xml}" "/etc/firewalld/services/$(basename "${svc_xml}")"
 done
-install_file 0644 "${SHARED}/aryaos/firewalld/zones/public.xml" "/etc/firewalld/zones/public.xml"
+for zone_xml in "${SHARED}/aryaos/firewalld/zones/"*.xml; do
+	install_file 0644 "${zone_xml}" "/etc/firewalld/zones/$(basename "${zone_xml}")"
+done
 install_file 0755 "${SHARED}/aryaos/99-aryaos-dispatcher" "/etc/NetworkManager/dispatcher.d/99-aryaos-dispatcher"
 
 

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -276,6 +276,17 @@ else
 	ok "public zone has no intra-zone forwarding (AP/PAN isolated from eth)"
 fi
 
+# Onboarding hotspot zone: tight INPUT (assigned to wlan0 in AP mode by
+# comitup-callback). Must exist, must NOT expose ssh / Node-RED / mesh, and
+# must have no intra-zone forwarding.
+require_path /etc/firewalld/zones/aryaos-hotspot.xml
+if grep -qsE '<service name="(ssh|aryaos-node-red|aryaos-mesh-sa)"' "${MNT}/etc/firewalld/zones/aryaos-hotspot.xml"; then
+	fail "aryaos-hotspot zone exposes ssh/node-red/mesh to onboarding clients"
+else
+	ok "aryaos-hotspot zone withholds ssh/node-red/mesh from onboarding clients"
+fi
+require_grep '(aryaos-hotspot|--change-interface)' /usr/local/sbin/comitup-callback.sh "comitup-callback assigns wlan0 to the hotspot zone"
+
 # Media longevity: zram swap config + periodic TRIM
 require_path /etc/systemd/zram-generator.conf
 require_grep '^\[zram0\]' /etc/systemd/zram-generator.conf "zram swap configured"

--- a/shared_files/aryaos/comitup-callback.sh
+++ b/shared_files/aryaos/comitup-callback.sh
@@ -26,5 +26,20 @@ fi
 # FIXME: https://github.com/snstac/aryaos/issues/48
 logger "AryaOS comitup callback: $*"
 
+# Move wlan0 between firewalld zones based on comitup state. While it is the
+# onboarding access point (HOTSPOT), pin it to the tight "aryaos-hotspot" zone so
+# a walk-up client can reach only DHCP/DNS/portal/web-admin — not ssh, Node-RED,
+# or the mesh feed. Once wlan0 becomes a trusted client uplink (CONNECTED),
+# restore the normal default zone so the operator is not locked out.
+WIFI_DEV="wlan0"
+case "${1:-}" in
+	HOTSPOT)
+		firewall-cmd --zone=aryaos-hotspot --change-interface="${WIFI_DEV}" >/dev/null 2>&1 || true
+		;;
+	CONNECTED)
+		firewall-cmd --zone=public --change-interface="${WIFI_DEV}" >/dev/null 2>&1 || true
+		;;
+esac
+
 # Ping a callback on Node-RED:
 wget -a http://127.0.0.1:1880/comitup_callback/$*

--- a/shared_files/aryaos/firewalld/zones/aryaos-hotspot.xml
+++ b/shared_files/aryaos/firewalld/zones/aryaos-hotspot.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+AryaOS onboarding-hotspot zone. Applied to wlan0 ONLY while it is the aryaos-xxxx
+access point (assigned by comitup-callback.sh on the HOTSPOT state, and moved back
+to the public zone on CONNECTED so a Wi-Fi *client* uplink keeps normal access).
+
+An onboarding client is an untrusted walk-up device, so this zone exposes only
+what onboarding and web administration need — DHCP/DNS/mDNS, the comitup captive
+portal (9080), and the web portal + Cockpit (80/443, "all config from the web
+UI") — and NOTHING else. In particular it does NOT expose ssh, the Node-RED
+editor (1880), the TAK Mesh SA feed (6969), or the AIS-catcher dashboard, which
+the default (public) zone allows for wired/trusted clients.
+
+Like public, this zone has NO forward element: a hotspot client is never routed
+onto the wired ethernet regardless of net.ipv4.ip_forward (see public.xml).
+-->
+<zone>
+  <short>AryaOS Hotspot</short>
+  <description>Onboarding Wi-Fi hotspot: DHCP/DNS, captive portal, and web admin only — no SSH, Node-RED, or mesh.</description>
+  <service name="dhcp"/>
+  <service name="dhcpv6-client"/>
+  <service name="dns"/>
+  <service name="mdns"/>
+  <service name="http"/>
+  <service name="https"/>
+  <service name="aryaos-comitup"/>
+</zone>

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -116,7 +116,9 @@ install -d -m 0755 "${ROOTFS_DIR}/etc/firewalld/services" "${ROOTFS_DIR}/etc/fir
 for svc_xml in "${SHARED_FILES}/aryaos/firewalld/services/"*.xml; do
 	install -v -m 0644 "${svc_xml}" "${ROOTFS_DIR}/etc/firewalld/services/"
 done
-install -v -m 0644 "${SHARED_FILES}/aryaos/firewalld/zones/public.xml" "${ROOTFS_DIR}/etc/firewalld/zones/public.xml"
+for zone_xml in "${SHARED_FILES}/aryaos/firewalld/zones/"*.xml; do
+	install -v -m 0644 "${zone_xml}" "${ROOTFS_DIR}/etc/firewalld/zones/"
+done
 
 ## One-click updates: helper + oneshot unit (driven by Cockpit -> AryaOS Site)
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-update" "${ROOTFS_DIR}/usr/local/sbin/aryaos-update"

--- a/stages/stage-aryaos/tasks/hardening.yml
+++ b/stages/stage-aryaos/tasks/hardening.yml
@@ -61,11 +61,13 @@
   with_fileglob:
     - "{{ shared_files }}/aryaos/firewalld/services/*.xml"
 
-- name: Install firewalld default zone
+- name: Install firewalld zones (default + onboarding hotspot)
   ansible.builtin.copy:
-    src: "{{ shared_files }}/aryaos/firewalld/zones/public.xml"
-    dest: /etc/firewalld/zones/public.xml
+    src: "{{ item }}"
+    dest: /etc/firewalld/zones/
     mode: "0644"
+  with_fileglob:
+    - "{{ shared_files }}/aryaos/firewalld/zones/*.xml"
 
 - name: Install aryaos-update helper
   ansible.builtin.copy:


### PR DESCRIPTION
Follow-up to the WiFi/security hardening. Deeper hardware testing showed `wlan0` sits in the default `public` zone, so a walk-up client on the `aryaos-xxxx` onboarding hotspot could reach the box's **SSH, Node-RED editor (1880), and TAK Mesh SA feed (6969)** on INPUT — not just the onboarding portal. (The forwarding/gateway leak was already fixed in #147; this is the *input* surface.)

## Change
- New tight **`aryaos-hotspot`** firewalld zone: exposes only `dhcp`/`dhcpv6-client`/`dns`/`mdns`, the comitup captive portal (`9080`), and the web portal + Cockpit (`80`/`443`). No `ssh`, no `aryaos-node-red`, no `aryaos-mesh-sa`, no `aryaos-ais-catcher`.
- **`comitup-callback.sh`** pins `wlan0` to `aryaos-hotspot` on the **HOTSPOT** state and back to `public` on **CONNECTED** — so a Wi-Fi *client* uplink keeps normal access and the operator is **never locked out** (no SSH lockout on a wifi-only box).
- Like `public`, the zone has no `forward` element → a hotspot client still can't gateway to ethernet.
- Firewalld zone installs switched to a glob (all three paths) so the new zone ships everywhere; `verify-image.sh` asserts the zone exists, withholds ssh/node-red/mesh, and that the callback assigns it.

## Verified on hardware
```
callback HOTSPOT  -> wlan0 zone = aryaos-hotspot
hotspot services  = aryaos-comitup dhcp dhcpv6-client dns http https mdns
wlan0 INPUT       -> dhcp/dns/http/https allowed; ssh(22)/1880/6969 ABSENT
callback CONNECTED-> wlan0 zone = public   (client uplink restored, no lockout)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)