### PR TITLE
harden: sandbox aryaos-neighbord (root service parsing untrusted mesh CoT)

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -302,6 +302,8 @@ fi
 # aryaos-neighbord parses untrusted multicast CoT — it must reject DTD/entity
 # (billion-laughs) payloads before ElementTree parsing.
 require_grep '<!DOCTYPE' /usr/local/sbin/aryaos-neighbord "neighbord rejects DTD/entity CoT (billion-laughs guard)"
+# aryaos-neighbord parses untrusted network input as root — it must be sandboxed.
+require_grep '^NoNewPrivileges=yes' /etc/systemd/system/aryaos-neighbord.service "neighbord is systemd-sandboxed"
 
 # Onboarding hotspot zone: tight INPUT (assigned to wlan0 in AP mode by
 # comitup-callback). Must exist, must NOT expose ssh / Node-RED / mesh, and

--- a/shared_files/aryaos/systemd/aryaos-neighbord.service
+++ b/shared_files/aryaos/systemd/aryaos-neighbord.service
@@ -10,5 +10,29 @@ ExecStart=/usr/local/sbin/aryaos-neighbord
 Restart=on-failure
 RestartSec=3s
 
+# Sandboxing: aryaos-neighbord parses UNTRUSTED multicast CoT from the LAN, so
+# contain a hypothetical parser bug. It only needs the network and /run/aryaos
+# (no system-dir writes), so it can be locked down hard while still receiving
+# adverts and running the beacon helper (ip/systemctl/gpspipe reads).
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/run/aryaos
+RuntimeDirectory=aryaos
+RuntimeDirectoryPreserve=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Audit of systemd hardening across the CoT fleet. The gateways (adsbcot/aiscot/dronecot/lincot/charontak/readsb/ais-catcher) run as their **own non-root users** (a decoder RCE is contained to that user), and `gpstak` uses `DynamicUser`. But **`aryaos-neighbord` and `aryaos-tak-dp-importd` run as root with no confinement** (`NoNewPrivileges=no`, `ProtectSystem=no`, full caps).

`aryaos-neighbord` parses **untrusted multicast CoT** off the LAN-reachable mesh (`6969`), so an unsandboxed root parser bug = full compromise. It only needs the network + `/run/aryaos`, so it can be locked down hard: `NoNewPrivileges`, `ProtectSystem=strict` + `ReadWritePaths=/run/aryaos`, `ProtectHome`, `PrivateTmp`, kernel/cgroup protections, `RestrictAddressFamilies`, `RestrictNamespaces`, `LockPersonality`, `MemoryDenyWriteExecute`, empty `CapabilityBoundingSet`, `SystemCallFilter=@system-service`.

## Verified on hardware
```
neighbord active; receives adverts + writes /run/aryaos/neighbors.json
beacon helper (ip/systemctl/gpspipe) still emits on the mesh; no seccomp/namespace denials
systemd-analyze security: 9.x -> 3.0 (OK)
```
`verify-image` asserts the sandbox.

> Follow-up: harden `aryaos-tak-dp-importd` (root; writes `/etc/aryaos/tls` + restarts charontak — needs `ReadWritePaths` tuning) and add `ProtectSystem` drop-ins for the readsb/ais-catcher/pytak gateway units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)