### PR TITLE
feature: pull down the box's own OS image for offline backup

### DIFF
--- a/scripts/build-aryaos-overlay-deb.sh
+++ b/scripts/build-aryaos-overlay-deb.sh
@@ -75,6 +75,8 @@ install_file 0755 "${SHARED}/aryaos/aryaos-config-backup" "/usr/local/sbin/aryao
 install_file 0755 "${SHARED}/aryaos/aryaos-factory-reset" "/usr/local/sbin/aryaos-factory-reset"
 install_file 0755 "${SHARED}/aryaos/aryaos-zeroize" "/usr/local/sbin/aryaos-zeroize"
 install_file 0755 "${SHARED}/aryaos/aryaos-radio" "/usr/local/sbin/aryaos-radio"
+# Offline image backup: pull down this box's own release .img.xz.
+install_file 0755 "${SHARED}/aryaos/aryaos-image-download" "/usr/local/sbin/aryaos-image-download"
 install_file 0755 "${SHARED}/aryaos/run_comitup.sh" "/usr/local/sbin/run_comitup.sh"
 install_file 0755 "${SHARED}/aryaos/comitup-callback.sh" "/usr/local/sbin/comitup-callback.sh"
 install_file 0755 "${SHARED}/aryaos/wifi-nuke.py" "/usr/local/sbin/wifi-nuke.py"

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -320,6 +320,10 @@ require_grep '(aryaos-hotspot|--change-interface)' /usr/local/sbin/comitup-callb
 require_grep '<interface name="pan0"/>' /etc/firewalld/zones/aryaos-hotspot.xml "pan0 statically bound to hotspot zone"
 require_grep 'aryaos-hotspot' /usr/local/sbin/aryaos-bt-pan-nap "bt-pan confines pan0 to the hotspot zone"
 
+# Offline image self-backup: helper + the build-commit stamp it resolves against.
+require_path /usr/local/sbin/aryaos-image-download
+require_path /etc/aryaos/image-commit
+
 # Time service: chrony (GPS-disciplined NTP server for the local networks)
 require_pkg chrony
 require_path /etc/chrony/conf.d/aryaos.conf

--- a/shared_files/aryaos/aryaos-image-download
+++ b/shared_files/aryaos/aryaos-image-download
@@ -1,0 +1,176 @@
+#!/usr/bin/python3
+"""Download this box's own AryaOS image (.img.xz) for an offline backup copy.
+
+A fielded unit may be reachable (e.g. over the onboarding hotspot) by an operator
+whose laptop can't reach GitHub. This lets the box pull down the exact image it
+was built from so the operator can copy it off for a cold backup / re-flash.
+
+The image is resolved from the git commit stamped into /etc/aryaos/image-commit at
+build time (the release tag embeds that short SHA). Modes:
+
+  aryaos-image-download --status        resolve the release + asset, print JSON (no download)
+  aryaos-image-download [--tag TAG]     download the .img.xz to /var/lib/aryaos/image/
+  aryaos-image-download --check         verify the downloaded image's sha256
+
+Prints a JSON object on stdout for the Cockpit "AryaOS Site" backend; exit 0 ok, 1 error.
+
+Copyright Sensors & Signals LLC https://www.snstac.com/
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+REPO = "snstac/aryaos"
+COMMIT_FILE = "/etc/aryaos/image-commit"
+DEST_DIR = "/var/lib/aryaos/image"
+API = f"https://api.github.com/repos/{REPO}/releases"
+UA = {"User-Agent": "aryaos-image-download", "Accept": "application/vnd.github+json"}
+
+
+def emit(payload, code):
+    sys.stdout.write(json.dumps(payload) + "\n")
+    raise SystemExit(code)
+
+
+def fail(message):
+    emit({"ok": False, "error": message}, 1)
+
+
+def _api(url):
+    try:
+        req = urllib.request.Request(url, headers=UA)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.load(resp)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        fail(f"GitHub API unreachable: {exc}")
+
+
+def stamped_sha():
+    try:
+        first = open(COMMIT_FILE, encoding="utf-8").read().strip().split()
+        return first[0][:12] if first else ""
+    except OSError:
+        return ""
+
+
+def resolve_release(tag=None):
+    releases = _api(f"{API}?per_page=60")
+    if not releases:
+        fail("No releases found")
+    if tag:
+        for rel in releases:
+            if rel.get("tag_name") == tag:
+                return rel
+        fail(f"Release {tag} not found")
+    sha = stamped_sha()
+    if sha:
+        for rel in releases:
+            if sha in rel.get("tag_name", ""):
+                return rel
+    # No stamp / no match: newest release, flagged so the UI can warn.
+    rel = releases[0]
+    rel["_fallback"] = True
+    return rel
+
+
+def pick_asset(rel):
+    for asset in rel.get("assets", []):
+        if asset.get("name", "").endswith(".img.xz"):
+            return asset
+    fail("Release has no .img.xz asset")
+
+
+def do_status(tag=None):
+    rel = resolve_release(tag)
+    asset = pick_asset(rel)
+    dest = os.path.join(DEST_DIR, asset["name"])
+    emit({
+        "ok": True,
+        "tag": rel["tag_name"],
+        "asset": asset["name"],
+        "size": asset["size"],
+        "url": asset["browser_download_url"],
+        "fallback": bool(rel.get("_fallback")),
+        "stamped_commit": stamped_sha(),
+        "already_downloaded": os.path.exists(dest) and os.path.getsize(dest) == asset["size"],
+        "dest": dest,
+    }, 0)
+
+
+def do_download(tag=None):
+    rel = resolve_release(tag)
+    asset = pick_asset(rel)
+    os.makedirs(DEST_DIR, mode=0o755, exist_ok=True)
+    dest = os.path.join(DEST_DIR, asset["name"])
+    if os.path.exists(dest) and os.path.getsize(dest) == asset["size"]:
+        emit({"ok": True, "tag": rel["tag_name"], "path": dest,
+              "size": os.path.getsize(dest), "cached": True}, 0)
+    tmp = dest + ".part"
+    try:
+        req = urllib.request.Request(asset["browser_download_url"], headers=UA)
+        with urllib.request.urlopen(req, timeout=60) as resp, open(tmp, "wb") as out:
+            total = asset["size"] or 0
+            done = 0
+            last = -1
+            while True:
+                chunk = resp.read(1024 * 256)
+                if not chunk:
+                    break
+                out.write(chunk)
+                done += len(chunk)
+                if total:
+                    pct = done * 100 // total
+                    if pct != last and pct % 5 == 0:
+                        sys.stderr.write(f"downloaded {pct}% ({done}/{total})\n")
+                        sys.stderr.flush()
+                        last = pct
+        os.replace(tmp, dest)
+    except (urllib.error.URLError, OSError) as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        fail(f"Download failed: {exc}")
+    emit({"ok": True, "tag": rel["tag_name"], "path": dest,
+          "size": os.path.getsize(dest), "cached": False}, 0)
+
+
+def do_check():
+    # sha256 of the newest downloaded image (for the operator to verify off-box).
+    if not os.path.isdir(DEST_DIR):
+        fail("No image downloaded")
+    imgs = [f for f in os.listdir(DEST_DIR) if f.endswith(".img.xz")]
+    if not imgs:
+        fail("No image downloaded")
+    path = os.path.join(DEST_DIR, sorted(imgs)[-1])
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(block)
+    emit({"ok": True, "path": path, "sha256": h.hexdigest(), "size": os.path.getsize(path)}, 0)
+
+
+def main():
+    args = sys.argv[1:]
+    tag = None
+    if "--tag" in args:
+        i = args.index("--tag")
+        tag = args[i + 1] if i + 1 < len(args) else None
+        args = args[:i] + args[i + 2:]
+    mode = args[0] if args else "--download"
+    if mode == "--status":
+        do_status(tag)
+    if mode == "--check":
+        do_check()
+    if mode in ("--download", "-"):
+        do_download(tag)
+    fail(f"Unknown mode: {mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -162,6 +162,16 @@ install -v -D -m 0644 "${SHARED_FILES}/charontak/charontak.ini" "${ROOTFS_DIR}/u
 ## gpsd: USB GNSS defaults (see shared_files/aryaos/gpsd.default)
 install -v -m 0644 "${SHARED_FILES}/aryaos/gpsd.default" "${ROOTFS_DIR}/etc/default/gpsd"
 
+## Stamp the build commit so the box can fetch its own release image for an
+## offline backup (aryaos-image-download matches the release tag by this SHA).
+## The release tag is generated post-build, but it embeds this short SHA.
+BUILD_SHA="$(git -C "$(dirname "${SHARED_FILES}")" rev-parse HEAD 2>/dev/null || echo "${GITHUB_SHA:-unknown}")"
+install -v -d -m 0755 "${ROOTFS_DIR}/etc/aryaos"
+printf '%s %s\n' "${BUILD_SHA}" "${GITHUB_REF_NAME:-main}" > "${ROOTFS_DIR}/etc/aryaos/image-commit"
+
+## Helper: pull down this box's own image (.img.xz) for an offline backup copy.
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-image-download" "${ROOTFS_DIR}/usr/local/sbin/aryaos-image-download"
+
 
 # UUID
 


### PR DESCRIPTION
A fielded unit can be reached (e.g. over the onboarding hotspot) by an operator whose laptop can't reach GitHub. This lets the box fetch the exact image it was built from, so the operator can copy it off for a cold backup / re-flash.

- **New `aryaos-image-download`** (root, Cockpit-driven): resolves the release from the git commit stamped at `/etc/aryaos/image-commit` (the release tag embeds that short SHA), downloads the `.img.xz` to `/var/lib/aryaos/image/`; `--status` / `--check` modes. Public releases → no auth/`gh` (urllib only).
- **Stamp the build commit** into `/etc/aryaos/image-commit` during stage-aryaos (the tag is generated post-build but contains this SHA — matched at download time).
- Install via overlay deb + stage; `verify-image` asserts both.

## Verified on hardware
```
--status (real commit stamped) -> tag v2026.07.21.150335-cb18ef3..., asset image_...img.xz (1.5 GB), fallback=False
asset URL -> HTTP 206 (live)
```

> Cockpit "OS image backup" card ships in the paired cockpit-aryaos PR. A live progress bar is an easy follow-up (the helper already prints per-5% progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)