### PR TITLE
fix: stamp the real build SHA into /etc/aryaos/image-commit

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -168,6 +168,11 @@ jobs:
       - name: Set SHARED_FILES dir
         run: echo "SHARED_FILES=$(pwd)/shared_files" >> "$GITHUB_ENV"
 
+      - name: Stamp build commit for aryaos-image-download
+        run: |
+          echo "ARYAOS_BUILD_SHA=${{ github.sha }}" >> "$GITHUB_ENV"
+          echo "ARYAOS_BUILD_REF=${{ github.ref_name }}" >> "$GITHUB_ENV"
+
       - name: Build offline documentation into the portal
         # Renders the MkDocs site into shared_files/aryaos/html/docs so the
         # overlay deb (install_tree html -> /var/www/html) ships it on the

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -323,6 +323,7 @@ require_grep 'aryaos-hotspot' /usr/local/sbin/aryaos-bt-pan-nap "bt-pan confines
 # Offline image self-backup: helper + the build-commit stamp it resolves against.
 require_path /usr/local/sbin/aryaos-image-download
 require_path /etc/aryaos/image-commit
+require_grep '^[0-9a-f]{7,}' /etc/aryaos/image-commit "image-commit stamped with a real SHA (not 'unknown')"
 
 # Time service: chrony (GPS-disciplined NTP server for the local networks)
 require_pkg chrony

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -165,9 +165,11 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/gpsd.default" "${ROOTFS_DIR}/etc/defa
 ## Stamp the build commit so the box can fetch its own release image for an
 ## offline backup (aryaos-image-download matches the release tag by this SHA).
 ## The release tag is generated post-build, but it embeds this short SHA.
-BUILD_SHA="$(git -C "$(dirname "${SHARED_FILES}")" rev-parse HEAD 2>/dev/null || echo "${GITHUB_SHA:-unknown}")"
+# ARYAOS_BUILD_SHA is exported into the build env by the workflow (via GITHUB_ENV,
+# the same mechanism as SHARED_FILES); fall back to git only for local builds.
+BUILD_SHA="${ARYAOS_BUILD_SHA:-$(git -C "$(dirname "${SHARED_FILES}")" rev-parse HEAD 2>/dev/null || echo unknown)}"
 install -v -d -m 0755 "${ROOTFS_DIR}/etc/aryaos"
-printf '%s %s\n' "${BUILD_SHA}" "${GITHUB_REF_NAME:-main}" > "${ROOTFS_DIR}/etc/aryaos/image-commit"
+printf '%s %s\n' "${BUILD_SHA}" "${ARYAOS_BUILD_REF:-${GITHUB_REF_NAME:-main}}" > "${ROOTFS_DIR}/etc/aryaos/image-commit"
 
 ## Helper: pull down this box's own image (.img.xz) for an offline backup copy.
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-image-download" "${ROOTFS_DIR}/usr/local/sbin/aryaos-image-download"


### PR DESCRIPTION
Fresh-flash verification caught this: the image-commit stamp shipped as **unknown**, so aryaos-image-download fell back to the newest release instead of resolving the box own image. The in-stage git rev-parse / GITHUB_SHA did not reach the pi-gen build env.

Export **ARYAOS_BUILD_SHA/REF via GITHUB_ENV** (same mechanism that already makes SHARED_FILES reach the stage); the stamp prefers it, falling back to git for local builds. verify-image now **fails** if the stamp is not a real SHA.

Everything else on the consolidated image verified correct on hardware — this was the only gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)