### PR TITLE
wifi: confine Bluetooth PAN (pan0) to the onboarding hotspot zone

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -286,6 +286,10 @@ else
 	ok "aryaos-hotspot zone withholds ssh/node-red/mesh from onboarding clients"
 fi
 require_grep '(aryaos-hotspot|--change-interface)' /usr/local/sbin/comitup-callback.sh "comitup-callback assigns wlan0 to the hotspot zone"
+# Bluetooth PAN (pan0) is the other onboarding radio — it must be confined to the
+# hotspot zone too (statically in the zone XML + at bridge-up in the bt-pan NAP).
+require_grep '<interface name="pan0"/>' /etc/firewalld/zones/aryaos-hotspot.xml "pan0 statically bound to hotspot zone"
+require_grep 'aryaos-hotspot' /usr/local/sbin/aryaos-bt-pan-nap "bt-pan confines pan0 to the hotspot zone"
 
 # Media longevity: zram swap config + periodic TRIM
 require_path /etc/systemd/zram-generator.conf

--- a/shared_files/aryaos/firewalld/zones/aryaos-hotspot.xml
+++ b/shared_files/aryaos/firewalld/zones/aryaos-hotspot.xml
@@ -16,7 +16,7 @@ onto the wired ethernet regardless of net.ipv4.ip_forward (see public.xml).
 -->
 <zone>
   <short>AryaOS Hotspot</short>
-  <description>Onboarding Wi-Fi hotspot: DHCP/DNS, captive portal, and web admin only — no SSH, Node-RED, or mesh.</description>
+  <description>Onboarding radios (Wi-Fi hotspot + Bluetooth PAN): DHCP/DNS, captive portal, and web admin only — no SSH, Node-RED, or mesh.</description>
   <service name="dhcp"/>
   <service name="dhcpv6-client"/>
   <service name="dns"/>
@@ -24,4 +24,9 @@ onto the wired ethernet regardless of net.ipv4.ip_forward (see public.xml).
   <service name="http"/>
   <service name="https"/>
   <service name="aryaos-comitup"/>
+  <!-- Bluetooth PAN (10.44.0.1) is the other onboarding radio; bind it here
+       statically. wlan0 is NOT listed: it is NetworkManager-managed and switches
+       between this zone (AP mode) and public (client uplink) via connection.zone
+       in comitup-callback.sh, so a static binding would fight NM. -->
+  <interface name="pan0"/>
 </zone>

--- a/shared_files/bt-pan/aryaos-bt-pan-nap
+++ b/shared_files/bt-pan/aryaos-bt-pan-nap
@@ -43,6 +43,14 @@ def ensure_bridge():
     run("ip", "addr", "replace", f"{ADDRESS}/{PREFIX}", "dev", BRIDGE)
     run("ip", "link", "set", BRIDGE, "up")
 
+    # Confine Bluetooth PAN clients to the onboarding zone: they get DHCP/DNS and
+    # the web portal/Cockpit, but NOT ssh, the Node-RED editor, or the mesh feed
+    # (an onboarding radio is an untrusted walk-up path — same posture as the
+    # WiFi hotspot). The zone XML statically binds pan0 too, for firewalld
+    # reloads; this call covers the case where firewalld started before the
+    # bridge existed. Forwarding to ethernet is already denied by the public zone.
+    run("firewall-cmd", "--zone=aryaos-hotspot", f"--change-interface={BRIDGE}", check=False)
+
 
 def register_nap():
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)


### PR DESCRIPTION
**Deep HIL follow-up.** After tightening the WiFi hotspot (`wlan0`) input surface in #149/#150, testing found the *other* onboarding radio — **Bluetooth PAN (`pan0`, `10.44.0.1`)** — still sits in the default `public` zone. So a paired BT PAN client could reach **ssh, the Node-RED editor, and the mesh feed**, the same gap wlan0 had. (Forwarding `pan0→eth0` was already denied by #147, so no gateway leak — just the input surface.)

## Fix
Confine `pan0` to the tight `aryaos-hotspot` zone (DHCP/DNS/mDNS + web portal/Cockpit only):
- **`<interface name="pan0"/>`** in the zone XML — declarative, survives firewalld reloads.
- **`firewall-cmd --change-interface=pan0`** at bridge-up in `aryaos-bt-pan-nap` — covers the boot case where firewalld started before the bnep bridge existed. `pan0` isn't NM-managed, so a runtime bind sticks (unlike wlan0, which stays dynamic via `connection.zone`).

`verify-image.sh` asserts both.

## Verified on hardware, across a reboot
```
BOOT pan0 zone:  aryaos-hotspot     # confined automatically on boot
BOOT wlan0 zone: aryaos-hotspot
ssh via pan0 zone: no  (node-red: no, mesh: no)
bt-pan active, pan0 ip 10.44.0.1/24 (DHCP still serves)
failed units: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)