### PR TITLE
fix(role): re-run serial assign after enabling AIS so the dAISy auto-wires

### DIFF
--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -134,6 +134,15 @@ set_role() {
 	done
 
 	config_set ARYAOS_ROLE "${role}"
+
+	# aryaos-serial-assign only wires the dAISy when ais-catcher is enabled (its
+	# elimination guard). It runs at boot before the role is known, so re-run it
+	# after enabling a role that uses AIS — otherwise selecting maritime/multi
+	# leaves ais-catcher with an empty SERIAL_PORT until the next boot.
+	if [[ " ${wanted} " == *" ais-catcher "* ]] && [[ -x /usr/local/sbin/aryaos-serial-assign ]]; then
+		/usr/local/sbin/aryaos-serial-assign || true
+	fi
+
 	echo "Device role set to '${role}'."
 }
 


### PR DESCRIPTION
Follow-up to #170. `aryaos-serial-assign` only assigns the dAISy when `ais-catcher` is already **enabled** (its elimination guard), but it runs at boot **before the role is known**. So a fresh box with `role=` empty got GPS assigned but not the dAISy — and later selecting `maritime`/`multi` enabled `ais-catcher` with an **empty `SERIAL_PORT`** (no AIS input) until the next boot. Found on the AIS HIL box.

`set_role` now re-runs `aryaos-serial-assign` after enabling a role that uses `ais-catcher`, so the dAISy wires immediately. Validated on the lab box: blank the port → `aryaos-role set maritime` → ais-catcher comes up reading the dAISy, no manual step.