### PR TITLE
wifi: assign hotspot zone via NetworkManager (fix #149 not applying on boot)

### DIFF
--- a/shared_files/aryaos/comitup-callback.sh
+++ b/shared_files/aryaos/comitup-callback.sh
@@ -31,13 +31,29 @@ logger "AryaOS comitup callback: $*"
 # a walk-up client can reach only DHCP/DNS/portal/web-admin — not ssh, Node-RED,
 # or the mesh feed. Once wlan0 becomes a trusted client uplink (CONNECTED),
 # restore the normal default zone so the operator is not locked out.
+#
+# The zone MUST be set via the NetworkManager connection, not a runtime
+# `firewall-cmd --change-interface`: NM owns an managed interface's zone through
+# the connection's `connection.zone` property and reverts any manual runtime
+# binding on the next connection event (which left wlan0 in the default `public`
+# zone despite this callback firing). `nmcli device reapply` applies the change
+# without dropping the AP.
 WIFI_DEV="wlan0"
+set_wlan_zone() {
+	local zone="$1" conn
+	conn="$(nmcli -t -f GENERAL.CONNECTION device show "${WIFI_DEV}" 2>/dev/null | sed 's/^GENERAL.CONNECTION://')"
+	[ -n "${conn}" ] || return 0
+	nmcli connection modify "${conn}" connection.zone "${zone}" >/dev/null 2>&1 || true
+	nmcli device reapply "${WIFI_DEV}" >/dev/null 2>&1 \
+		|| firewall-cmd --zone="${zone:-public}" --change-interface="${WIFI_DEV}" >/dev/null 2>&1 || true
+}
 case "${1:-}" in
 	HOTSPOT)
-		firewall-cmd --zone=aryaos-hotspot --change-interface="${WIFI_DEV}" >/dev/null 2>&1 || true
+		set_wlan_zone aryaos-hotspot
 		;;
 	CONNECTED)
-		firewall-cmd --zone=public --change-interface="${WIFI_DEV}" >/dev/null 2>&1 || true
+		# Empty zone => the connection uses the default (public) zone.
+		set_wlan_zone ""
 		;;
 esac
 


### PR DESCRIPTION
**HIL follow-up to #149.** Testing on a fresh flash showed `wlan0` stayed in the default `public` zone even though `comitup-callback` fired `HOTSPOT` at boot — so the hotspot INPUT tightening (no ssh/node-red/mesh) **never actually applied**.

**Root cause:** NetworkManager owns a managed interface's firewalld zone via the connection's `connection.zone` property, and reverts any runtime `firewall-cmd --change-interface` on the next connection event. The AP connection shipped with `connection.zone` empty → default (`public`).

**Fix:** set the zone on the NM connection — `nmcli connection modify <conn> connection.zone aryaos-hotspot` + `nmcli device reapply` (non-disruptive; the AP stays up). `CONNECTED` clears it so a Wi-Fi client uplink uses `public` (no lockout).

**Verified on hardware:**
```
# unset zone, reboot:
BOOT wlan0 zone: aryaos-hotspot     # applied automatically on boot
comitup:         HOTSPOT
survives nmcli connection up:  aryaos-hotspot
ssh in hotspot zone:           no
```

Without this, #149 shipped inert. Full HIL + integration suite otherwise green on the clean image (Node-RED 401 remote, CoT→mesh, resilience, backup/restore, EMCON, SSID tracking).
🤖 Generated with [Claude Code](https://claude.com/claude-code)