### PR TITLE
verify-image: assert cockpit-aryaos location chip ships

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -165,6 +165,9 @@ require_path /usr/share/cockpit/aryaos/aryaos.js
 require_grep 'id="card-neighbors"' /usr/share/cockpit/aryaos/index.html "cockpit-aryaos neighbor card"
 require_grep 'refreshNeighbors' /usr/share/cockpit/aryaos/aryaos.js "cockpit-aryaos neighbor refresh"
 require_grep 'id="card-updates"' /usr/share/cockpit/aryaos/index.html "cockpit-aryaos software updates card"
+require_grep 'id="card-location"' /usr/share/cockpit/aryaos/index.html "cockpit-aryaos location chip card"
+require_path /usr/share/cockpit/aryaos/aryaos-basemap.js
+require_grep 'ARYAOS_BASEMAP' /usr/share/cockpit/aryaos/aryaos-basemap.js "cockpit-aryaos offline base map data"
 
 # GPSTAK network GPS (package from stage-pytak)
 require_pkg gpstak


### PR DESCRIPTION
Release-gate follow-up to cockpit-aryaos #8 (offline location chip). Adds three assertions to `verify-image.sh` so a build fails if the chip is missing:

- `id="card-location"` present in `index.html`
- `/usr/share/cockpit/aryaos/aryaos-basemap.js` present
- `ARYAOS_BASEMAP` (the offline North America base-map data) present in that file

The `cockpit-aryaos` deb was rebuilt/published on merge of #8, so the next image build will include these files.