### PR TITLE
feat: put Node-RED behind HTTPS /nr proxy, empty flows, off the LAN

### DIFF
--- a/docs/node-red.md
+++ b/docs/node-red.md
@@ -1,27 +1,29 @@
-# Node-RED dashboard
+# Node-RED
 
-AryaOS ships [Node-RED](https://nodered.org/) as an optional low-code
-automation and visualization surface. It runs as **`nodered.service`** on port
-**1880**; the read-only **Dashboard** is at **`http://<host>:1880/ui`** and the
-flow editor at **`http://<host>:1880/`**.
+AryaOS ships [Node-RED](https://nodered.org/) as an **optional** low-code
+automation surface — it is **not required for any AryaOS functionality**. It
+boots with **empty flows** and is **not the admin surface** (that's Cockpit).
 
-!!! warning "Rotate the Node-RED admin password before fielding a unit"
-    Node-RED ships with a **publicly known default admin password** and its
-    editor can run code on the device. Change it from **AryaOS Site → Node-RED
-    admin password** (see [AryaOS Site](admin/aryaos-site.md)) or with
-    `sudo aryaos-set-nodered-password`. Restrict access to the flow editor on any
-    production gateway.
+## Accessing it
 
-## What it does
+Node-RED binds **loopback only** and is served behind the box's HTTPS reverse
+proxy — the flow editor is at **`https://<host>/nr/`** (accept the self-signed
+cert). It is **not** reachable on `:1880` over the LAN; the public firewall zone
+no longer opens the Node-RED port, so the editor (which can run code on the
+device) is not exposed as walk-up attack surface. For remote access, reach
+`/nr/` over the [VPN](networking/vpn-tailscale.md).
 
-| Tab / flow | Purpose |
-|------------|---------|
-| **Dashboard** | Admin links to the portal, Cockpit, and the onboarding hotspot |
-| **TAK / Maps** | Mesh SA visualization (world map) — read-only ops picture |
-| **TFR** | Injects Temporary Flight Restriction CoT from a `TFR_STATE` file |
-| **Recorder** | Optional CoT logging under `/var/www/html/recorder/` |
-| **ADS-B** | Decoder stats display when JSON feeds are present |
-| **Debug Logs** | Operator debug channel |
+!!! warning "Set a strong Node-RED admin password before fielding a unit"
+    The editor can run code on the device. Set a unique password from **AryaOS
+    Site → Node-RED admin password** (see [AryaOS Site](admin/aryaos-site.md)) or
+    with `sudo aryaos-set-nodered-password`.
+
+## Optional legacy flows
+
+The previous AryaOS demo flows (dashboard, Mesh SA map, TFR/recorder helpers)
+are **no longer loaded by default**. The bundle still ships at
+`/home/node-red/.node-red/aryaos_flows.json` — import it by hand from the editor
+(**Menu → Import**) if you want those flows.
 
 ## Node-RED is not the admin surface
 

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -238,6 +238,17 @@ require_path /etc/systemd/system/nodered.service.d/aryaos.conf
 require_grep '^[[:space:]]*User=node-red' /etc/systemd/system/nodered.service.d/aryaos.conf "nodered runs as node-red (not root)"
 # The hardened settings.js (the one node-red now uses) must carry adminAuth.
 require_grep 'adminAuth' /home/node-red/.node-red/settings.js "node-red adminAuth configured"
+# Node-RED is optional + tucked away: empty flows, bound to loopback, served under
+# /nr behind the lighttpd HTTPS proxy, and NOT exposed on :1880 on the LAN.
+require_grep '^\[\]' /home/node-red/.node-red/flows.json "node-red ships empty flows"
+require_grep 'uiHost:[[:space:]]*"127.0.0.1"' /home/node-red/.node-red/settings.js "node-red binds loopback only"
+require_grep 'httpAdminRoot:[[:space:]]*"/nr"' /home/node-red/.node-red/settings.js "node-red served under /nr"
+require_grep 'port"[[:space:]]*=>[[:space:]]*1880' /etc/lighttpd/conf-available/95-aryaos-cockpit-https.conf "lighttpd reverse-proxies /nr to Node-RED"
+if grep -qsE '<service name="aryaos-node-red"' "${MNT}/etc/firewalld/zones/public.xml"; then
+	fail "public (LAN) zone still exposes Node-RED :1880 — should be proxied via /nr only"
+else
+	ok "Node-RED not exposed on the public (LAN) zone (reachable via /nr only)"
+fi
 
 # Hardening (stage-aryaos): firewall, brute-force protection, auto security
 # updates, per-device web TLS, sysctl/sshd tightening

--- a/shared_files/aryaos/95-aryaos-cockpit-https.conf
+++ b/shared_files/aryaos/95-aryaos-cockpit-https.conf
@@ -23,7 +23,9 @@ $SERVER["socket"] == ":80" {
         url.redirect-code = 308
         url.redirect = (
             "^/admin$" => "https://%0/admin/",
-            "^/admin/(.*)$" => "https://%0/admin/$1"
+            "^/admin/(.*)$" => "https://%0/admin/$1",
+            "^/nr$" => "https://%0/nr/",
+            "^/nr/(.*)$" => "https://%0/nr/$1"
         )
     }
 }
@@ -76,6 +78,23 @@ $SERVER["socket"] == ":443" {
         proxy.server = ( "" => ( (
             "host" => "127.0.0.1",
             "port" => 9090
+        ) ) )
+    }
+
+    ## Node-RED behind HTTPS at /nr (localhost-only backend; settings.js sets
+    ## httpAdminRoot/httpNodeRoot=/nr and uiHost=127.0.0.1). Not exposed on :1880
+    ## on the LAN — the public firewall zone no longer opens Node-RED. Bare /nr
+    ## needs a trailing slash so the editor's relative assets resolve.
+    $HTTP["url"] == "/nr" {
+        url.redirect-code = 308
+        url.redirect = ( "^/nr$" => "/nr/" )
+    }
+    $HTTP["url"] =~ "^/nr/" {
+        setenv.add-request-header = ("X-Forwarded-Proto" => "https")
+        proxy.header = ( "upgrade" => "enable" )
+        proxy.server = ( "" => ( (
+            "host" => "127.0.0.1",
+            "port" => 1880
         ) ) )
     }
 }

--- a/shared_files/aryaos/firewalld/zones/public.xml
+++ b/shared_files/aryaos/firewalld/zones/public.xml
@@ -27,7 +27,10 @@ Docker's own container forwarding is unaffected (it lives in the docker zone).
   <service name="dhcpv6-client"/>
   <service name="dns"/>
   <service name="aryaos-mesh-sa"/>
-  <service name="aryaos-node-red"/>
+  <!-- Node-RED (:1880) is NOT opened on the LAN: it binds loopback and is reached
+       only via the authenticated HTTPS reverse proxy at /nr (lighttpd). Exposing
+       the flow editor (arbitrary code execution) on the wired LAN is unnecessary
+       attack surface for a field appliance. -->
   <service name="aryaos-ais-catcher"/>
   <!-- aryaos-comitup (9080 onboarding captive portal) is intentionally NOT opened
        on the wired LAN: it is only needed on the onboarding radios (Wi-Fi hotspot +

--- a/shared_files/node-red/settings.js
+++ b/shared_files/node-red/settings.js
@@ -150,7 +150,9 @@ module.exports = {
      * The following property can be used to listen on a specific interface. For
      * example, the following would only allow connections from the local machine.
      */
-    //uiHost: "127.0.0.1",
+    // AryaOS: bind loopback only — Node-RED is reached via the lighttpd HTTPS
+    // reverse proxy at /nr/, never directly on :1880 over the LAN.
+    uiHost: "127.0.0.1",
 
     /** The maximum size of HTTP request that will be accepted by the runtime api.
      * Default: 5mb
@@ -167,7 +169,9 @@ module.exports = {
      * The following property can be used to specify a different root path.
      * If set to false, this is disabled.
      */
-    //httpAdminRoot: '/admin',
+    // AryaOS: serve the editor under /nr so it works behind the lighttpd proxy
+    // (https://<host>/nr/). The proxy preserves this path prefix.
+    httpAdminRoot: "/nr",
 
     /** The following property can be used to add a custom middleware function
      * in front of all admin http routes. For example, to set custom http
@@ -191,7 +195,8 @@ module.exports = {
      * can be used to specify a different root path. If set to false, this is
      * disabled.
      */
-    //httpNodeRoot: '/red-nodes',
+    // AryaOS: http-in nodes under /nr too, so any flow endpoints sit behind the proxy.
+    httpNodeRoot: "/nr",
 
     /** The following property can be used to configure cross-origin resource sharing
      * in the HTTP nodes.

--- a/stages/stage-node-red/00-install/00-run.sh
+++ b/stages/stage-node-red/00-install/00-run.sh
@@ -40,8 +40,11 @@ mkdir -p "${ROOTFS_DIR}/home/node-red/.node-red"
 install -v -m 644 "${SHARED_FILES}/node-red/settings.js" "${ROOTFS_DIR}/home/node-red/.node-red/settings.js"
 install -v -m 644 "${SHARED_FILES}/node-red/package.json" "${ROOTFS_DIR}/home/node-red/.node-red/package.json"
 install -v -m 644 "${SHARED_FILES}/node-red/package-lock.json" "${ROOTFS_DIR}/home/node-red/.node-red/package-lock.json"
+# Ship the legacy AryaOS flow bundle as an OPTIONAL import (not auto-loaded); the
+# box now boots with EMPTY flows. Node-RED is no longer required for functionality
+# and is tucked behind the HTTPS /nr proxy. Import aryaos_flows.json by hand if wanted.
 install -v -m 644 "${SHARED_FILES}/node-red/aryaos_flows.json" "${ROOTFS_DIR}/home/node-red/.node-red/"
-cat "${ROOTFS_DIR}/home/node-red/.node-red/aryaos_flows.json" > "${ROOTFS_DIR}/home/node-red/.node-red/flows.json"
+printf '[]\n' > "${ROOTFS_DIR}/home/node-red/.node-red/flows.json"
 
 # Pin nodered.service to the node-red user + /home/node-red (the upstream unit runs
 # as root out of /root/.node-red, whose stock settings.js has no adminAuth — that


### PR DESCRIPTION
Security-scan follow-up. Node-RED is no longer required for AryaOS functionality, and exposing its **flow editor (arbitrary code execution) on the LAN `:1880`** is unnecessary attack surface. Tuck it away:

- **settings.js:** `uiHost=127.0.0.1` (loopback only); `httpAdminRoot`/`httpNodeRoot=/nr`.
- **lighttpd:** reverse-proxy `/nr` → `127.0.0.1:1880` behind the existing HTTPS (mirrors the Cockpit `/admin` proxy incl. websocket upgrade).
- **firewall:** drop `aryaos-node-red` from the public zone → `:1880` no longer on the LAN.
- **flows:** ship **empty** `[]`; the legacy demo bundle stays at `~/.node-red/aryaos_flows.json` as an optional import.
- **verify-image:** asserts empty flows, loopback bind, `/nr` root, the lighttpd `/nr` proxy, and that public zone no longer opens Node-RED.
- **docs:** access via `https://<host>/nr/`.

**Validated on a live box:** `https://<host>/nr/` → HTTP 200 (Node-RED editor); `:1880` now `filtered` from the LAN; bound `127.0.0.1`; flows `[]`.