### PR TITLE
feat: robust NMEA-serial assignment for GPS + AIS (aryaos-serial-assign)

### DIFF
--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -90,6 +90,27 @@ Edit them with Cockpit's file editor or over SSH, then `sudo systemctl restart <
 ## See also
 
 - [Site configuration](./site-config.md) — `ARYAOS_ADSB_DECODER`, `ARYAOS_UAT_RTL_SERIAL`, `ARYAOS_ADSB_JSON_DIR`
+## Serial (NMEA) receivers — GPS and AIS
+
+USB-serial receivers — a **GPS puck** and a **dAISy** (or equivalent serial AIS receiver) — are
+assigned the same way in spirit, but by the **NMEA they emit** rather than an EEPROM serial,
+since serial adapters (CP210x, CH340, FTDI, Prolific…) have no consistent identity.
+
+At boot, **`aryaos-serial-assign`** probes each USB-serial device and classifies it:
+
+- **GPS** if it emits `$GPxxx`/`$GNxxx` → written to `gpsd` (`/etc/default/gpsd` `DEVICES`).
+- **AIS** if it emits `!AIVDM`/`!AIVDO` → written to `ais-catcher` (`SERIAL_PORT`).
+- A **dAISy with no vessels in range is silent**; when AIS is intended and it's the only
+  non-GPS serial left, it's assigned by **elimination** at 38400 baud.
+
+It writes stable `by-id` paths and runs before `gpsd`/`ais-catcher`, so a laydown survives
+swapping the GPS puck or dAISy for a different make. Re-run by hand with
+`sudo aryaos-serial-assign`. To pin a device manually instead, set `DEVICES`/`SERIAL_PORT`
+yourself and disable `aryaos-serial-assign.service`.
+
+## See also
+
 - [Device roles](./device-roles.md) — how a role apply switches decoders
 - [Aircraft (ADS-B)](../deploy/air-adsb.md) — deploying the aircraft pipeline
+- [Maritime vessels (AIS)](../deploy/maritime-ais.md) — the AIS pipeline
 - [CLI helpers](../reference/cli-helpers.md) — `aryaos-sdr`

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -276,6 +276,13 @@ require_pkg soapysdr-module-lms7
 require_pkg limesuite
 require_pkg soapysdr-module-remote
 
+# Robust NMEA-serial assignment (GPS vs AIS/dAISy by sentence sniffing) — no
+# hardcoded ttyUSB*/single-make by-id, which broke on differing adapters.
+require_path /usr/local/sbin/aryaos-serial-assign
+require_unit aryaos-serial-assign.service
+require_grep '^DEVICES=""' /etc/default/gpsd "gpsd device not hardcoded (aryaos-serial-assign owns it)"
+require_grep '^SERIAL_PORT=$' /etc/default/ais-catcher "ais-catcher serial not hardcoded (aryaos-serial-assign owns it)"
+
 # Lifecycle helpers (Cockpit -> AryaOS Site: backup/restore, factory reset, zeroize)
 require_path /usr/local/sbin/aryaos-config-backup
 require_path /usr/local/sbin/aryaos-factory-reset

--- a/shared_files/aiscot/ais-catcher.default.conf
+++ b/shared_files/aiscot/ais-catcher.default.conf
@@ -22,8 +22,11 @@
 #
 
 # [-e baudrate port - open device at serial port with given baudrate]
+# SERIAL_PORT is set at boot by aryaos-serial-assign (identifies the dAISy by the
+# !AIVDM it emits, or by elimination if silent) — do not hardcode a ttyUSB*/by-id
+# path here; it breaks when the adapter or enumeration order changes.
 SERIAL_BAUDRATE=38400
-SERIAL_PORT=/dev/ttyUSB1
+SERIAL_PORT=
 
 # [-u xxx.xx.xx.xx yyy - UDP destination address and port (default: off)]
 UDP_DEST_ADDR=127.0.0.1

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -1,0 +1,117 @@
+#!/bin/bash
+# aryaos-serial-assign — identify GPS vs AIS (dAISy) USB-serial receivers by the
+# NMEA they emit and wire gpsd / ais-catcher to the right device. Robust to the
+# adapter chipset and USB enumeration order, so a laydown survives swapping the
+# GPS puck or the dAISy for a different make — the analogue of aryaos-sdr's
+# EEPROM-serial pinning, but for NMEA serial.
+#
+# GPS emits $GPxxx/$GNxxx; a dAISy emits !AIVDM/!AIVDO. A dAISy with no vessels
+# in range is silent, so when AIS is intended (ais-catcher enabled) and exactly
+# one non-GPS serial is left, it is assigned as the dAISy by elimination.
+#
+# Runs at boot before gpsd/ais-catcher (and re-runnable by hand: `sudo
+# aryaos-serial-assign`). Writes /etc/default/gpsd and /etc/default/ais-catcher
+# with stable by-id device paths, then restarts those services if already up.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+GPSD_DEF="/etc/default/gpsd"
+AIS_DEF="/etc/default/ais-catcher"
+AIS_BAUD_DEFAULT=38400
+BAUDS=(9600 38400 4800 115200)
+PROBE_SECS=3
+
+log() { logger -t aryaos-serial-assign "$*" 2>/dev/null || true; echo "aryaos-serial-assign: $*"; }
+
+require_root() {
+	[[ "$(id -u)" == 0 ]] || { echo "aryaos-serial-assign: must run as root" >&2; exit 2; }
+}
+
+# Wait briefly for USB-serial devices to enumerate at boot.
+wait_for_serial() {
+	local i
+	for i in $(seq 1 10); do
+		compgen -G "/dev/serial/by-id/*" >/dev/null 2>&1 && return 0
+		sleep 1
+	done
+	return 0
+}
+
+# Classify one device: prints "gps:<baud>", "ais:<baud>", "busy", or "" (silent).
+classify() {
+	local dev="$1" b data
+	if fuser "$dev" >/dev/null 2>&1; then echo "busy"; return; fi
+	for b in "${BAUDS[@]}"; do
+		stty -F "$dev" "$b" raw -echo >/dev/null 2>&1 || continue
+		# Stream via cat|head so a timeout-killed read still yields its partial
+		# data (head -c under timeout drops its buffer when killed).
+		data="$(timeout "$PROBE_SECS" cat "$dev" 2>/dev/null | head -c 512 | tr -c '[:print:]\n' ' ')"
+		if grep -qE '!AI(VDM|VDO)' <<<"$data"; then echo "ais:$b"; return; fi
+		if grep -qE '\$G[PNLA](GGA|RMC|GLL|VTG|GSV|ZDA)' <<<"$data"; then echo "gps:$b"; return; fi
+	done
+	echo ""
+}
+
+set_kv() {  # set_kv <file> <KEY> <value-unquoted>
+	local f="$1" k="$2" v="$3"
+	[[ -f "$f" ]] || return 0
+	if grep -qE "^${k}=" "$f"; then
+		sed -i "s|^${k}=.*|${k}=\"${v}\"|" "$f"
+	else
+		printf '%s="%s"\n' "$k" "$v" >>"$f"
+	fi
+}
+
+main() {
+	require_root
+	wait_for_serial
+	local gps_dev="" ais_dev="" ais_baud="$AIS_BAUD_DEFAULT" cls dev
+	local -a leftover=()
+
+	shopt -s nullglob
+	for dev in /dev/serial/by-id/*; do
+		cls="$(classify "$dev")"
+		case "$cls" in
+			busy)  log "skip $dev (held by a running service)";;
+			gps:*) [[ -z "$gps_dev" ]] && { gps_dev="$dev"; log "GPS on $dev (${cls#gps:} baud)"; };;
+			ais:*) [[ -z "$ais_dev" ]] && { ais_dev="$dev"; ais_baud="${cls#ais:}"; log "AIS/dAISy on $dev (${cls#ais:} baud)"; };;
+			"")    leftover+=("$dev"); log "silent/unknown serial: $dev";;
+		esac
+	done
+	shopt -u nullglob
+
+	# Silent dAISy: if AIS is intended and exactly one non-GPS serial is left,
+	# assign it by elimination at the dAISy default baud.
+	if [[ -z "$ais_dev" && ${#leftover[@]} -eq 1 ]] \
+		&& systemctl is-enabled ais-catcher.service >/dev/null 2>&1; then
+		ais_dev="${leftover[0]}"; ais_baud="$AIS_BAUD_DEFAULT"
+		log "AIS/dAISy assumed on $ais_dev by elimination (silent; ${ais_baud} baud)"
+	fi
+
+	local changed=0
+	if [[ -n "$gps_dev" ]]; then
+		set_kv "$GPSD_DEF" DEVICES "$gps_dev"; changed=1
+		log "gpsd DEVICES -> $gps_dev"
+	fi
+	if [[ -n "$ais_dev" ]]; then
+		set_kv "$AIS_DEF" SERIAL_PORT "$ais_dev"
+		# baud key is written bare (no quotes) to match the shipped default
+		if grep -qE '^SERIAL_BAUDRATE=' "$AIS_DEF" 2>/dev/null; then
+			sed -i "s|^SERIAL_BAUDRATE=.*|SERIAL_BAUDRATE=${ais_baud}|" "$AIS_DEF"
+		fi
+		changed=1
+		log "ais-catcher SERIAL_PORT -> $ais_dev @ ${ais_baud}"
+	fi
+	[[ -z "$gps_dev$ais_dev" ]] && log "no GPS or AIS serial identified"
+
+	# Pick up new assignments if the consumers are already running.
+	if [[ "$changed" == 1 ]]; then
+		systemctl try-restart gpsd.service >/dev/null 2>&1 || true
+		systemctl try-restart ais-catcher.service >/dev/null 2>&1 || true
+	fi
+}
+
+main "$@"

--- a/shared_files/aryaos/gpsd.default
+++ b/shared_files/aryaos/gpsd.default
@@ -17,5 +17,9 @@
 
 START_DAEMON="true"
 GPSD_OPTIONS="-n"
-DEVICES="/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_D-if00-port0"
+# DEVICES is set at boot by aryaos-serial-assign, which identifies the GPS by the
+# $GPxxx/$GNxxx NMEA it emits (any adapter chipset) — do not hardcode a specific
+# puck's by-id here; it breaks on any unit whose GNSS is a different make.
+# USBAUTO stays on as a fallback for udev-recognised GNSS receivers.
+DEVICES=""
 USBAUTO="true"

--- a/shared_files/aryaos/systemd/aryaos-serial-assign.service
+++ b/shared_files/aryaos/systemd/aryaos-serial-assign.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AryaOS serial assignment — wire gpsd/ais-catcher to the right NMEA device
+Documentation=https://github.com/snstac/aryaos
+# Identify GPS vs AIS/dAISy by the NMEA they emit and write the by-id device into
+# /etc/default/{gpsd,ais-catcher} before those services read it. It also
+# try-restarts them afterward, so it is correct even if they started first.
+After=local-fs.target
+Before=ais-catcher.service gpsd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-serial-assign
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -171,6 +171,13 @@ for svc in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot drone
 		"${ROOTFS_DIR}/etc/systemd/system/${svc}.service.d/safe-mode.conf"
 done
 
+## Serial assignment: identify GPS vs AIS/dAISy by the NMEA they emit and wire
+## gpsd/ais-catcher to the right by-id device at boot (robust to adapter/enum
+## changes) — the NMEA-serial analogue of aryaos-sdr's EEPROM-serial pinning.
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-serial-assign" "${ROOTFS_DIR}/usr/local/sbin/aryaos-serial-assign"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-serial-assign.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-serial-assign.service"
+
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).
 install -v -m 0644 "${SHARED_FILES}/aryaos/zram-generator.conf" "${ROOTFS_DIR}/etc/systemd/zram-generator.conf"

--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -47,6 +47,8 @@ systemctl enable aryaos-neighbord.service
 systemctl enable aryaos-radio-silence.service
 # Safe mode: crash-loop guard (early), USB-off applier (late), boot-stable timer.
 systemctl enable aryaos-crash-guard.service
+# Serial assignment: wire gpsd/ais-catcher to the right NMEA device before they start.
+systemctl enable aryaos-serial-assign.service
 systemctl enable aryaos-safe-mode.service
 systemctl enable aryaos-boot-stable.timer
 


### PR DESCRIPTION
HIL on the AIS laydown exposed that `gpsd`/`ais-catcher` were pinned to a **specific Prolific GPS** and **`/dev/ttyUSB1`** — so on a unit whose GPS/dAISy use different USB-serial adapters (this box: CP210x GPS + CH340 dAISy), `gpsd` chased an absent device and `ais-catcher` pointed at the *GPS* port. Neither AIS nor GPS flowed.

**Fix — `aryaos-serial-assign`** (the NMEA-serial analogue of `aryaos-sdr` EEPROM pinning): at boot, probe each USB-serial device and classify by the NMEA it emits — GPS (`$GPxxx`/`$GNxxx`) vs AIS/dAISy (`!AIVDM`/`!AIVDO`) — and write the stable `by-id` path into `/etc/default/{gpsd,ais-catcher}`. A **silent dAISy** (no vessels in range) is assigned **by elimination** at 38400 when AIS is intended. Runs before `gpsd`/`ais-catcher`; try-restarts them if already up.

- Removes the hardcoded Prolific from `gpsd.default` and `ttyUSB1` from `ais-catcher.default.conf`.
- Enables `aryaos-serial-assign.service`; `verify-image` asserts it + the un-hardcoded defaults.
- Docs: `config/radios-sdr.md` serial section.

**Validated on the lab AIS+GPS box:** correctly derived GPS→CP2102N (sniffed) and dAISy→CH340 (elimination); `gpsd` got a **3D fix** and `ais-catcher` read the dAISy, all services up.