### PR TITLE
feat: brownout / crash-loop safe mode + power-health hardening

### DIFF
--- a/docs/get-started/hardware.md
+++ b/docs/get-started/hardware.md
@@ -105,12 +105,27 @@ A USB GNSS puck gives the gateway its own position, which AryaOS publishes to TA
 ## Power & battery for backpack ops
 
 AryaOS is designed for disconnected, dismounted use — no LTE, no Wi-Fi backhaul required.
+Power is the most common field failure, so size it correctly:
 
-- Power the Pi from a good-quality USB power bank; use one that meets the Pi model's current draw (a Pi 4/5 wants a solid 5V/3A source).
-- SDRs draw additional current — size the battery for the Pi **plus** every attached radio.
+- **Raspberry Pi 5: use a 5V/5A (27&nbsp;W) USB-C PD supply** — the official Raspberry Pi 27&nbsp;W supply, or a charger that *explicitly* lists a `5V/5A` output. (Earlier Pis: a Pi 4 wants a solid 5V/3A source.)
+    - **A high-wattage GaN charger is not a substitute.** Multi-port GaN bricks (e.g. Anker Prime 100&nbsp;W, UGREEN Nexode) deliver 5A only at 9–20&nbsp;V; at 5&nbsp;V they cap at **3A (15&nbsp;W)**, so a Pi 5 runs starved and browns out under load. Verify the `5V/5A` line item, not the total wattage.
+- **SDRs draw additional current.** AryaOS ships `usb_max_current_enable=1`, so the Pi 5 feeds the full USB budget to the radios — but only if the supply can actually deliver it. Size the battery/supply for the Pi **plus** every attached radio.
+- **PoE:** the Waveshare PoE M.2 HAT+ (and similar) output **5V/4.5A (~22.5&nbsp;W) on 802.3at (PoE+)** — enough for a Pi 5 with an NVMe SSD and a couple of SDRs, but **only from a true PoE+ (802.3at) source**. A plain **802.3af** switch or injector (~13&nbsp;W) will brown the box out; use PoE+ (802.3at) or PoE++ (802.3bt).
 - A powered USB hub can help when running multiple SDRs on a Pi 3/4.
 
+If the supply still can't keep up, AryaOS does not just crash-loop: after repeated short boots it drops into **[safe mode](#safe-mode)** — USB peripherals off, sensors stopped, box still reachable — until you fit an adequate supply and restore it. The AryaOS Site page in Cockpit also shows a live **power-health** warning (from `vcgencmd get_throttled`) whenever it detects under-voltage or throttling.
+
 See [Disconnected / backpack ops](../deploy/offline-backpack.md) for the full field loadout.
+
+### Safe mode
+
+If the box reboots repeatedly without staying up — the classic symptom of an under-spec'd supply browning out under load — AryaOS latches **safe mode** after 3 consecutive short boots (each under 3 minutes):
+
+- USB peripherals are **powered off** and the sensor/SDR services are **withheld**, so the box idles at minimal draw and boots cleanly.
+- **Ethernet, SSH and Cockpit stay up**, so you can always get in and diagnose.
+- It is **sticky** — clear it from **Cockpit → AryaOS Site → Safe mode** ("Restore now" or "Restore &amp; reboot"), or on the command line with `sudo aryaos-safe-mode off`. Check state any time with `aryaos-safe-mode status`.
+
+The usual fix is a better power supply (above). Safe mode buys you a reachable box to fix instead of a dark one in a crash loop.
 
 ## The pre-built AirTAK go-kit
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,6 +52,15 @@ A radio is plugged in but the decoder sees nothing.
 3. **Power.** Multiple SDRs can exceed the Pi's USB budget — use a powered hub and a stronger power supply. See [Hardware & requirements](get-started/hardware.md).
 4. **Antenna.** No detections despite a working dongle usually means an antenna/placement problem — check the connector and line of sight.
 
+## Box keeps rebooting, or all sensors are stopped (safe mode) {#safe-mode}
+
+If the box reboots in a loop, or comes up with every sensor stopped and USB peripherals dead, it has almost certainly **browned out under load on an under-spec'd power supply** — and AryaOS has latched **safe mode** to keep it reachable instead of crash-looping.
+
+1. **Confirm.** Run `aryaos-safe-mode status`, or look for the red banner on the **AryaOS Site** Cockpit page. `safe-mode: ON` with a `crash-loop` reason means it tripped after 3 consecutive short boots.
+2. **Fix the power** — nearly always the cause. See [Power & battery](get-started/hardware.md#power--battery-for-backpack-ops): a Pi 5 needs a **5V/5A (27&nbsp;W)** supply; a big GaN charger that only does 5V/3A, or a PoE HAT on plain 802.3af, will not sustain it.
+3. **Restore.** On a good supply, clear safe mode from **Cockpit → AryaOS Site → Safe mode** ("Restore now" or "Restore &amp; reboot"), or `sudo aryaos-safe-mode off` — this re-powers USB and restarts the sensors.
+4. **Check under-voltage** any time with `vcgencmd get_throttled` (`0x0` is clean); the AryaOS Site page also shows this as a live power-health warning.
+
 ## A service won't start
 
 A gateway shows as failed or keeps restarting.

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -168,6 +168,8 @@ require_grep 'id="card-updates"' /usr/share/cockpit/aryaos/index.html "cockpit-a
 require_grep 'id="card-location"' /usr/share/cockpit/aryaos/index.html "cockpit-aryaos location chip card"
 require_path /usr/share/cockpit/aryaos/aryaos-basemap.js
 require_grep 'ARYAOS_BASEMAP' /usr/share/cockpit/aryaos/aryaos-basemap.js "cockpit-aryaos offline base map data"
+require_grep 'get_throttled' /usr/share/cockpit/aryaos/aryaos.js "cockpit-aryaos power-health indicator"
+require_grep 'id="safe-mode-banner"' /usr/share/cockpit/aryaos/index.html "cockpit-aryaos safe-mode banner"
 
 # GPSTAK network GPS (package from stage-pytak)
 require_pkg gpstak
@@ -287,6 +289,18 @@ require_grep 'nmcli radio wifi off' /usr/local/sbin/aryaos-radio "aryaos-radio d
 for svc in comitup aryaos-bt-pan aryaos-bt-ready; do
 	require_grep 'ConditionPathExists=!/etc/aryaos/emcon' "/etc/systemd/system/${svc}.service.d/emcon.conf" "${svc} gated off during EMCON"
 done
+
+# Safe mode: brownout / crash-loop fail-safe (powers off USB, withholds sensors).
+require_path /usr/local/sbin/aryaos-safe-mode
+require_unit aryaos-crash-guard.service
+require_unit aryaos-safe-mode.service
+require_unit aryaos-boot-stable.timer
+require_pkg uhubctl
+for svc in readsb adsbcot ais-catcher; do
+	require_grep 'ConditionPathExists=!/etc/aryaos/safe-mode' "/etc/systemd/system/${svc}.service.d/safe-mode.conf" "${svc} withheld in safe mode"
+done
+# USB current cap relaxed so the Pi 5 can feed SDRs on a 5A / PoE+ supply.
+require_grep 'usb_max_current_enable=1' /boot/firmware/config.txt "USB current cap relaxed for SDRs (Pi 5)"
 # AP/PAN isolation: the default zone must NOT enable intra-zone forwarding, or a
 # hotspot/Bluetooth client could be routed onto the wired ethernet.
 require_path /etc/firewalld/zones/public.xml

--- a/shared_files/aryaos/aryaos-safe-mode
+++ b/shared_files/aryaos/aryaos-safe-mode
@@ -1,0 +1,198 @@
+#!/bin/bash
+# aryaos-safe-mode — brownout / crash-loop fail-safe.
+#
+# If the box repeatedly reboots without staying up (the classic symptom of an
+# under-spec'd power supply browning out under SDR + CPU load — e.g. a weak USB
+# charger, or a PoE HAT fed from an 802.3af source), AryaOS drops into SAFE MODE:
+# it powers off USB peripherals and does not start the sensor/SDR services, so
+# the box idles at minimal draw and boots cleanly — leaving ethernet, SSH and
+# Cockpit up so an admin can get in and diagnose. Safe mode is sticky: it stays
+# until an admin clears it (Cockpit "Exit safe mode", or `aryaos-safe-mode off`).
+#
+# Detection: an early-boot oneshot (aryaos-crash-guard.service) increments a
+# counter each boot; a +180s timer (aryaos-boot-stable.timer) resets it once the
+# box has proven it can stay up. So only boots that fail to survive 3 minutes
+# accumulate; after THRESHOLD of them in a row, safe mode latches.
+#
+# Usage:
+#   aryaos-safe-mode status            Show safe-mode + crash-counter state (no root).
+#   aryaos-safe-mode on [reason]       Manually enter safe mode now.
+#   aryaos-safe-mode off [--reboot]    Exit: re-power USB, restart sensors (or reboot).
+#   aryaos-safe-mode check-boot        (internal) early-boot crash-loop check.
+#   aryaos-safe-mode boot-ok           (internal) +180s: mark boot healthy, reset counter.
+#   aryaos-safe-mode --boot            (internal) re-assert USB-off if latched.
+#
+# Backs the safe-mode banner in Cockpit -> AryaOS Site. USB current caps are
+# separately relaxed via /boot/firmware/config.txt (usb_max_current_enable=1),
+# which the Pi 5 + PoE HAT needs to feed SDRs; safe mode is the fail-safe for
+# when the supply still can't keep up. SDR receivers are receive-only; powering
+# their USB off in safe mode is about shedding current draw, not emissions.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SAFE_FLAG="/etc/aryaos/safe-mode"
+STATE_DIR="/var/lib/aryaos"
+BOOT_COUNT="${STATE_DIR}/boot-attempts"
+REASON_FILE="${STATE_DIR}/safe-mode-reason"
+CONFIG="/etc/aryaos/aryaos-config.txt"
+THRESHOLD=3
+
+# Sensor/SDR services whose USB peripherals draw the current that browns the box
+# out. Keep in sync with aryaos-role's all_managed_units.
+MANAGED_UNITS="readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot"
+
+require_root() {
+	if [[ "$(id -u)" != "0" ]]; then
+		echo "aryaos-safe-mode: must run as root (try sudo)" >&2
+		exit 2
+	fi
+}
+
+_log() { logger -t aryaos-safe-mode "$*" 2>/dev/null || true; }
+
+# --- USB peripheral power (best-effort; never fail the caller) ---
+usb_off() {
+	# Prefer a true VBUS cut via uhubctl; fall back to de-authorizing downstream
+	# USB devices so their drivers detach and the SDRs stop sampling.
+	if command -v uhubctl >/dev/null 2>&1; then
+		uhubctl -a off >/dev/null 2>&1 || true
+	fi
+	local a dev
+	for a in /sys/bus/usb/devices/*/authorized; do
+		[[ -w "$a" ]] || continue
+		dev="$(basename "$(dirname "$a")")"
+		# only downstream devices (e.g. 3-1), not root hubs (usb1/usb2)
+		[[ "$dev" == *-* ]] || continue
+		echo 0 > "$a" 2>/dev/null || true
+	done
+}
+
+usb_on() {
+	if command -v uhubctl >/dev/null 2>&1; then
+		uhubctl -a on >/dev/null 2>&1 || true
+	fi
+	local a dev
+	for a in /sys/bus/usb/devices/*/authorized; do
+		[[ -w "$a" ]] || continue
+		dev="$(basename "$(dirname "$a")")"
+		[[ "$dev" == *-* ]] || continue
+		echo 1 > "$a" 2>/dev/null || true
+	done
+}
+
+configured_role() {
+	local role="multi"
+	if [[ -f "$CONFIG" ]]; then
+		role="$(sed -n 's/^ARYAOS_ROLE=//p' "$CONFIG" | tr -d '"' | head -1)"
+	fi
+	[[ -n "$role" ]] && echo "$role" || echo "multi"
+}
+
+stop_sensors() { systemctl stop ${MANAGED_UNITS} >/dev/null 2>&1 || true; }
+
+start_sensors() {
+	# Flag is already cleared; re-apply the configured role so the right pipelines
+	# come back (their ConditionPathExists gate now passes).
+	if [[ -x /usr/local/sbin/aryaos-role ]]; then
+		/usr/local/sbin/aryaos-role set "$(configured_role)" >/dev/null 2>&1 || true
+	else
+		systemctl start ${MANAGED_UNITS} >/dev/null 2>&1 || true
+	fi
+}
+
+latch_safe_mode() {
+	local reason="${1:-manual}"
+	install -d -m 0755 /etc/aryaos "$STATE_DIR"
+	echo "$reason" > "$REASON_FILE" 2>/dev/null || true
+	: > "$SAFE_FLAG"
+	_log "SAFE MODE engaged: ${reason}"
+}
+
+read_count() {
+	local n=0
+	[[ -f "$BOOT_COUNT" ]] && n="$(cat "$BOOT_COUNT" 2>/dev/null || echo 0)"
+	[[ "$n" =~ ^[0-9]+$ ]] || n=0
+	echo "$n"
+}
+
+cmd_on() {
+	require_root
+	latch_safe_mode "${1:-manual (admin)}"
+	stop_sensors
+	usb_off
+	echo "Safe mode ON — USB peripherals powered off, sensor services stopped."
+	echo "Clear with: aryaos-safe-mode off"
+}
+
+cmd_off() {
+	require_root
+	local do_reboot=0
+	[[ "${1:-}" == "--reboot" ]] && do_reboot=1
+	rm -f "$SAFE_FLAG" "$REASON_FILE"
+	echo 0 > "$BOOT_COUNT" 2>/dev/null || true
+	usb_on
+	if [[ "$do_reboot" == "1" ]]; then
+		_log "SAFE MODE cleared by admin — rebooting"
+		echo "Safe mode cleared. Rebooting for a clean start…"
+		systemctl reboot
+	else
+		start_sensors
+		_log "SAFE MODE cleared by admin — hot-restored"
+		echo "Safe mode cleared — USB re-powered, sensors restored (role: $(configured_role))."
+	fi
+}
+
+cmd_check_boot() {
+	require_root
+	install -d -m 0755 /etc/aryaos "$STATE_DIR"
+	if [[ -f "$SAFE_FLAG" ]]; then
+		# Already latched — keep USB off, do not accumulate.
+		usb_off
+		_log "boot: safe mode already active — USB kept off"
+		exit 0
+	fi
+	local n; n="$(read_count)"; n=$((n + 1))
+	echo "$n" > "$BOOT_COUNT"
+	if (( n >= THRESHOLD )); then
+		latch_safe_mode "crash-loop: ${n} consecutive short boots (<180s)"
+		usb_off
+		_log "boot: crash-loop threshold reached (${n}/${THRESHOLD}) — entered SAFE MODE"
+	else
+		_log "boot: attempt ${n}/${THRESHOLD} (counter resets after 180s uptime)"
+	fi
+}
+
+cmd_boot_ok() {
+	require_root
+	install -d -m 0755 "$STATE_DIR"
+	echo 0 > "$BOOT_COUNT" 2>/dev/null || true
+	_log "boot marked stable (uptime>180s) — crash counter reset"
+}
+
+cmd_boot_apply() {
+	[[ -f "$SAFE_FLAG" ]] || exit 0
+	usb_off
+}
+
+cmd_status() {
+	if [[ -f "$SAFE_FLAG" ]]; then
+		echo "safe-mode: ON"
+		echo "reason: $(cat "$REASON_FILE" 2>/dev/null || echo unknown)"
+	else
+		echo "safe-mode: off"
+	fi
+	echo "boot-attempts: $(read_count)/${THRESHOLD}"
+}
+
+case "${1:-status}" in
+	status) cmd_status ;;
+	on) cmd_on "${2:-}" ;;
+	off) cmd_off "${2:-}" ;;
+	check-boot) cmd_check_boot ;;
+	boot-ok) cmd_boot_ok ;;
+	--boot) cmd_boot_apply ;;
+	*) echo "usage: aryaos-safe-mode {status|on [reason]|off [--reboot]}" >&2; exit 2 ;;
+esac

--- a/shared_files/aryaos/systemd/aryaos-boot-stable.service
+++ b/shared_files/aryaos/systemd/aryaos-boot-stable.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=AryaOS boot-stable marker — reset the crash counter once the box stays up
+Documentation=https://github.com/snstac/aryaos
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/aryaos-safe-mode boot-ok

--- a/shared_files/aryaos/systemd/aryaos-boot-stable.timer
+++ b/shared_files/aryaos/systemd/aryaos-boot-stable.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=AryaOS boot-stable timer — mark this boot healthy 180s after boot
+Documentation=https://github.com/snstac/aryaos
+
+[Timer]
+# If the box survives 180s, the boot "counts" — reset the crash-loop counter.
+# A brownout under load trips well before this, so only healthy boots reset it.
+OnBootSec=180
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target

--- a/shared_files/aryaos/systemd/aryaos-crash-guard.service
+++ b/shared_files/aryaos/systemd/aryaos-crash-guard.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AryaOS crash-loop guard — latch safe mode after repeated short boots
+Documentation=https://github.com/snstac/aryaos
+# Run very early so the /etc/aryaos/safe-mode flag is set before any sensor
+# service evaluates its ConditionPathExists gate. Only touches files + best-effort
+# USB power, so it is safe this early (no dbus/systemctl needed).
+DefaultDependencies=no
+After=local-fs.target
+Before=sysinit.target
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-safe-mode check-boot
+
+[Install]
+WantedBy=sysinit.target

--- a/shared_files/aryaos/systemd/aryaos-safe-mode.service
+++ b/shared_files/aryaos/systemd/aryaos-safe-mode.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AryaOS safe mode — power off USB peripherals while latched
+Documentation=https://github.com/snstac/aryaos
+# Runs late (USB enumerated) to actually cut VBUS to peripherals once the box is
+# up in safe mode. The sensor services are already withheld by their
+# ConditionPathExists gate; this sheds the residual USB current draw.
+After=multi-user.target
+ConditionPathExists=/etc/aryaos/safe-mode
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-safe-mode --boot
+
+[Install]
+WantedBy=multi-user.target

--- a/shared_files/aryaos/systemd/safe-mode.conf
+++ b/shared_files/aryaos/systemd/safe-mode.conf
@@ -1,0 +1,7 @@
+# AryaOS safe mode: do not start this sensor/SDR service while
+# /etc/aryaos/safe-mode exists. The box is in the brownout / crash-loop
+# fail-safe — USB peripherals are powered off and the box idles at minimal draw
+# so it boots cleanly and stays reachable. Cleared by `aryaos-safe-mode off`
+# (Cockpit -> AryaOS Site -> "Exit safe mode").
+[Unit]
+ConditionPathExists=!/etc/aryaos/safe-mode

--- a/stages/stage-aryaos/00-install/00-packages
+++ b/stages/stage-aryaos/00-install/00-packages
@@ -3,3 +3,4 @@ python3-systemd
 firewalld
 unattended-upgrades
 chrony
+uhubctl

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -154,6 +154,23 @@ for svc in comitup aryaos-bt-pan aryaos-bt-ready; do
 		"${ROOTFS_DIR}/etc/systemd/system/${svc}.service.d/emcon.conf"
 done
 
+## Fail-safe: brownout / crash-loop "safe mode". If the box reboots repeatedly
+## without staying up (weak PSU / PoE brown-out under load), it powers off USB
+## peripherals and withholds the sensor services so it boots clean and stays
+## reachable for an admin. Cockpit-driven exit; auto-latches via crash-guard.
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-safe-mode" "${ROOTFS_DIR}/usr/local/sbin/aryaos-safe-mode"
+install -v -d -m 0755 "${ROOTFS_DIR}/var/lib/aryaos"
+for unit in aryaos-crash-guard.service aryaos-safe-mode.service aryaos-boot-stable.service aryaos-boot-stable.timer; do
+	install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/${unit}" \
+		"${ROOTFS_DIR}/etc/systemd/system/${unit}"
+done
+# Safe-mode gate: sensor/SDR services must not start while /etc/aryaos/safe-mode
+# exists (kept in sync with aryaos-safe-mode MANAGED_UNITS / aryaos-role).
+for svc in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot; do
+	install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/safe-mode.conf" \
+		"${ROOTFS_DIR}/etc/systemd/system/${svc}.service.d/safe-mode.conf"
+done
+
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).
 install -v -m 0644 "${SHARED_FILES}/aryaos/zram-generator.conf" "${ROOTFS_DIR}/etc/systemd/zram-generator.conf"

--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -45,6 +45,10 @@ systemctl enable aryaos-tak-dp-importd.service
 systemctl enable aryaos-neighbord.service
 # EMCON: re-applies WiFi/Bluetooth rfkill at boot when /etc/aryaos/emcon is set.
 systemctl enable aryaos-radio-silence.service
+# Safe mode: crash-loop guard (early), USB-off applier (late), boot-stable timer.
+systemctl enable aryaos-crash-guard.service
+systemctl enable aryaos-safe-mode.service
+systemctl enable aryaos-boot-stable.timer
 
 getent group gpsd >/dev/null || groupadd --system gpsd
 systemctl enable gpsd


### PR DESCRIPTION
Field boxes are powered many ways (USB bricks, PoE HATs) and an under-spec supply browns the Pi 5 out under SDR + CPU load — confirmed this session: on a 5V/3A GaN charger the box brownout-looped in ~30s; on the official 27W (5V/5A) it ran a full-load burn-in clean (0 undervolt flags, 57°C). This adds a fail-safe so a marginal supply yields a *reachable* box instead of a crash loop.

## What lands
- **`aryaos-safe-mode` CLI** (mirrors `aryaos-radio`): `status｜on｜off [--reboot]｜check-boot｜boot-ok｜--boot`. Flag `/etc/aryaos/safe-mode`; crash counter `/var/lib/aryaos/boot-attempts`.
- **Detection**: `aryaos-crash-guard.service` (early boot) increments the counter; `aryaos-boot-stable.timer` (+180s) resets it once the box proves it can stay up. After **3** short boots → latch safe mode.
- **Safe mode actions**: power off USB peripherals (uhubctl, sysfs de-authorize fallback) + withhold sensor/SDR services via `ConditionPathExists=!/etc/aryaos/safe-mode` drop-ins. Ethernet/SSH/Cockpit stay up; **sticky** until an admin clears it.
- Adds `uhubctl`; verify-image asserts the subsystem + the (already-shipped) relaxed USB current cap.
- **Docs**: corrects the Pi 5 power spec (5V/5A, not 5V/3A), adds PoE (802.3at, not af) guidance, and a safe-mode section in `hardware.md` + `troubleshooting.md`.

Crash-counter logic validated on the Pi 5 (0/3 → 2/3 → reset). Cockpit banner + power-health warning ship in the paired `cockpit-aryaos` release; full latch→USB-off→restore path gets HIL-tested on the built image (uhubctl + drop-ins present).