### PR TITLE
feat(portal): field command-deck landing page (day/night, colorblind-safe)

### DIFF
--- a/shared_files/aryaos/html/css/styles.css
+++ b/shared_files/aryaos/html/css/styles.css
@@ -1,44 +1,114 @@
-/* AryaOS portal — restrained operations theme (UIKit overrides) */
+/* AryaOS portal — field command deck. Day/night (auto) + colorblind-safe status.
+ * Built for USFS-style outdoor use: big glove targets, high contrast, sunlight-
+ * legible day theme. Status never rides on color alone — every state also carries
+ * an icon + text label. Colorblind-safe hues are an Okabe-Ito-derived set
+ * (bluish-green / orange / vermillion), not red-vs-green. */
 
-.aos-theme-sigint {
-  --aos-bg0: #0b0f0e;
-  --aos-bg1: #111816;
-  --aos-panel: rgba(19, 27, 24, 0.94);
-  --aos-panel-border: rgba(126, 178, 151, 0.22);
-  --aos-text: #e0e7e3;
-  --aos-muted: #91a59b;
-  --aos-phosphor: #7edc9f;
-  --aos-phosphor-dim: #4c8d68;
-  --aos-amber: #d8aa4a;
-  --aos-magenta: #bd6c88;
-  --aos-danger: #dc5f67;
+:root {
   --aos-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Monaco, Consolas, monospace;
+  --aos-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  /* Colorblind-safe status aliases (resolve per-theme --aos-ok/warn/bad below). */
+  --aos-phosphor: var(--aos-ok);
+  --aos-phosphor-dim: var(--aos-ok);
+  --aos-amber: var(--aos-warn);
+  --aos-danger: var(--aos-bad);
 }
 
-.aos-page.aos-theme-sigint {
+/* ---- DAY (light, sunlight-legible) — the default first paint ---- */
+:root,
+:root[data-theme="day"] {
+  --aos-bg0: #e7ebeb;
+  --aos-bg1: #f4f6f6;
+  --aos-page-grad: linear-gradient(180deg, #f4f6f6 0%, #e7ebeb 60%, #dde3e2 100%);
+  --aos-panel: #ffffff;
+  --aos-panel-2: #eef2f1;
+  --aos-panel-border: rgba(16, 46, 39, 0.18);
+  --aos-text: #0d1a16;
+  --aos-muted: #47574f;
+  --aos-accent: #0a6b57;
+  --aos-accent-ink: #ffffff;
+  --aos-magenta: #9c3d78;
+  --aos-ok: #0b7a4f;
+  --aos-warn: #8f5400;
+  --aos-bad: #bf2a1a;
+  --aos-elev: 0 8px 22px rgba(6, 20, 16, 0.10);
+  --aos-scan: rgba(0, 0, 0, 0.28);
+  color-scheme: light;
+}
+
+/* ---- NIGHT (dark, low-glare) — auto when the device prefers dark ---- */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="day"]) {
+    --aos-bg0: #0b0f0e;
+    --aos-bg1: #111816;
+    --aos-page-grad:
+      radial-gradient(ellipse 120% 80% at 50% -20%, rgba(126, 220, 159, 0.06), transparent 55%),
+      linear-gradient(180deg, #111816 0%, #0b0f0e 48%, #080b0a 100%);
+    --aos-panel: #131b18;
+    --aos-panel-2: #172420;
+    --aos-panel-border: rgba(126, 178, 151, 0.24);
+    --aos-text: #e6ede9;
+    --aos-muted: #93a89e;
+    --aos-accent: #6ed4be;
+    --aos-accent-ink: #071211;
+    --aos-magenta: #cf8fae;
+    --aos-ok: #3ddc97;
+    --aos-warn: #f2a93b;
+    --aos-bad: #ff6f5e;
+    --aos-elev: 0 10px 30px rgba(0, 0, 0, 0.42);
+    --aos-scan: rgba(0, 0, 0, 0.35);
+    color-scheme: dark;
+  }
+}
+
+/* ---- NIGHT forced via the toggle ---- */
+:root[data-theme="night"] {
+  --aos-bg0: #0b0f0e;
+  --aos-bg1: #111816;
+  --aos-page-grad:
+    radial-gradient(ellipse 120% 80% at 50% -20%, rgba(126, 220, 159, 0.06), transparent 55%),
+    linear-gradient(180deg, #111816 0%, #0b0f0e 48%, #080b0a 100%);
+  --aos-panel: #131b18;
+  --aos-panel-2: #172420;
+  --aos-panel-border: rgba(126, 178, 151, 0.24);
+  --aos-text: #e6ede9;
+  --aos-muted: #93a89e;
+  --aos-accent: #6ed4be;
+  --aos-accent-ink: #071211;
+  --aos-magenta: #cf8fae;
+  --aos-ok: #3ddc97;
+  --aos-warn: #f2a93b;
+  --aos-bad: #ff6f5e;
+  --aos-elev: 0 10px 30px rgba(0, 0, 0, 0.42);
+  --aos-scan: rgba(0, 0, 0, 0.35);
+  color-scheme: dark;
+}
+
+.aos-page {
   min-height: 100vh;
+  margin: 0;
   color: var(--aos-text);
   background-color: var(--aos-bg0);
-  background-image:
-    radial-gradient(ellipse 120% 80% at 50% -20%, rgba(126, 220, 159, 0.055), transparent 55%),
-    linear-gradient(180deg, var(--aos-bg1) 0%, var(--aos-bg0) 48%, #080b0a 100%);
+  background-image: var(--aos-page-grad);
+  background-attachment: fixed;
   position: relative;
+  font-family: var(--aos-sans);
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .aos-page.aos-theme-sigint::after {
+  .aos-page::after {
     content: "";
     pointer-events: none;
     position: fixed;
     inset: 0;
     z-index: 9999;
-    opacity: 0.018;
+    opacity: 0.02;
     background: repeating-linear-gradient(
       0deg,
       transparent,
       transparent 2px,
-      rgba(0, 0, 0, 0.35) 2px,
-      rgba(0, 0, 0, 0.35) 3px
+      var(--aos-scan) 2px,
+      var(--aos-scan) 3px
     );
   }
 }
@@ -817,4 +887,297 @@
   padding: 4px;
   border-radius: 6px;
   flex: 0 0 auto;
+}
+
+/* ============================================================================
+ * Command deck — field-first landing (big targets, day/night, colorblind-safe)
+ * ==========================================================================*/
+
+* { box-sizing: border-box; }
+
+/* --- App bar --- */
+.aos-appbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem clamp(0.9rem, 3vw, 1.6rem);
+  background: color-mix(in srgb, var(--aos-panel) 92%, transparent);
+  border-bottom: 2px solid var(--aos-panel-border);
+  backdrop-filter: blur(6px);
+}
+.aos-appbar-brand { display: flex; align-items: baseline; gap: 0.5rem; min-width: 0; }
+.aos-appbar-logo { color: var(--aos-accent); font-size: 1.15rem; }
+.aos-appbar-name {
+  font-family: var(--aos-mono);
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  font-size: 1.05rem;
+  color: var(--aos-text);
+}
+.aos-appbar-host {
+  font-family: var(--aos-mono);
+  color: var(--aos-muted);
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aos-appbar-right { display: flex; align-items: center; gap: 0.6rem; flex: none; }
+.aos-online {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--aos-mono);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--aos-ok);
+}
+.aos-online-dot {
+  width: 0.6rem; height: 0.6rem; border-radius: 50%;
+  background: var(--aos-ok);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--aos-ok) 24%, transparent);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .aos-online-dot { animation: aos-blink 1.6s ease-in-out infinite; }
+}
+@keyframes aos-blink { 0%,100%{opacity:1;} 50%{opacity:0.35;} }
+.aos-online--off { color: var(--aos-bad); }
+.aos-online--off .aos-online-dot { background: var(--aos-bad); box-shadow: 0 0 0 3px color-mix(in srgb, var(--aos-bad) 24%, transparent); animation: none; }
+
+/* Day/night toggle — a real glove target */
+.aos-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2.75rem;
+  padding: 0 0.9rem;
+  border: 2px solid var(--aos-panel-border);
+  border-radius: 8px;
+  background: var(--aos-panel-2);
+  color: var(--aos-text);
+  font-family: var(--aos-mono);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.aos-theme-toggle:hover { border-color: var(--aos-accent); }
+.aos-theme-ico { font-size: 1.1rem; color: var(--aos-accent); }
+
+/* --- Deck container --- */
+.aos-deck {
+  width: min(100%, 68rem);
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 1.75rem) clamp(0.9rem, 3vw, 1.6rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.9rem, 2.2vw, 1.4rem);
+}
+
+/* --- Big status pills --- */
+.aos-statusrow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.8rem;
+}
+.aos-stat {
+  --sc: var(--aos-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-height: 4.25rem;
+  padding: 0.7rem 0.9rem;
+  background: var(--aos-panel);
+  border: 1px solid var(--aos-panel-border);
+  border-left: 7px solid var(--sc);
+  border-radius: 10px;
+  box-shadow: var(--aos-elev);
+}
+.aos-stat-ico { font-size: 1.5rem; color: var(--sc); line-height: 1; }
+.aos-stat-body { display: flex; flex-direction: column; min-width: 0; }
+.aos-stat-k { font-family: var(--aos-mono); font-size: 0.7rem; letter-spacing: 0.12em; color: var(--aos-muted); }
+.aos-stat-v { font-size: 1.15rem; font-weight: 800; color: var(--sc); line-height: 1.15; overflow-wrap: anywhere; }
+.aos-stat--ok { --sc: var(--aos-ok); }
+.aos-stat--warn { --sc: var(--aos-warn); }
+.aos-stat--bad { --sc: var(--aos-bad); }
+.aos-stat--pending { --sc: var(--aos-muted); }
+
+/* --- Banners --- */
+.aos-banner {
+  padding: 0.75rem 0.9rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid var(--aos-bad);
+  background: color-mix(in srgb, var(--aos-bad) 14%, var(--aos-panel));
+  color: var(--aos-text);
+}
+.aos-banner--warn { border-color: var(--aos-warn); background: color-mix(in srgb, var(--aos-warn) 15%, var(--aos-panel)); }
+.aos-banner[hidden] { display: none; }
+
+/* --- Big action tiles --- */
+.aos-tiles {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.8rem;
+}
+.aos-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 8rem;
+  padding: 1.1rem 1rem;
+  background: var(--aos-panel);
+  border: 2px solid var(--aos-panel-border);
+  border-radius: 12px;
+  box-shadow: var(--aos-elev);
+  color: var(--aos-text);
+  text-decoration: none;
+  transition: transform 0.08s ease, border-color 0.12s ease;
+}
+.aos-tile:hover, .aos-tile:focus-visible {
+  border-color: var(--aos-accent);
+  transform: translateY(-2px);
+  outline: none;
+}
+.aos-tile--primary {
+  background: linear-gradient(160deg, color-mix(in srgb, var(--aos-accent) 22%, var(--aos-panel)), var(--aos-panel));
+  border-color: var(--aos-accent);
+}
+.aos-tile-ico { font-size: 2rem; line-height: 1; color: var(--aos-accent); }
+.aos-tile-title { font-size: 1.15rem; font-weight: 800; letter-spacing: 0.01em; }
+.aos-tile-sub { font-size: 0.82rem; color: var(--aos-muted); }
+
+/* --- TAK gateway chips (colorblind-safe: color + glyph + label) --- */
+.aos-takrow { display: flex; flex-direction: column; gap: 0.5rem; }
+.aos-tak-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+}
+.aos-tak-chip {
+  --sc: var(--aos-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2.5rem;
+  padding: 0 0.8rem;
+  border: 2px solid var(--sc);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sc) 12%, var(--aos-panel));
+  font-family: var(--aos-mono);
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--aos-text);
+}
+.aos-tak-chip-label { letter-spacing: 0.04em; }
+.aos-tak-dot {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.15rem; height: 1.15rem; border-radius: 50%;
+  background: var(--sc); color: var(--aos-panel);
+  font-size: 0.8rem; font-weight: 900;
+}
+.aos-tak--up { --sc: var(--aos-ok); }
+.aos-tak--down { --sc: var(--aos-bad); }
+.aos-tak--degraded { --sc: var(--aos-warn); }
+.aos-tak--pending, .aos-tak--absent, .aos-tak--disabled, .aos-tak--unavailable { --sc: var(--aos-muted); }
+.aos-tak--up .aos-tak-dot::before { content: "\2713"; }
+.aos-tak--down .aos-tak-dot::before { content: "\2717"; }
+.aos-tak--degraded .aos-tak-dot::before { content: "\0021"; }
+.aos-tak--pending .aos-tak-dot::before,
+.aos-tak--absent .aos-tak-dot::before,
+.aos-tak--disabled .aos-tak-dot::before,
+.aos-tak--unavailable .aos-tak-dot::before { content: "\2026"; }
+.aos-tak-hint { color: var(--aos-muted); font-size: 0.8rem; }
+.aos-tak-hint a { color: var(--aos-accent); }
+
+/* --- Small status pill (GNSS) — colorblind glyph prefix --- */
+.aos-pill {
+  display: inline-flex; align-items: center;
+  padding: 0.15rem 0.55rem; border-radius: 999px;
+  font-family: var(--aos-mono); font-size: 0.75rem; font-weight: 700;
+  border: 1px solid var(--aos-muted); color: var(--aos-text);
+  background: color-mix(in srgb, var(--aos-muted) 14%, var(--aos-panel));
+}
+.aos-pill--ok { border-color: var(--aos-ok); background: color-mix(in srgb, var(--aos-ok) 16%, var(--aos-panel)); }
+.aos-pill--warn { border-color: var(--aos-warn); background: color-mix(in srgb, var(--aos-warn) 16%, var(--aos-panel)); }
+.aos-pill--bad { border-color: var(--aos-bad); background: color-mix(in srgb, var(--aos-bad) 16%, var(--aos-panel)); }
+.aos-pill--ok::before { content: "\2713\00a0"; color: var(--aos-ok); font-weight: 900; }
+.aos-pill--warn::before { content: "\0021\00a0"; color: var(--aos-warn); font-weight: 900; }
+.aos-pill--bad::before { content: "\2717\00a0"; color: var(--aos-bad); font-weight: 900; }
+.aos-pill--pending::before { content: "\2026\00a0"; color: var(--aos-muted); }
+
+/* --- Collapsible telemetry drawers --- */
+.aos-drawer {
+  background: var(--aos-panel);
+  border: 1px solid var(--aos-panel-border);
+  border-radius: 10px;
+  box-shadow: var(--aos-elev);
+  overflow: hidden;
+}
+.aos-drawer-sum {
+  display: flex; align-items: center; gap: 0.6rem;
+  min-height: 3.25rem;
+  padding: 0 1rem;
+  cursor: pointer;
+  font-weight: 800;
+  font-size: 1.05rem;
+  list-style: none;
+  color: var(--aos-text);
+}
+.aos-drawer-sum::-webkit-details-marker { display: none; }
+.aos-drawer-sum::before {
+  content: "\203A";
+  font-size: 1.3rem; color: var(--aos-accent);
+  transition: transform 0.12s ease;
+  transform: rotate(0deg);
+}
+.aos-drawer[open] > .aos-drawer-sum::before { transform: rotate(90deg); }
+.aos-drawer-hint { font-weight: 500; font-size: 0.82rem; color: var(--aos-muted); margin-left: auto; }
+.aos-drawer-body { padding: 0 1rem 1rem; }
+.aos-drawer-note { color: var(--aos-muted); font-size: 0.9rem; }
+
+/* --- Footer / legal --- */
+.aos-foot {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+  margin-top: 0.6rem;
+  padding: 1.2rem;
+  background: var(--aos-panel);
+  border: 1px solid var(--aos-panel-border);
+  border-radius: 10px;
+}
+.aos-foot-h { font-size: 1rem; margin: 0 0 0.4rem; }
+.aos-foot p { color: var(--aos-muted); font-size: 0.88rem; margin: 0 0 0.6rem; }
+.aos-foot a { color: var(--aos-accent); }
+.aos-foot-list { list-style: none; padding: 0; margin: 0; font-size: 0.9rem; line-height: 1.9; }
+.aos-docs-qr { display: flex; align-items: center; gap: 0.6rem; color: var(--aos-muted); font-size: 0.8rem; }
+.aos-docs-qr img { background: #fff; padding: 4px; border-radius: 6px; }
+.aos-legal { text-align: center; color: var(--aos-muted); font-size: 0.78rem; margin: 0.4rem 0 0; }
+.aos-legal a { color: var(--aos-accent); }
+
+/* --- Telemetry internals adapt to theme (override UIKit) --- */
+.aos-drawer-body .uk-description-list dt { color: var(--aos-text); }
+.aos-drawer-body .uk-table { color: var(--aos-text); }
+.aos-drawer-body .uk-table th { color: var(--aos-muted); }
+
+/* --- Responsive --- */
+@media (max-width: 900px) {
+  .aos-tiles { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 560px) {
+  .aos-statusrow { grid-template-columns: 1fr; }
+  .aos-tiles { grid-template-columns: 1fr; }
+  .aos-appbar-host { display: none; }
+  .aos-drawer-hint { display: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .aos-online-dot { animation: none; }
+  .aos-tile { transition: none; }
 }

--- a/shared_files/aryaos/html/index.html
+++ b/shared_files/aryaos/html/index.html
@@ -22,442 +22,266 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="AryaOS situational awareness appliance — status, RF links, and local GNSS.">
+    <meta name="theme-color" content="#0b0f0e" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#eef1ef" media="(prefers-color-scheme: light)">
     <link rel="stylesheet" href="css/uikit.min.css"/>
     <link href="css/styles.css" rel="stylesheet">
+    <script>
+      /* Set the theme before first paint to avoid a flash. */
+      (function () {
+        try {
+          var t = localStorage.getItem("aos-theme");
+          if (t === "day" || t === "night") document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {}
+      })();
+    </script>
   </head>
 
-  <body class="aos-page aos-theme-sigint">
-    <div class="aos-topstrip" aria-hidden="true">
-      <span class="aos-topstrip-label">ARYAOS</span>
-      <span class="aos-topstrip-sep">//</span>
-      <span>NET</span>
-      <span class="aos-topstrip-sep">·</span>
-      <span>RF</span>
-      <span class="aos-topstrip-sep">·</span>
-      <span>GNSS</span>
-      <span class="aos-topstrip-rx" title="Portal session">RX</span>
-    </div>
-    <div class="uk-section uk-section-small aos-hero">
-      <div class="uk-container uk-container-small uk-text-center">
-        <div class="aos-hero-badge"><span class="aos-hero-badge-dot" aria-hidden="true"></span> LINK ESTABLISHED</div>
-        <div id="aos-tak-gateway-strip" class="aos-tak-strip" aria-label="TAK gateway services">
-          <div id="aos-tak-error" class="uk-alert-danger aos-tak-strip-alert uk-hidden" uk-alert></div>
-          <div class="aos-tak-chips" role="list">
-            <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-adsbcot" title="adsbcot">
-              <span class="aos-tak-dot" aria-hidden="true"></span>
-              <span class="aos-tak-chip-label">ADS-B</span>
-            </div>
-            <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-aiscot" title="aiscot">
-              <span class="aos-tak-dot" aria-hidden="true"></span>
-              <span class="aos-tak-chip-label">AIS</span>
-            </div>
-            <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-dronecot" title="dronecot">
-              <span class="aos-tak-dot" aria-hidden="true"></span>
-              <span class="aos-tak-chip-label">UAS</span>
-            </div>
-            <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-sikw00fcot" title="sikw00fcot">
-              <span class="aos-tak-dot" aria-hidden="true"></span>
-              <span class="aos-tak-chip-label">SiK</span>
-            </div>
-          </div>
-          <p class="uk-text-meta aos-tak-hint">
-            All green = TAK gateways running. Open <a class="uk-link-text" href="/admin/">Cockpit</a> if any indicator is not green.
-          </p>
-        </div>
-        <div id="aos-system-strip" class="aos-system-strip" aria-label="System health">
-          <span class="aos-system-metric">
-            <span class="aos-system-label">CPU</span>
-            <span id="aos-sys-temp" class="aos-system-value">…</span>
-          </span>
-          <span class="aos-system-metric">
-            <span class="aos-system-label">Load</span>
-            <span id="aos-sys-load" class="aos-system-value">…</span>
-          </span>
-          <span class="aos-system-metric">
-            <span class="aos-system-label">Power</span>
-            <span id="aos-sys-power-pill" class="aos-pill aos-pill--pending">…</span>
-          </span>
-        </div>
-        <h1 class="uk-heading-small uk-margin-remove-bottom aos-hero-title">AryaOS</h1>
-        <p class="uk-text-lead uk-margin-small-top uk-margin-remove-bottom aos-hero-lead">
-          Local situational awareness stack — admin, telemetry, and spectrum-adjacent tooling on the edge.
-        </p>
-        <p class="uk-text-meta uk-margin-top aos-hero-meta">
-          Secure channel: this portal is served over <strong>HTTPS</strong>. Cleartext HTTP shows a port 443 notice.
-        </p>
+  <body class="aos-page">
+    <!-- App bar: brand · host · online · day/night toggle -->
+    <header class="aos-appbar">
+      <div class="aos-appbar-brand">
+        <span class="aos-appbar-logo" aria-hidden="true">◆</span>
+        <span class="aos-appbar-name">ARYAOS</span>
+        <span class="aos-appbar-host" id="aos-appbar-host" title="This unit">…</span>
       </div>
-    </div>
+      <div class="aos-appbar-right">
+        <span class="aos-online" id="aos-online" title="Portal reachable">
+          <span class="aos-online-dot" aria-hidden="true"></span> ONLINE
+        </span>
+        <button type="button" class="aos-theme-toggle" id="aos-theme-toggle"
+                aria-label="Switch day / night theme" title="Day / night">
+          <span class="aos-theme-ico" aria-hidden="true">◐</span>
+          <span class="aos-theme-txt" id="aos-theme-txt">Auto</span>
+        </button>
+      </div>
+    </header>
 
-    <div class="uk-section uk-section-small">
-      <div class="uk-container">
-        <div class="uk-grid-large uk-child-width-1-1 uk-child-width-1-3@m" uk-grid>
-          <div>
-            <div class="uk-card uk-card-default uk-card-body uk-card-small">
-              <h2 class="uk-card-title">Get started</h2>
-              <p class="uk-text-meta uk-margin-remove-top">
-                System administration uses Cockpit over TLS on this host.
-              </p>
-              <div class="uk-margin aos-card-actions">
-                <a class="uk-button uk-button-primary uk-button-large" href="/admin/">
-                  <svg class="aos-icon-cog" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <circle cx="12" cy="12" r="3"/>
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
-                  </svg>
-                  Open Cockpit (admin)
-                </a>
-              </div>
-              <hr class="uk-divider-small">
-              <h3 class="uk-heading-small">TAK connection</h3>
-              <p class="uk-text-small uk-margin-small">
-                TAK Server enrollment URLs and connection data packages are applied from Cockpit so configuration changes require an administrator login.
-              </p>
-              <a class="uk-button uk-button-default" href="/admin/aryaos">
-                Configure TAK in Cockpit
-              </a>
-              <hr class="uk-divider-small">
-              <h3 class="uk-heading-small">Documentation</h3>
-              <p class="uk-text-small uk-margin-small">
-                The full AryaOS documentation is bundled on this device and works offline — no internet needed.
-              </p>
-              <div class="uk-margin aos-card-actions">
-                <a class="uk-button uk-button-default" href="/docs/">Open docs on this device</a>
-                <a class="uk-button uk-button-text" href="https://www.aryaos.org/" target="_blank" rel="noopener noreferrer">aryaos.org &#8599;</a>
-              </div>
-              <div class="aos-docs-qr">
-                <img src="img/aryaos-docs-qr.svg" alt="QR code for https://www.aryaos.org" width="104" height="104" loading="lazy">
-                <span class="uk-text-meta">Scan for the online docs</span>
-              </div>
-            </div>
+    <main class="aos-deck">
+      <!-- Big colorblind-safe status pills -->
+      <section class="aos-statusrow" aria-label="System status">
+        <div class="aos-stat aos-stat--pending" id="aos-hero-gps">
+          <span class="aos-stat-ico" aria-hidden="true">&#128752;</span>
+          <span class="aos-stat-body"><span class="aos-stat-k">GPS</span><span class="aos-stat-v" id="aos-hero-gps-v">…</span></span>
+        </div>
+        <div class="aos-stat aos-stat--pending" id="aos-hero-power">
+          <span class="aos-stat-ico" aria-hidden="true">&#9889;</span>
+          <span class="aos-stat-body"><span class="aos-stat-k">POWER</span><span class="aos-stat-v" id="aos-hero-power-v">…</span></span>
+        </div>
+        <div class="aos-stat aos-stat--pending" id="aos-hero-sensors">
+          <span class="aos-stat-ico" aria-hidden="true">&#128225;</span>
+          <span class="aos-stat-body"><span class="aos-stat-k">SENSORS</span><span class="aos-stat-v" id="aos-hero-sensors-v">…</span></span>
+        </div>
+      </section>
+
+      <div id="aos-status-error" class="aos-banner aos-banner--bad uk-hidden" role="alert"></div>
+
+      <!-- Big action tiles -->
+      <nav class="aos-tiles" aria-label="Primary actions">
+        <a class="aos-tile aos-tile--primary" href="/admin/">
+          <span class="aos-tile-ico" aria-hidden="true">&#9881;</span>
+          <span class="aos-tile-title">Admin Console</span>
+          <span class="aos-tile-sub">Cockpit &mdash; configure &amp; manage</span>
+        </a>
+        <a class="aos-tile" href="/admin/gps">
+          <span class="aos-tile-ico" aria-hidden="true">&#128506;</span>
+          <span class="aos-tile-title">Map &amp; Data</span>
+          <span class="aos-tile-sub">Live position &amp; sensors</span>
+        </a>
+        <a class="aos-tile" href="/docs/">
+          <span class="aos-tile-ico" aria-hidden="true">&#128214;</span>
+          <span class="aos-tile-title">Docs</span>
+          <span class="aos-tile-sub">On-device &mdash; works offline</span>
+        </a>
+        <a class="aos-tile" href="/docs/troubleshooting/">
+          <span class="aos-tile-ico" aria-hidden="true">&#128735;</span>
+          <span class="aos-tile-title">Support</span>
+          <span class="aos-tile-sub">Troubleshooting &amp; help</span>
+        </a>
+      </nav>
+
+      <!-- TAK gateway chips -->
+      <section class="aos-takrow" aria-label="TAK gateway services">
+        <div id="aos-tak-error" class="aos-banner aos-banner--bad uk-hidden" role="alert"></div>
+        <div class="aos-tak-chips" role="list">
+          <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-adsbcot" title="adsbcot">
+            <span class="aos-tak-dot" aria-hidden="true"></span>
+            <span class="aos-tak-chip-label">ADS-B</span>
           </div>
-
-          <div>
-            <div class="uk-card uk-card-default uk-card-body uk-card-small">
-              <h2 class="uk-card-title">Connection &amp; status</h2>
-              <p class="uk-text-meta uk-margin-remove-top">
-                Machine facts from this host (served as JSON, not via Node-RED).
-              </p>
-
-              <div id="aos-status-error" class="uk-alert-danger uk-hidden" uk-alert></div>
-
-              <dl class="uk-description-list aos-status-dl">
-                <div class="aos-status-group aos-status-group--meta">
-                  <dt class="uk-text-bold">Hostname</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-hostname" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-hostname" aria-label="Copy hostname" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--meta">
-                  <dt class="uk-text-bold">FQDN</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-fqdn" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-fqdn" aria-label="Copy FQDN" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--net">
-                  <dt class="uk-text-bold">Primary IP <span class="uk-text-muted">(routing)</span></dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <code id="aos-primary-ip" class="aos-mono-inline aos-copy-value">…</code>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-primary-ip" aria-label="Copy primary IP" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--net">
-                  <dt class="uk-text-bold">IPv4 interfaces</dt>
-                  <dd>
-                    <div class="aos-copy-wrap aos-copy-wrap-block">
-                      <pre class="aos-mono aos-copy-value" id="aos-ipv4-block">…</pre>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-ipv4-block" aria-label="Copy IPv4 listing" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--meta">
-                  <dt class="uk-text-bold">Uptime</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-uptime" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-uptime" aria-label="Copy uptime" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--meta">
-                  <dt class="uk-text-bold">Your browser used</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <code id="aos-browser-host" class="aos-mono-inline aos-copy-value">—</code>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-browser-host" aria-label="Copy browser hostname" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-              </dl>
-            </div>
+          <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-aiscot" title="aiscot">
+            <span class="aos-tak-dot" aria-hidden="true"></span>
+            <span class="aos-tak-chip-label">AIS</span>
           </div>
+          <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-dronecot" title="dronecot">
+            <span class="aos-tak-dot" aria-hidden="true"></span>
+            <span class="aos-tak-chip-label">UAS</span>
+          </div>
+          <div class="aos-tak-chip aos-tak--pending" role="listitem" id="aos-tak-chip-sikw00fcot" title="sikw00fcot">
+            <span class="aos-tak-dot" aria-hidden="true"></span>
+            <span class="aos-tak-chip-label">SiK</span>
+          </div>
+          <span class="aos-tak-hint">All green = TAK gateways up. Open <a href="/admin/">Admin</a> if any is not.</span>
+        </div>
+      </section>
 
-          <div>
-            <div class="uk-card uk-card-default uk-card-body uk-card-small aos-gps-card">
-              <h2 class="uk-card-title">GNSS <span class="uk-text-meta">(gpsd)</span></h2>
-              <p class="uk-text-meta uk-margin-remove-top">
-                Live snapshot from the local gpsd socket. USB receivers often appear as <code>/dev/ttyUSB0</code> or <code>/dev/ttyACM0</code>.
-              </p>
-              <div id="aos-gps-error" class="uk-alert-warning uk-hidden aos-gps-alert" uk-alert></div>
-              <dl class="uk-description-list uk-text-small aos-status-dl">
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Status</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <div class="aos-copy-value-row">
-                        <span id="aos-gps-status-pill" class="aos-pill aos-pill--pending" title=""></span>
-                        <span id="aos-gps-status" class="aos-copy-value">…</span>
-                      </div>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-status" aria-label="Copy GNSS status" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Fix</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-fix" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-fix" aria-label="Copy fix type" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Position</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <code id="aos-gps-pos" class="aos-mono-inline aos-copy-value">—</code>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-pos" aria-label="Copy position" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Altitude (MSL)</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-alt-msl" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-alt-msl" aria-label="Copy altitude MSL" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Altitude (HAE)</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-alt-hae" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-alt-hae" aria-label="Copy altitude HAE" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Accuracy (CE / LE) <span class="uk-text-meta">(m — gpsd eph / epv, or CE from √(epx²+epy²) if eph absent)</span></dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-ce-le" class="aos-copy-value aos-mono-inline">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-ce-le" aria-label="Copy CE and LE" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Maidenhead grid</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-grid" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-grid" aria-label="Copy grid" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Satellites</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-sats" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-sats" aria-label="Copy satellite counts" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Fix time (UTC)</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-time" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-time" aria-label="Copy fix time" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">Track / speed / climb</dt>
-                  <dd>
-                    <div class="aos-copy-wrap">
-                      <span id="aos-gps-motion" class="aos-copy-value">…</span>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-motion" aria-label="Copy track speed climb" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-                <div class="aos-status-group aos-status-group--gps">
-                  <dt class="uk-text-bold">gpsd / errors</dt>
-                  <dd>
-                    <div class="aos-copy-wrap aos-copy-wrap-block">
-                      <pre class="aos-mono aos-mono-tiny aos-copy-value" id="aos-gps-errdetail">—</pre>
-                      <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-errdetail" aria-label="Copy gpsd detail" title="Copy">
-                        <svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      </button>
-                    </div>
-                  </dd>
-                </div>
-              </dl>
+      <!-- Collapsible telemetry drawers -->
+      <details class="aos-drawer">
+        <summary class="aos-drawer-sum">Connection <span class="aos-drawer-hint">host · IP · uptime</span></summary>
+        <div class="aos-drawer-body">
+          <dl class="uk-description-list aos-status-dl">
+            <div class="aos-status-group aos-status-group--meta">
+              <dt class="uk-text-bold">Hostname</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-hostname" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-hostname" aria-label="Copy hostname" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
             </div>
+            <div class="aos-status-group aos-status-group--meta">
+              <dt class="uk-text-bold">FQDN</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-fqdn" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-fqdn" aria-label="Copy FQDN" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--net">
+              <dt class="uk-text-bold">Primary IP <span class="uk-text-muted">(routing)</span></dt>
+              <dd><div class="aos-copy-wrap"><code id="aos-primary-ip" class="aos-mono-inline aos-copy-value">…</code>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-primary-ip" aria-label="Copy primary IP" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--net">
+              <dt class="uk-text-bold">IPv4 interfaces</dt>
+              <dd><div class="aos-copy-wrap aos-copy-wrap-block"><pre class="aos-mono aos-copy-value" id="aos-ipv4-block">…</pre>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-ipv4-block" aria-label="Copy IPv4 listing" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--meta">
+              <dt class="uk-text-bold">Uptime</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-uptime" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-uptime" aria-label="Copy uptime" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--meta">
+              <dt class="uk-text-bold">Your browser used</dt>
+              <dd><div class="aos-copy-wrap"><code id="aos-browser-host" class="aos-mono-inline aos-copy-value">—</code>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-browser-host" aria-label="Copy browser hostname" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+          </dl>
+        </div>
+      </details>
+
+      <details class="aos-drawer">
+        <summary class="aos-drawer-sum">GNSS <span class="aos-drawer-hint">position · fix · satellites</span></summary>
+        <div class="aos-drawer-body">
+          <div id="aos-gps-error" class="aos-banner aos-banner--warn uk-hidden" role="alert"></div>
+          <dl class="uk-description-list uk-text-small aos-status-dl">
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Status</dt>
+              <dd><div class="aos-copy-wrap"><div class="aos-copy-value-row"><span id="aos-gps-status-pill" class="aos-pill aos-pill--pending" title=""></span><span id="aos-gps-status" class="aos-copy-value">…</span></div>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-status" aria-label="Copy GNSS status" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Fix</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-fix" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-fix" aria-label="Copy fix type" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Position</dt>
+              <dd><div class="aos-copy-wrap"><code id="aos-gps-pos" class="aos-mono-inline aos-copy-value">—</code>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-pos" aria-label="Copy position" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Altitude (MSL)</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-alt-msl" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-alt-msl" aria-label="Copy altitude MSL" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Altitude (HAE)</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-alt-hae" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-alt-hae" aria-label="Copy altitude HAE" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Accuracy (CE / LE) <span class="uk-text-meta">(m)</span></dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-ce-le" class="aos-copy-value aos-mono-inline">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-ce-le" aria-label="Copy CE and LE" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Maidenhead grid</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-grid" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-grid" aria-label="Copy grid" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Satellites</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-sats" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-sats" aria-label="Copy satellite counts" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Fix time (UTC)</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-time" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-time" aria-label="Copy fix time" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">Track / speed / climb</dt>
+              <dd><div class="aos-copy-wrap"><span id="aos-gps-motion" class="aos-copy-value">…</span>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-motion" aria-label="Copy track speed climb" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+            <div class="aos-status-group aos-status-group--gps">
+              <dt class="uk-text-bold">gpsd / errors</dt>
+              <dd><div class="aos-copy-wrap aos-copy-wrap-block"><pre class="aos-mono aos-mono-tiny aos-copy-value" id="aos-gps-errdetail">—</pre>
+                <button type="button" class="aos-copy-btn" data-copy-for="aos-gps-errdetail" aria-label="Copy gpsd detail" title="Copy"><svg class="aos-copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div></dd>
+            </div>
+          </dl>
+        </div>
+      </details>
+
+      <details class="aos-drawer">
+        <summary class="aos-drawer-sum">Nearby AryaOS nodes <span class="aos-drawer-hint">CoT mesh neighbors</span></summary>
+        <div class="aos-drawer-body">
+          <div id="aos-neighbors-error" class="aos-banner aos-banner--warn uk-hidden" role="alert"></div>
+          <p id="aos-neighbors-empty" class="aos-drawer-note" role="status">Listening for AryaOS CoT beacons…</p>
+          <div class="uk-overflow-auto">
+            <table class="uk-table uk-table-small uk-table-divider uk-table-middle aos-neighbor-table uk-hidden" id="aos-neighbor-table" aria-label="Nearby AryaOS nodes">
+              <thead><tr><th scope="col">Node</th><th scope="col">Roles</th><th scope="col">Health</th><th scope="col">Position</th><th scope="col">Seen</th><th scope="col">Admin</th></tr></thead>
+              <tbody id="aos-neighbors-tbody"></tbody>
+            </table>
           </div>
         </div>
-      </div>
-    </div>
+      </details>
 
-    <div class="uk-section uk-section-small uk-padding-remove-top">
-      <div class="uk-container">
-        <div class="uk-width-1-1">
-          <div class="uk-card uk-card-default uk-card-body uk-card-small aos-neighbor-card">
-            <h2 class="uk-card-title">Nearby AryaOS nodes</h2>
-            <p class="uk-text-meta uk-margin-remove-top">
-              AryaOS host beacons heard on the CoT mesh. Admin links open the remote node's Cockpit page.
-            </p>
-            <div id="aos-neighbors-error" class="uk-alert-warning uk-hidden aos-neighbor-alert" uk-alert></div>
-            <p id="aos-neighbors-empty" class="uk-text-meta aos-neighbor-empty" role="status">Listening for AryaOS CoT beacons…</p>
-            <div class="uk-overflow-auto">
-              <table class="uk-table uk-table-small uk-table-divider uk-table-middle aos-neighbor-table uk-hidden" id="aos-neighbor-table" aria-label="Nearby AryaOS nodes">
-                <thead>
-                  <tr>
-                    <th scope="col">Node</th>
-                    <th scope="col">Roles</th>
-                    <th scope="col">Health</th>
-                    <th scope="col">Position</th>
-                    <th scope="col">Seen</th>
-                    <th scope="col">Admin</th>
-                  </tr>
-                </thead>
-                <tbody id="aos-neighbors-tbody"></tbody>
-              </table>
-            </div>
+      <details class="aos-drawer">
+        <summary class="aos-drawer-sum">Radios / RF <span class="aos-drawer-hint">Wi-Fi · BT · SDR</span></summary>
+        <div class="aos-drawer-body">
+          <div id="aos-radios-error" class="aos-banner aos-banner--bad uk-hidden" role="alert"></div>
+          <p id="aos-radios-empty" class="aos-drawer-note uk-hidden" role="status"></p>
+          <div class="uk-overflow-auto">
+            <table class="uk-table uk-table-small uk-table-divider uk-table-middle aos-rf-table uk-hidden" id="aos-rf-table" aria-label="Radio and RF devices">
+              <thead><tr><th scope="col">Type</th><th scope="col">Device</th><th scope="col">State</th><th scope="col">Notes</th><th scope="col" class="aos-rf-col-src">Src</th></tr></thead>
+              <tbody id="aos-radios-tbody"></tbody>
+            </table>
           </div>
         </div>
-      </div>
-    </div>
+      </details>
 
-    <div class="uk-section uk-section-small uk-padding-remove-top">
-      <div class="uk-container">
-        <div class="uk-width-1-1">
-          <div class="uk-card uk-card-default uk-card-body uk-card-small aos-rf-card">
-            <h2 class="uk-card-title">Radios / RF</h2>
-            <p class="uk-text-meta uk-margin-remove-top">
-              Host-detected WLAN, Bluetooth, USB SDR-class devices (sysfs / lsusb), and common decoder services. Devices without a driver or blocked USB visibility may not appear.
-            </p>
-            <div id="aos-radios-error" class="uk-alert-danger uk-hidden aos-rf-alert" uk-alert></div>
-            <p id="aos-radios-empty" class="uk-text-meta aos-rf-empty uk-hidden" role="status"></p>
-            <div class="uk-overflow-auto">
-              <table class="uk-table uk-table-small uk-table-divider uk-table-middle aos-rf-table uk-hidden" id="aos-rf-table" aria-label="Radio and RF devices">
-                <thead>
-                  <tr>
-                    <th scope="col">Type</th>
-                    <th scope="col">Device</th>
-                    <th scope="col">State</th>
-                    <th scope="col">Notes</th>
-                    <th scope="col" class="aos-rf-col-src">Src</th>
-                  </tr>
-                </thead>
-                <tbody id="aos-radios-tbody"></tbody>
-              </table>
-            </div>
+      <!-- Footer: docs QR + support -->
+      <footer class="aos-foot">
+        <div class="aos-foot-col">
+          <h2 class="aos-foot-h">Documentation</h2>
+          <p>Bundled on this device and works offline. Full guides also on <a href="https://aryaos.rtfd.io/en/stable/" target="_blank" rel="noopener noreferrer">Read the Docs</a>.</p>
+          <div class="aos-docs-qr">
+            <img src="img/aryaos-docs-qr.svg" alt="QR code for https://www.aryaos.org" width="96" height="96" loading="lazy">
+            <span>Scan for online docs</span>
           </div>
         </div>
-      </div>
-    </div>
-
-    <div class="uk-section uk-section-small uk-section-muted">
-      <div class="uk-container">
-        <div class="uk-grid-match uk-child-width-1-1 uk-child-width-1-2@m" uk-grid>
-          <div>
-            <div class="uk-card uk-card-default uk-card-body uk-card-small">
-              <h2 class="uk-card-title">Documentation</h2>
-              <p>
-                Product guides and reference material live on Read the Docs.
-              </p>
-              <a class="uk-button uk-button-primary" href="https://aryaos.rtfd.io/en/stable/" target="_blank" rel="noopener noreferrer">
-                AryaOS documentation
-              </a>
-            </div>
-          </div>
-          <div>
-            <div class="uk-card uk-card-default uk-card-body uk-card-small">
-              <h2 class="uk-card-title">Support</h2>
-              <p>
-                Sensors &amp; Signals LLC — sales, integration, and technical support.
-              </p>
-              <ul class="uk-list uk-list-bullet">
-                <li><a href="https://www.snstac.com" target="_blank" rel="noopener noreferrer">www.snstac.com</a></li>
-                <li><a href="mailto:info@snstac.com">info@snstac.com</a></li>
-                <li>Phone: <a href="tel:+14155988226">+1-415-598-8226</a></li>
-              </ul>
-            </div>
-          </div>
+        <div class="aos-foot-col">
+          <h2 class="aos-foot-h">Support</h2>
+          <p>Sensors &amp; Signals LLC — sales, integration, and technical support.</p>
+          <ul class="aos-foot-list">
+            <li><a href="https://www.snstac.com" target="_blank" rel="noopener noreferrer">www.snstac.com</a></li>
+            <li><a href="mailto:info@snstac.com">info@snstac.com</a></li>
+            <li>Phone: <a href="tel:+14155988226">+1-415-598-8226</a></li>
+          </ul>
         </div>
-      </div>
-    </div>
+      </footer>
 
-    <div class="uk-section uk-section-xsmall">
-      <div class="uk-container uk-container-small">
-        <h3 class="uk-heading-small">License</h3>
-        <div class="aos-license">
-          <pre>
-Copyright Sensors &amp; Signals LLC <a href="https://www.snstac.com">www.snstac.com</a>
+      <p class="aos-legal">
+        Served over <strong>HTTPS</strong> · Apache-2.0 · Copyright Sensors &amp; Signals LLC ·
+        <a href="https://www.snstac.com">www.snstac.com</a>
+      </p>
+    </main>
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
-          </pre>
-        </div>
-      </div>
-    </div>
-
-    <script src="js/uikit.min.js" defer></script>
     <script src="js/portal-landing.js" defer></script>
   </body>
 </html>

--- a/shared_files/aryaos/html/js/portal-landing.js
+++ b/shared_files/aryaos/html/js/portal-landing.js
@@ -587,6 +587,70 @@
     });
   }
 
+  /* --- Command-deck hero: big colorblind-safe status pills + online + host --- */
+  function setStat(id, state, value) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.classList.remove("aos-stat--ok", "aos-stat--warn", "aos-stat--bad", "aos-stat--pending");
+    el.classList.add("aos-stat--" + (state || "pending"));
+    var v = document.getElementById(id + "-v");
+    if (v) v.textContent = value;
+  }
+  function setOnline(ok) {
+    var el = document.getElementById("aos-online");
+    if (!el) return;
+    el.classList.toggle("aos-online--off", !ok);
+    el.innerHTML = '<span class="aos-online-dot" aria-hidden="true"></span> ' + (ok ? "ONLINE" : "OFFLINE");
+  }
+  function fillHero(d) {
+    var host = document.getElementById("aos-appbar-host");
+    if (host) host.textContent = d && d.hostname ? d.hostname : "";
+    var g = d && d.gps;
+    if (g && g.ok && g.mode >= 2 && g.lat != null) setStat("aos-hero-gps", "ok", (g.fix_type || g.mode + "D") + " FIX");
+    else if (g && g.ok) setStat("aos-hero-gps", "warn", "NO FIX");
+    else setStat("aos-hero-gps", d ? "bad" : "pending", d ? "OFFLINE" : "…");
+    var thr = d && d.system && d.system.throttle;
+    if (thr && thr.state === "bad") setStat("aos-hero-power", "bad", "UNDER-VOLT");
+    else if (thr && thr.state === "warn") setStat("aos-hero-power", "warn", "WARN");
+    else if (thr) setStat("aos-hero-power", "ok", "OK");
+    else setStat("aos-hero-power", "pending", "…");
+    var tg = d && d.tak_gateways;
+    if (tg && tg.items && tg.items.length) {
+      var total = tg.items.length, up = 0;
+      tg.items.forEach(function (it) { if (it && it.state === "up") up++; });
+      setStat("aos-hero-sensors", up === total ? "ok" : up === 0 ? "bad" : "warn", up + "/" + total);
+    } else {
+      setStat("aos-hero-sensors", "pending", "—");
+    }
+  }
+
+  /* --- Day / night theme toggle (auto → day → night); persisted --- */
+  (function () {
+    var root = document.documentElement;
+    var btn = document.getElementById("aos-theme-toggle");
+    if (!btn) return;
+    var txt = document.getElementById("aos-theme-txt");
+    var ico = btn.querySelector(".aos-theme-ico");
+    var ORDER = ["auto", "day", "night"];
+    var ICON = { auto: "◐", day: "☀", night: "☾" };
+    var LABEL = { auto: "Auto", day: "Day", night: "Night" };
+    function current() {
+      try { var t = localStorage.getItem("aos-theme"); return t === "day" || t === "night" ? t : "auto"; }
+      catch (e) { return "auto"; }
+    }
+    function apply(mode) {
+      if (mode === "day" || mode === "night") root.setAttribute("data-theme", mode);
+      else root.removeAttribute("data-theme");
+      try { mode === "auto" ? localStorage.removeItem("aos-theme") : localStorage.setItem("aos-theme", mode); } catch (e) {}
+      if (txt) txt.textContent = LABEL[mode];
+      if (ico) ico.textContent = ICON[mode];
+    }
+    apply(current());
+    btn.addEventListener("click", function () {
+      apply(ORDER[(ORDER.indexOf(current()) + 1) % ORDER.length]);
+    });
+  })();
+
   var api = "/cgi-bin/aryaos-portal-status";
   var neighborsApi = "/cgi-bin/aryaos-neighbors";
   function loadStatus() {
@@ -597,6 +661,8 @@
       })
       .then(function (d) {
         errEl && errEl.classList.add("uk-hidden");
+        setOnline(true);
+        fillHero(d);
         fillHost(d);
         fillGps(d.gps || null);
         fillRadios(d.radios != null ? d.radios : { ok: true, devices: [], error: null });
@@ -605,6 +671,8 @@
       })
       .catch(function (e) {
         showErr("Could not load status from " + api + ". " + (e && e.message ? e.message : ""));
+        setOnline(false);
+        fillHero(null);
         fillRadios(null);
         fillGps(null);
         fillTakGateways(null);


### PR DESCRIPTION
Redesigns the box landing page (lighttpd `/`) for USFS-style field use — big glove targets, sunlight-legible **day** theme + low-glare **night** (auto via `prefers-color-scheme`, toggle persisted), and **colorblind-safe** status (Okabe–Ito bluish-green/orange/vermillion + ✓/!/✕ glyph + text label, never color-only).

- **Command deck**: app bar (brand · host · ONLINE · theme toggle) → 3 big status pills (GPS/POWER/SENSORS) → 4 large action tiles (Admin/Map/Docs/Support) → TAK chips → telemetry (Connection/GNSS/Neighbors/Radios) in tap-to-open drawers.
- Same `aryaos-portal-status` JSON + element IDs; offline `/docs/` link + QR kept (verify-image gate intact). Dropped the UIKit JS dep (custom banners replace `uk-alert`).

Deployed live on the lab Pi 5 and validated (serves 200, safe-mode-wrapped deploy). `node --check` clean.