### PR TITLE
feat: LimeSDR (dragonegg) support + NVMe boot docs

### DIFF
--- a/docs/deploy/sigint-limesdr.md
+++ b/docs/deploy/sigint-limesdr.md
@@ -1,0 +1,74 @@
+# SIGINT / wideband SDR (LimeSDR Mini) — "dragonegg"
+
+The **dragonegg** laydown is AryaOS + a **LimeSDR Mini** + GPS: a wideband
+(10&nbsp;MHz–3.5&nbsp;GHz) software-defined radio on the edge for spectrum monitoring and
+signal-collection tasks, with the box's own position on the map.
+
+AryaOS ships the driver and access layer for the LimeSDR; the collection/analysis application
+you point at it is deployment-specific.
+
+## What's on the image
+
+- **`soapysdr-module-lms7`** — the SoapySDR driver for LimeSDR / LMS7002M. Any SoapySDR client
+  (readsb, SDR++, SDRangel, GQRX, GNU Radio) can drive the Lime as `driver=lime`.
+- **`limesuite`** — LimeSuite tools: `LimeUtil` (find/probe/update), `LimeQuickTest`.
+- **`soapysdr-module-remote`** — SoapyRemote, so a remote operator can use the Lime over the
+  network (see [Remote access](#remote-access-soapyremote)).
+- **`soapysdr-tools`** — `SoapySDRUtil` for enumeration/probing.
+
+## First use
+
+Verify the device and update its gateware (a LimeSDR Mini usually needs a one-time update):
+
+```bash
+LimeUtil --find                       # should list "LimeSDR Mini"
+SoapySDRUtil --probe="driver=lime"    # full capability probe
+sudo LimeUtil --update                # one-time gateware/firmware update
+```
+
+!!! warning "Power"
+    The LimeSDR Mini is a **heavy, bursty USB draw**. With GPS and a Pi&nbsp;5 this is one of
+    the highest-draw laydowns — use a proper **5V/5A (27&nbsp;W)** supply (or a true PoE+
+    802.3at source). On a marginal supply the box can brown out; AryaOS will flag under-voltage
+    (power-health) and, if it crash-loops, drop into
+    [safe mode](../get-started/hardware.md#safe-mode).
+
+## Using the LimeSDR
+
+### As the ADS-B 1090 front-end
+
+The Lime can replace an RTL-SDR for ADS-B:
+
+```bash
+sudo scripts/readsb-use-lime.sh          # driver=lime, gain 40
+```
+
+This sets `readsb` to `--device-type soapysdr --soapy-device driver=lime` and restarts it.
+CoT then flows through `adsbcot` → Charontak as usual.
+
+### Remote access (SoapyRemote) {#remote-access-soapyremote}
+
+Expose the Lime to a remote operator running SDR++, SDRangel or GQRX with the SoapyRemote
+plugin (they connect to `driver=remote,remote=<host>`):
+
+```bash
+SoapySDRServer --bind          # serves the local SDRs over the network
+```
+
+!!! danger "Not enabled by default"
+    `SoapySDRServer` is **not** started automatically — it opens the SDR to the network
+    unauthenticated. Start it manually only when needed, and **bind it to the Tailscale/VPN
+    interface, not the open LAN** (see [Firewall](../networking/firewall.md) and
+    [VPN](../networking/vpn-tailscale.md)). Stop it when you're done.
+
+### Local capture / analysis
+
+Any SoapySDR/LimeSuite-based tool (GNU Radio, `SoapySDRUtil`, custom collectors) can open the
+Lime locally as `driver=lime`. The specific SIGINT collection/analysis application is chosen
+per deployment and is outside the base image.
+
+## See also
+
+- [Radios & SDRs](../config/radios-sdr.md) — SDR selection and serials
+- [Own position (GPS)](own-position-gps.md) — the GPS half of dragonegg
+- [Hardware & requirements](../get-started/hardware.md#power--battery-for-backpack-ops) — power

--- a/docs/operations/nvme-boot.md
+++ b/docs/operations/nvme-boot.md
@@ -1,0 +1,72 @@
+# Boot from NVMe
+
+AryaOS boots from a **microSD card** by default. On hardware with an NVMe slot — the Waveshare
+PoE M.2 HAT+, other M.2 HATs, or SNS-supplied boxes — you can run AryaOS from an **NVMe SSD**
+instead, which is far more endurance-friendly for continuous field use (see
+[Media longevity](media-longevity.md)) and noticeably faster.
+
+Booting from NVMe is a **Raspberry Pi bootloader change**, not something the AryaOS image does
+for you — the steps below are one-time, per unit.
+
+## 1. Fit the drive
+
+Seat an M.2 **NVMe** SSD (2230/2242/2260/2280) in the HAT. The Pi&nbsp;5 auto-detects the PCIe
+link; no `config.txt` change is needed for detection. To force PCIe Gen&nbsp;3 (faster, but not
+all HATs/SSDs are stable):
+
+```
+# /boot/firmware/config.txt
+dtparam=pciex1_gen=3
+```
+
+The Waveshare PoE M.2 HAT+ runs at Gen&nbsp;2 by default, which is plenty for AryaOS.
+
+## 2. Put AryaOS on the NVMe
+
+Either flash the AryaOS `.img` directly to the NVMe from another machine, or clone a running
+SD install to the NVMe on the box:
+
+```bash
+lsblk                              # confirm the NVMe is /dev/nvme0n1
+# Option A — clone the running SD card to NVMe:
+sudo rpi-clone nvme0n1             # if rpi-clone is available
+# Option B — write a downloaded image (see the OS image backup card in Cockpit):
+sudo sh -c 'xzcat /var/lib/aryaos/image/*.img.xz > /dev/nvme0n1'
+```
+
+`findmnt /` afterwards should still show the SD root until you change the boot order.
+
+## 3. Set the boot order to prefer NVMe
+
+Edit the bootloader EEPROM config and set `BOOT_ORDER` so the Pi tries NVMe first, then SD:
+
+```bash
+sudo rpi-eeprom-config --edit
+```
+
+```
+BOOT_ORDER=0xf416
+```
+
+Boot-order digits are read right-to-left: `6`=NVMe, `1`=SD, `4`=USB, `f`=retry. `0xf416` means
+**NVMe → SD → USB → repeat**, so a box with no NVMe still falls back to the SD card. Reboot.
+
+## 4. Verify
+
+```bash
+findmnt /                          # root should now be /dev/nvme0n1p2
+rpi-eeprom-config | grep BOOT_ORDER
+```
+
+!!! warning "Power headroom"
+    NVMe adds roughly **2–4&nbsp;W** on the PCIe link. On a marginal supply — a 5V/3A brick, or
+    a PoE HAT fed from plain **802.3af** — adding NVMe (plus SDRs) can tip the box into a
+    brownout. Pair NVMe boot with a proper **5V/5A (27&nbsp;W)** supply or a true **PoE+
+    (802.3at)** source. AryaOS surfaces under-voltage via power-health and falls back to
+    [safe mode](../get-started/hardware.md#safe-mode) if it crash-loops. See
+    [Hardware & requirements](../get-started/hardware.md#power--battery-for-backpack-ops).
+
+## See also
+
+- [Media longevity](media-longevity.md) — why NVMe/eMMC beats SD for continuous use
+- [OS image backup](backup-restore.md) — pulling the unit's own `.img` to re-flash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Aircraft (ADS-B): deploy/air-adsb.md
       - Maritime vessels (AIS): deploy/maritime-ais.md
       - Counter-UAS (drones): deploy/counter-uas.md
+      - SIGINT / wideband (LimeSDR): deploy/sigint-limesdr.md
       - Own position (GPS): deploy/own-position-gps.md
       - Multi-sensor COP: deploy/multi-sensor.md
       - Relay & routing: deploy/relay-routing.md
@@ -94,6 +95,7 @@ nav:
       - SBOM & supply chain: operations/sbom.md
       - Nearby nodes: operations/neighbors.md
       - Media longevity: operations/media-longevity.md
+      - Boot from NVMe: operations/nvme-boot.md
       - Back up & restore: operations/backup-restore.md
       - Factory reset: operations/factory-reset.md
       - Zeroize: operations/zeroize.md

--- a/scripts/readsb-use-lime.sh
+++ b/scripts/readsb-use-lime.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Configure readsb to use a LimeSDR (Mini) via SoapySDR and restart.
+#
+# For the "dragonegg" laydown (AryaOS + LimeSDR Mini + GPS): use the Lime as the
+# 1090 MHz ADS-B front-end. Requires soapysdr-module-lms7 (shipped) — verify the
+# device first with `LimeUtil --find` and `SoapySDRUtil --probe="driver=lime"`.
+# A LimeSDR Mini often needs a one-time gateware update: `LimeUtil --update`.
+#
+# Usage:
+#   sudo ./scripts/readsb-use-lime.sh
+#   sudo ./scripts/readsb-use-lime.sh "driver=lime" 40
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+
+set -euo pipefail
+
+SOAPY_DEVICE="${1:-driver=lime}"
+GAIN="${2:-40}"
+READSB_DEF="/etc/default/readsb"
+
+if [[ ! -f "${READSB_DEF}" ]]; then
+	echo "Missing ${READSB_DEF} — is readsb installed?" >&2
+	exit 1
+fi
+
+if ! /usr/bin/readsb --help 2>&1 | grep -q soapysdr; then
+	echo "readsb lacks SoapySDR support — rebuild with SOAPYSDR=yes (readsb-install.sh)." >&2
+	exit 1
+fi
+
+if ! SoapySDRUtil --info 2>&1 | grep -qi 'lime\|lms7'; then
+	echo "SoapySDR has no LimeSDR (lms7) module — is soapysdr-module-lms7 installed?" >&2
+	exit 1
+fi
+
+python3 - "${READSB_DEF}" "${SOAPY_DEVICE}" "${GAIN}" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+soapy = sys.argv[2]
+gain = sys.argv[3]
+text = path.read_text()
+line = f'RECEIVER_OPTIONS="--device-type soapysdr --soapy-device {soapy} --gain {gain}"\n'
+if re.search(r"^RECEIVER_OPTIONS=", text, re.M):
+    text = re.sub(r"^RECEIVER_OPTIONS=.*$", line.rstrip(), text, count=1, flags=re.M)
+else:
+    text = text.rstrip() + "\n" + line
+path.write_text(text)
+PY
+
+systemctl restart readsb
+echo "=== readsb status ==="
+systemctl --no-pager --full status readsb || true

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -270,6 +270,11 @@ require_path /usr/local/sbin/aryaos-set-nodered-password
 require_path /usr/local/sbin/aryaos-sdr
 require_path /usr/local/sbin/aryaos-role
 require_pkg rtl-sdr
+# LimeSDR (dragonegg: AryaOS + LimeSDR Mini + GPS) — SoapySDR lms7 driver + tools
+# + SoapyRemote for network SIGINT access (scripts/readsb-use-lime.sh drives ADS-B off it).
+require_pkg soapysdr-module-lms7
+require_pkg limesuite
+require_pkg soapysdr-module-remote
 
 # Lifecycle helpers (Cockpit -> AryaOS Site: backup/restore, factory reset, zeroize)
 require_path /usr/local/sbin/aryaos-config-backup

--- a/stages/stage-base/00-install/00-packages
+++ b/stages/stage-base/00-install/00-packages
@@ -35,6 +35,9 @@ python3-setuptools
 python3-yaml
 rtl-sdr
 soapysdr-module-rtlsdr
+soapysdr-module-lms7
+soapysdr-module-remote
+limesuite
 socat
 sudo
 ssl-cert


### PR DESCRIPTION
Adds LimeSDR Mini support for the **dragonegg** laydown (AryaOS + LimeSDR Mini + GPS), plus NVMe-boot documentation.

**LimeSDR**
- Base SDR packages gain `soapysdr-module-lms7` (LimeSDR SoapySDR driver), `limesuite` (`LimeUtil`), and `soapysdr-module-remote` (SoapyRemote for network SIGINT access). `readsb` already builds with SoapySDR, so `driver=lime` works immediately.
- `scripts/readsb-use-lime.sh` — use the Lime as the ADS-B 1090 front-end.
- `verify-image` asserts the three packages ship.
- `docs/deploy/sigint-limesdr.md` — dragonegg page: find/probe/`LimeUtil --update`, the power caveat (Lime is a heavy draw → wants 5V/5A), ADS-B front-end, SoapyRemote remote access (not enabled by default, VPN-bind), and a note that the collection/analysis app is deployment-specific.

**NVMe**
- `docs/operations/nvme-boot.md` — booting AryaOS from NVMe (PoE M.2 HAT): PCIe, image→NVMe, `rpi-eeprom` `BOOT_ORDER=0xf416`, verify, and the power-headroom caveat.

Both pages in the mkdocs nav. Package names confirmed in Debian trixie (all 23.11/0.5.2).