### PR TITLE
feature: act as a network time server (chrony, GPS-disciplined)

### DIFF
--- a/packaging/aryaos-overlay/postinst
+++ b/packaging/aryaos-overlay/postinst
@@ -59,6 +59,10 @@ case "$1" in
     if command -v systemctl >/dev/null 2>&1; then
       systemctl daemon-reload || true
       systemctl enable aryaos-firstboot.service aryaos-gps-time-sync.service aryaos-tak-dp-importd.service aryaos-neighbord.service aryaos-radio-silence.service NetworkManager-dispatcher.service 2>/dev/null || true
+      # Time service: chrony (GPS-disciplined + serves the local network) replaces
+      # the client-only systemd-timesyncd.
+      systemctl disable --now systemd-timesyncd.service 2>/dev/null || true
+      systemctl enable chrony.service 2>/dev/null || true
       # Hardening: activate sysctl/sshd/fail2ban/firewalld config shipped by
       # this package (no-ops in image-build chroots where nothing is running).
       systemctl enable firewalld.service fail2ban.service 2>/dev/null || true

--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -136,6 +136,8 @@ done
 for zone_xml in "${SHARED}/aryaos/firewalld/zones/"*.xml; do
 	install_file 0644 "${zone_xml}" "/etc/firewalld/zones/$(basename "${zone_xml}")"
 done
+# chrony drop-in: GPS-disciplined NTP + serve time to the local networks.
+install_file 0644 "${SHARED}/aryaos/chrony/aryaos.conf" "/etc/chrony/conf.d/aryaos.conf"
 install_file 0755 "${SHARED}/aryaos/99-aryaos-dispatcher" "/etc/NetworkManager/dispatcher.d/99-aryaos-dispatcher"
 
 

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -320,6 +320,11 @@ require_grep '(aryaos-hotspot|--change-interface)' /usr/local/sbin/comitup-callb
 require_grep '<interface name="pan0"/>' /etc/firewalld/zones/aryaos-hotspot.xml "pan0 statically bound to hotspot zone"
 require_grep 'aryaos-hotspot' /usr/local/sbin/aryaos-bt-pan-nap "bt-pan confines pan0 to the hotspot zone"
 
+# Time service: chrony (GPS-disciplined NTP server for the local networks)
+require_pkg chrony
+require_path /etc/chrony/conf.d/aryaos.conf
+require_grep '<service name="ntp"' /etc/firewalld/zones/public.xml "NTP served on the AryaOS (LAN) zone"
+
 # Media longevity: zram swap config + periodic TRIM
 require_path /etc/systemd/zram-generator.conf
 require_grep '^\[zram0\]' /etc/systemd/zram-generator.conf "zram swap configured"

--- a/shared_files/aryaos/chrony/aryaos.conf
+++ b/shared_files/aryaos/chrony/aryaos.conf
@@ -1,0 +1,16 @@
+# AryaOS time service (drop-in; the packaged chrony.conf provides pool/drift/rtc).
+#
+# Makes the box a time SERVER for its own networks and, when a GNSS receiver has a
+# fix, a GPS-disciplined source — so a fielded unit hands out accurate time to the
+# LAN / onboarding radios even with no internet. Which networks may query is scoped
+# by the firewalld `ntp` service (opened on the AryaOS + hotspot zones), not here.
+
+# GPS reference clock via gpsd's SHM segment (used only when gpsd has a fix).
+refclock SHM 0 refid GPS precision 1e-1 offset 0.0 delay 0.2
+
+# Serve time to clients (firewall scopes which networks can reach us).
+allow
+
+# Fall back to the local clock (stratum 10) so the box still serves time when it
+# has neither upstream NTP nor a GPS fix (offline field use).
+local stratum 10

--- a/shared_files/aryaos/firewalld/zones/aryaos-hotspot.xml
+++ b/shared_files/aryaos/firewalld/zones/aryaos-hotspot.xml
@@ -29,4 +29,5 @@ onto the wired ethernet regardless of net.ipv4.ip_forward (see public.xml).
        between this zone (AP mode) and public (client uplink) via connection.zone
        in comitup-callback.sh, so a static binding would fight NM. -->
   <interface name="pan0"/>
+  <service name="ntp"/>
 </zone>

--- a/shared_files/aryaos/firewalld/zones/public.xml
+++ b/shared_files/aryaos/firewalld/zones/public.xml
@@ -33,4 +33,5 @@ Docker's own container forwarding is unaffected (it lives in the docker zone).
        on the wired LAN: it is only needed on the onboarding radios (Wi-Fi hotspot +
        Bluetooth PAN), which get it via the aryaos-hotspot zone. comitup-web binds
        0.0.0.0, so the firewall is what scopes it; LAN admin is via Cockpit. -->
+  <service name="ntp"/>
 </zone>

--- a/stages/stage-aryaos/00-install/00-packages
+++ b/stages/stage-aryaos/00-install/00-packages
@@ -2,3 +2,4 @@ fail2ban
 python3-systemd
 firewalld
 unattended-upgrades
+chrony

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -120,6 +120,8 @@ done
 for zone_xml in "${SHARED_FILES}/aryaos/firewalld/zones/"*.xml; do
 	install -v -m 0644 "${zone_xml}" "${ROOTFS_DIR}/etc/firewalld/zones/"
 done
+# chrony drop-in: GPS-disciplined NTP + serve time to the local networks.
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/chrony/aryaos.conf" "${ROOTFS_DIR}/etc/chrony/conf.d/aryaos.conf"
 
 ## One-click updates: helper + oneshot unit (driven by Cockpit -> AryaOS Site)
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-update" "${ROOTFS_DIR}/usr/local/sbin/aryaos-update"

--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -37,6 +37,10 @@ systemctl enable lighttpd
 systemctl enable firewalld
 systemctl enable fail2ban
 systemctl enable aryaos-gps-time-sync.service
+# Time service: chrony (GPS-disciplined + serves the local network) instead of the
+# client-only systemd-timesyncd.
+systemctl disable systemd-timesyncd.service 2>/dev/null || true
+systemctl enable chrony.service
 systemctl enable aryaos-tak-dp-importd.service
 systemctl enable aryaos-neighbord.service
 # EMCON: re-applies WiFi/Bluetooth rfkill at boot when /etc/aryaos/emcon is set.


### PR DESCRIPTION
Adds the ability to **serve time to the local network** (requested). Replaces the client-only `systemd-timesyncd` with **chrony**:

- **`/etc/chrony/conf.d/aryaos.conf`** drop-in: GPS reference clock via gpsd's SHM segment (used when a GNSS fix is present), `allow` to serve clients, and `local stratum 10` so the box **still hands out time offline** (no upstream NTP, no GPS). The packaged `chrony.conf` still provides pool/drift/rtc via its `confdir` include.
- Install `chrony` (stage packages), enable it + disable `systemd-timesyncd` (overlay postinst + stage chroot).
- Open the firewalld **`ntp` service (123/udp)** on the **AryaOS (LAN)** and **hotspot** zones — the box serves its own networks, not the internet.

`verify-image` asserts chrony + the drop-in + the ntp firewall service.

## Verified on hardware
```
chrony listening on 0.0.0.0:123; GPS SHM refclock loaded from the drop-in
LAN client -> box: SERVED NTP (stratum 3 upstream-locked / 10 local fallback)
systemd-timesyncd swapped out
```

Notes: GPS-disciplined stratum-1 kicks in automatically once a GNSS receiver has a fix (gpsd exports SHM). A Cockpit on/off toggle + a docs page are easy follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)