### PR TITLE
fix: pass ARYAOS_BUILD_SHA into the pi-gen Docker container

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -230,6 +230,8 @@ jobs:
             -e GITHUB_WORKSPACE=${{ github.workspace }}
             -e ARYAOS_CI_TRIM_WORK=1
             -e ARYAOS_LAB_ACCESS=${{ env.ARYAOS_LAB_ACCESS }}
+            -e ARYAOS_BUILD_SHA=${{ github.sha }}
+            -e ARYAOS_BUILD_REF=${{ github.ref_name }}
 
       - name: Show deploy output
         if: success()

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -165,8 +165,9 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/gpsd.default" "${ROOTFS_DIR}/etc/defa
 ## Stamp the build commit so the box can fetch its own release image for an
 ## offline backup (aryaos-image-download matches the release tag by this SHA).
 ## The release tag is generated post-build, but it embeds this short SHA.
-# ARYAOS_BUILD_SHA is exported into the build env by the workflow (via GITHUB_ENV,
-# the same mechanism as SHARED_FILES); fall back to git only for local builds.
+# ARYAOS_BUILD_SHA is passed into the pi-gen Docker container by the workflow
+# via `docker-opts: -e ARYAOS_BUILD_SHA=...` (GITHUB_ENV does NOT cross into the
+# container). Fall back to git only for local (non-container) builds.
 BUILD_SHA="${ARYAOS_BUILD_SHA:-$(git -C "$(dirname "${SHARED_FILES}")" rev-parse HEAD 2>/dev/null || echo unknown)}"
 install -v -d -m 0755 "${ROOTFS_DIR}/etc/aryaos"
 printf '%s %s\n' "${BUILD_SHA}" "${ARYAOS_BUILD_REF:-${GITHUB_REF_NAME:-main}}" > "${ROOTFS_DIR}/etc/aryaos/image-commit"


### PR DESCRIPTION
The `/etc/aryaos/image-commit` stamp landed as `unknown`, failing the `verify-image` gate on the last main build ([run](https://github.com/snstac/aryaos/actions/runs/29857855725)). #162 tried to fix this via `GITHUB_ENV` but that never reaches the pi-gen build.

**Root cause:** pi-gen runs inside a Docker container (`usimd/pi-gen-action`). Env vars written to `GITHUB_ENV` are visible to the workflow shell but **not** inside the container. `stage-aryaos/00-install/00-run.sh` read an unset `ARYAOS_BUILD_SHA` and fell back to `git rev-parse` (no `.git` in the container) → `unknown`.

**Fix:** pass `ARYAOS_BUILD_SHA` / `ARYAOS_BUILD_REF` through `docker-opts: -e` — the same channel already used for `ARYAOS_LAB_ACCESS` / `ARYAOS_CI_TRIM_WORK` — and correct the misleading comment.