### PR TITLE
harden: CoT entity-expansion DoS guard + onboarding portal off the wired LAN

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -292,6 +292,16 @@ if grep -qsE '<forward\s*/?>' "${MNT}/etc/firewalld/zones/public.xml"; then
 else
 	ok "public zone has no intra-zone forwarding (AP/PAN isolated from eth)"
 fi
+# The comitup onboarding portal (9080) must NOT be open on the wired LAN — only the
+# onboarding radios (aryaos-hotspot zone) need it.
+if grep -qsE '<service name="aryaos-comitup"' "${MNT}/etc/firewalld/zones/public.xml"; then
+	fail "public zone opens the comitup portal (9080) to the wired LAN"
+else
+	ok "comitup onboarding portal not exposed on the wired LAN"
+fi
+# aryaos-neighbord parses untrusted multicast CoT — it must reject DTD/entity
+# (billion-laughs) payloads before ElementTree parsing.
+require_grep '<!DOCTYPE' /usr/local/sbin/aryaos-neighbord "neighbord rejects DTD/entity CoT (billion-laughs guard)"
 
 # Onboarding hotspot zone: tight INPUT (assigned to wlan0 in AP mode by
 # comitup-callback). Must exist, must NOT expose ssh / Node-RED / mesh, and

--- a/shared_files/aryaos/aryaos-import-tak-dp
+++ b/shared_files/aryaos/aryaos-import-tak-dp
@@ -108,6 +108,10 @@ def parse_enrollment_url(value):
 
 
 def parse_preferences(pref_bytes):
+    # Defense-in-depth: reject a DTD/entity block (billion-laughs) even though this
+    # path is admin-gated (root-only socket) and size-capped. config.pref has no DTD.
+    if b"<!DOCTYPE" in pref_bytes or b"<!ENTITY" in pref_bytes:
+        fail("config.pref must not contain a DTD or entity declaration")
     try:
         root = ET.fromstring(pref_bytes)
     except ET.ParseError as exc:

--- a/shared_files/aryaos/aryaos-neighbord
+++ b/shared_files/aryaos/aryaos-neighbord
@@ -191,6 +191,13 @@ def _should_beacon(cache: dict[str, dict]) -> bool:
 
 
 def _parse_event(data: bytes, source_ip: str) -> tuple[str, dict] | None:
+    # This datagram is UNTRUSTED — any LAN host can send to the mesh group. CoT is
+    # plain XML with no DTD, so reject a DOCTYPE/ENTITY declaration outright: it
+    # blocks internal entity-expansion (billion-laughs) DoS, which stdlib
+    # ElementTree is vulnerable to (defusedxml is not on the image). ElementTree
+    # does not resolve external entities, so there is no XXE/file-read vector here.
+    if b"<!DOCTYPE" in data or b"<!ENTITY" in data:
+        return None
     try:
         root = ET.fromstring(data.strip())
     except ET.ParseError:

--- a/shared_files/aryaos/firewalld/zones/public.xml
+++ b/shared_files/aryaos/firewalld/zones/public.xml
@@ -29,5 +29,8 @@ Docker's own container forwarding is unaffected (it lives in the docker zone).
   <service name="aryaos-mesh-sa"/>
   <service name="aryaos-node-red"/>
   <service name="aryaos-ais-catcher"/>
-  <service name="aryaos-comitup"/>
+  <!-- aryaos-comitup (9080 onboarding captive portal) is intentionally NOT opened
+       on the wired LAN: it is only needed on the onboarding radios (Wi-Fi hotspot +
+       Bluetooth PAN), which get it via the aryaos-hotspot zone. comitup-web binds
+       0.0.0.0, so the firewall is what scopes it; LAN admin is via Cockpit. -->
 </zone>


### PR DESCRIPTION
Deep HIL pentest of the CoT/XML attack surface. **No XXE anywhere** — the fleet uses stdlib ElementTree, which doesn't resolve external entities (file-read/SSRF via CoT not possible; confirmed live). Two real hardening items:

## 1. Entity-expansion (billion-laughs) DoS in `aryaos-neighbord` (moderate)
`aryaos-neighbord:195` `ET.fromstring`s **untrusted multicast CoT** from `239.2.3.1:6969` (LAN-reachable; `recvfrom` at :314). ElementTree expands internal entities, so a single crafted UDP datagram could trigger a memory/CPU spike (bounded by the ~64 KB datagram cap, no rate-limiting, sync disk-write per parse). **Fix:** reject any `<!DOCTYPE`/`<!ENTITY` before parsing — CoT has no legitimate DTD, and `defusedxml` isn't on the image so this is dependency-free. Same guard added to `aryaos-import-tak-dp`'s `config.pref` parse (defense-in-depth; that path is already root-socket-gated + size-capped).

## 2. Onboarding portal (`9080`) was open on the wired LAN
The comitup captive portal was in the **`public`** firewalld zone, so it was reachable from the wired LAN — not just the onboarding radios. `comitup-web` binds `0.0.0.0`, so the firewall scopes it. **Fix:** remove `aryaos-comitup` from `public`; the onboarding radios keep it via the `aryaos-hotspot` zone (LAN admin is Cockpit).

`verify-image.sh` asserts the neighbord DTD guard and that 9080 isn't in the public zone.

## Verified on hardware
```
DTD/entity CoT -> rejected; neighbord stays active
9080 from the LAN -> 000 (blocked); still on hotspot/PAN via aryaos-hotspot
```

Also noted (low, not changed here): `/tar1090` `/skyaware` ADS-B maps are unauth (ADS-B is public data); Node-RED httpNode endpoints have no auth (no sensitive one active).

🤖 Generated with [Claude Code](https://claude.com/claude-code)