### PR TITLE
radio: make EMCON actually survive a reboot

### DIFF
--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -85,6 +85,11 @@ install_file 0644 "${SHARED}/aryaos/systemd/aryaos-update.service" "/etc/systemd
 install_file 0644 "${SHARED}/aryaos/systemd/aryaos-factory-reset.service" "/etc/systemd/system/aryaos-factory-reset.service"
 install_file 0644 "${SHARED}/aryaos/systemd/aryaos-zeroize.service" "/etc/systemd/system/aryaos-zeroize.service"
 install_file 0644 "${SHARED}/aryaos/systemd/aryaos-radio-silence.service" "/etc/systemd/system/aryaos-radio-silence.service"
+# EMCON gate: keep the radio users from starting (and un-blocking the radios)
+# while /etc/aryaos/emcon exists.
+install_file 0644 "${SHARED}/aryaos/systemd/comitup.service.d/emcon.conf" "/etc/systemd/system/comitup.service.d/emcon.conf"
+install_file 0644 "${SHARED}/aryaos/systemd/aryaos-bt-pan.service.d/emcon.conf" "/etc/systemd/system/aryaos-bt-pan.service.d/emcon.conf"
+install_file 0644 "${SHARED}/aryaos/systemd/aryaos-bt-ready.service.d/emcon.conf" "/etc/systemd/system/aryaos-bt-ready.service.d/emcon.conf"
 # Pin nodered.service to the node-red user (upstream unit runs as root out of
 # /root/.node-red with no adminAuth = unauthenticated root-privileged admin API).
 install_file 0644 "${SHARED}/aryaos/systemd/nodered.service.d/aryaos.conf" "/etc/systemd/system/nodered.service.d/aryaos.conf"

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -267,6 +267,13 @@ require_path /usr/share/aryaos/defaults/charontak.ini
 # Radios: WiFi hotspot control + EMCON/radio-silence (Cockpit -> AryaOS Site)
 require_path /usr/local/sbin/aryaos-radio
 require_path /etc/systemd/system/aryaos-radio-silence.service
+# EMCON must survive a reboot: aryaos-radio disables WiFi at the NM level (rfkill
+# alone gets re-enabled by NetworkManager), and comitup/bt-pan/bt-ready are gated
+# off while the flag exists so they don't un-block the radios on boot.
+require_grep 'nmcli radio wifi off' /usr/local/sbin/aryaos-radio "aryaos-radio disables WiFi via NetworkManager for EMCON"
+for svc in comitup aryaos-bt-pan aryaos-bt-ready; do
+	require_grep 'ConditionPathExists=!/etc/aryaos/emcon' "/etc/systemd/system/${svc}.service.d/emcon.conf" "${svc} gated off during EMCON"
+done
 # AP/PAN isolation: the default zone must NOT enable intra-zone forwarding, or a
 # hotspot/Bluetooth client could be routed onto the wired ethernet.
 require_path /etc/firewalld/zones/public.xml

--- a/shared_files/aryaos/aryaos-radio
+++ b/shared_files/aryaos/aryaos-radio
@@ -65,11 +65,14 @@ silence_on() {
 	require_root
 	install -d -m 0755 /etc/aryaos
 	: > "${EMCON_FLAG}"
-	# Drop the hotspot first so it is not fighting the radio, then block.
-	systemctl stop comitup.service >/dev/null 2>&1 || true
+	# Stop the radio users so they do not fight the block, disable the WiFi radio
+	# at the NetworkManager level (NM re-enables a merely rfkill-blocked radio on
+	# its own), then rfkill-block both radios.
+	systemctl stop comitup.service aryaos-bt-pan.service >/dev/null 2>&1 || true
+	command -v nmcli >/dev/null 2>&1 && nmcli radio wifi off >/dev/null 2>&1 || true
 	_rfkill block wifi
 	_rfkill block bluetooth
-	logger "aryaos-radio: EMCON ON (WiFi + Bluetooth rfkill-blocked)"
+	logger "aryaos-radio: EMCON ON (WiFi + Bluetooth radios disabled)"
 	echo "EMCON on: WiFi + Bluetooth radios blocked (persists across reboot)."
 	echo "SDR receivers are receive-only and left running; stop their services to silence them."
 }
@@ -77,13 +80,16 @@ silence_on() {
 silence_off() {
 	require_root
 	rm -f "${EMCON_FLAG}"
+	command -v nmcli >/dev/null 2>&1 && nmcli radio wifi on >/dev/null 2>&1 || true
 	_rfkill unblock wifi
 	_rfkill unblock bluetooth
-	# Bring the hotspot back only if it is still enabled.
+	# Bring the onboarding radios back (their units are ConditionPathExists-gated
+	# on the EMCON flag, which is now removed).
+	systemctl start aryaos-bt-ready.service aryaos-bt-pan.service >/dev/null 2>&1 || true
 	if systemctl is-enabled comitup.service >/dev/null 2>&1; then
 		systemctl start comitup.service >/dev/null 2>&1 || true
 	fi
-	logger "aryaos-radio: EMCON OFF (radios unblocked)"
+	logger "aryaos-radio: EMCON OFF (radios re-enabled)"
 	echo "EMCON off: WiFi + Bluetooth radios unblocked."
 }
 
@@ -94,7 +100,11 @@ silence_status() {
 
 boot_apply() {
 	# aryaos-radio-silence.service at boot: re-assert the block if EMCON is set.
+	# The comitup / bt-pan / bt-ready units are ConditionPathExists-gated on the
+	# flag so they do not start and un-block the radios; disabling WiFi via nmcli
+	# keeps NetworkManager from re-enabling it.
 	[[ -f "${EMCON_FLAG}" ]] || exit 0
+	command -v nmcli >/dev/null 2>&1 && nmcli radio wifi off >/dev/null 2>&1 || true
 	_rfkill block wifi
 	_rfkill block bluetooth
 	logger "aryaos-radio: EMCON re-applied at boot"

--- a/shared_files/aryaos/systemd/aryaos-bt-pan.service.d/emcon.conf
+++ b/shared_files/aryaos/systemd/aryaos-bt-pan.service.d/emcon.conf
@@ -1,0 +1,5 @@
+# EMCON (aryaos-radio silence): do not bring up the Bluetooth PAN when radio
+# silence is active (Bluetooth is rfkill-blocked). Cleared by `aryaos-radio
+# silence off`.
+[Unit]
+ConditionPathExists=!/etc/aryaos/emcon

--- a/shared_files/aryaos/systemd/aryaos-bt-ready.service.d/emcon.conf
+++ b/shared_files/aryaos/systemd/aryaos-bt-ready.service.d/emcon.conf
@@ -1,0 +1,5 @@
+# EMCON (aryaos-radio silence): do not run the Bluetooth prep when radio silence
+# is active — aryaos-bt-ready unblocks Bluetooth (`rfkill unblock bluetooth`),
+# which would defeat the block. Cleared by `aryaos-radio silence off`.
+[Unit]
+ConditionPathExists=!/etc/aryaos/emcon

--- a/shared_files/aryaos/systemd/comitup.service.d/emcon.conf
+++ b/shared_files/aryaos/systemd/comitup.service.d/emcon.conf
@@ -1,0 +1,6 @@
+# EMCON (aryaos-radio silence): do not start the WiFi hotspot when radio silence
+# is active. Bringing up the AP makes NetworkManager re-enable the WiFi radio,
+# which would defeat the rfkill block. The flag is cleared by `aryaos-radio
+# silence off`, which then starts comitup again.
+[Unit]
+ConditionPathExists=!/etc/aryaos/emcon

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -144,6 +144,12 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-zeroize.service" \
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-radio" "${ROOTFS_DIR}/usr/local/sbin/aryaos-radio"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-radio-silence.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-radio-silence.service"
+# EMCON gate: comitup/bt-pan/bt-ready must not start (and un-block the radios)
+# while /etc/aryaos/emcon exists.
+for svc in comitup aryaos-bt-pan aryaos-bt-ready; do
+	install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/${svc}.service.d/emcon.conf" \
+		"${ROOTFS_DIR}/etc/systemd/system/${svc}.service.d/emcon.conf"
+done
 
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).


### PR DESCRIPTION
**Deep HIL finding.** EMCON (`aryaos-radio silence`) did **not** persist across a reboot. The `/etc/aryaos/emcon` flag survived and `aryaos-radio-silence.service` re-blocked the radios early at boot — but then **`aryaos-bt-ready` ran `rfkill unblock bluetooth`** and **comitup brought up the AP** (which makes NetworkManager re-enable the WiFi radio). The box came back up **transmitting**, defeating EMCON.

## Fix (verified on hardware across a reboot)
- **`nmcli radio wifi off`** in addition to rfkill: NM re-enables a merely rfkill-blocked radio on its own, and the NM `WirelessEnabled` state persists across reboot. Applied in silence-on and the boot re-apply; reverted in silence-off.
- **`ConditionPathExists=!/etc/aryaos/emcon`** drop-ins on `comitup`, `aryaos-bt-pan`, `aryaos-bt-ready` so they don't start (and un-block the radios / bring up the AP) while EMCON is active.
- silence-off re-enables WiFi and restarts the onboarding radios.

```
# EMCON on, reboot:
BOOT wifi blocked=1  bt blocked=1  nmcli-wifi=disabled
AP up=0  comitup=inactive  bt-pan=inactive  pan0=absent
# silence off:
nmcli-wifi=enabled  AP=AryaOS-xxxx  pan0=active     # clean recovery
```

`verify-image.sh` asserts the `nmcli radio wifi off` and the three gates. Without this, the EMCON/LPI feature was cosmetic after any reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)