### PR TITLE
feat(sdr): network SDR sharing — rtl_tcp + SoapyRemote (opt-in)

### DIFF
--- a/docs/config/network-sdr.md
+++ b/docs/config/network-sdr.md
@@ -1,0 +1,57 @@
+# Network SDR sharing
+
+AryaOS can serve an onboard SDR **raw over the network** so a remote operator can
+tune and demodulate it from a desktop client (SDR++, SDRangel, GQRX, SDR#,
+`dump1090`, …) instead of decoding it on the box. A dongle can only do one job at
+a time, so sharing a dongle **stops its decoder** first.
+
+!!! danger "Raw SDR sharing is unauthenticated — opt-in only"
+    Both servers below give any client that can reach the port **full control of
+    the dongle** (tuning + raw IQ). They are **off by default**, and the firewall
+    does **not** open their ports on any zone. Enable a share only on a **trusted
+    or VPN** network — open the firewall service deliberately, or bind the server
+    to your [VPN](../networking/vpn-tailscale.md) address (`AOS_RTLTCP_BIND` /
+    `AOS_SOAPY_BIND`). Turn it back off when you're done.
+
+## Servers
+
+| Server | Devices | Client connects as | Port |
+|---|---|---|---|
+| **rtl_tcp** | RTL-SDR only (per dongle) | `rtl_tcp` host:port (SDR#, GQRX, dump1090…) | `1234 + index` |
+| **SoapyRemote** | any SoapySDR device (RTL / LimeSDR / Airspy / HackRF) | `driver=remote,remote=<host>` (SDR++, SDRangel) | `55132` |
+
+## Sharing a dongle
+
+```bash
+aryaos-sdr list                         # find the dongle index
+sudo aryaos-sdr share 0 rtltcp          # RTL-SDR 0 over rtl_tcp on :1234
+sudo aryaos-sdr share 0 soapy           # all SoapySDR devices over SoapyRemote :55132
+sudo aryaos-sdr share 0 off             # stop sharing (then re-apply a role to decode)
+aryaos-sdr share-status                 # JSON: which share servers are running
+```
+
+Resume normal decoding after sharing with `sudo aryaos-role set <role>`.
+
+## Opening access (deliberately)
+
+The share ports are closed by default. To reach a share, either **bind to the VPN**:
+
+```bash
+# rtl_tcp bound to the Tailscale address only:
+sudo systemctl edit aryaos-rtltcp@0     # add: [Service]\nEnvironment=AOS_RTLTCP_BIND=100.x.y.z
+```
+
+…or **open the firewall service on a trusted zone** (the definitions ship but are
+attached to no zone):
+
+```bash
+sudo firewall-cmd --zone=public --add-service=aryaos-rtltcp        # or aryaos-soapyremote
+# make permanent only if you really want it always-on:
+sudo firewall-cmd --permanent --zone=public --add-service=aryaos-rtltcp
+```
+
+## See also
+
+- [Radios & SDRs](radios-sdr.md) — SDR serials and decoder assignment
+- [SIGINT / wideband (LimeSDR)](../deploy/sigint-limesdr.md) — the dragonegg laydown
+- [VPN (Tailscale)](../networking/vpn-tailscale.md) — the recommended path for remote SDR access

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Site configuration: config/site-config.md
       - Device roles: config/device-roles.md
       - Radios & SDRs: config/radios-sdr.md
+      - Network SDR sharing: config/network-sdr.md
   - Network:
       - Wi-Fi & onboarding hotspot: networking/wifi-hotspot.md
       - Bluetooth PAN: bluetooth-pan.md

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -287,6 +287,21 @@ require_pkg soapysdr-module-lms7
 require_pkg limesuite
 require_pkg soapysdr-module-remote
 
+# Network SDR sharing (aryaos-sdr share): rtl_tcp per-dongle + SoapyRemote, both
+# on-demand and NOT firewalled by default (raw unauthenticated SDR = opt-in).
+require_grep 'share INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr share subcommand"
+require_unit aryaos-rtltcp@.service
+require_unit aryaos-soapyremote.service
+require_path /etc/firewalld/services/aryaos-rtltcp.xml
+require_path /etc/firewalld/services/aryaos-soapyremote.xml
+for z in public aryaos-hotspot; do
+	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
+		fail "${z} zone exposes a raw SDR share server by default (must be opt-in)"
+	else
+		ok "${z} zone does not open SDR-share servers by default"
+	fi
+done
+
 # Robust NMEA-serial assignment (GPS vs AIS/dAISy by sentence sniffing) — no
 # hardcoded ttyUSB*/single-make by-id, which broke on differing adapters.
 require_path /usr/local/sbin/aryaos-serial-assign

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -21,7 +21,7 @@ SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
-	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL}" >&2
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | share INDEX {rtltcp|soapy|off} | share-status}" >&2
 	exit 2
 }
 
@@ -104,6 +104,45 @@ set_serial() {
 	fi
 }
 
+# Share a dongle over the network (rtl_tcp / SoapyRemote). A dongle can only do
+# one job, so decoders holding an RTL device are stopped first. Both servers are
+# UNAUTHENTICATED and OFF by default; the firewall is NOT opened for them — the
+# operator opens aryaos-rtltcp/aryaos-soapyremote on a trusted zone or binds to a
+# VPN (AOS_RTLTCP_BIND / AOS_SOAPY_BIND). See docs/reference network-sdr page.
+share_sdr() {
+	local index="$1" mode="$2"
+	if [[ ! "${index}" =~ ^[0-9]+$ ]]; then
+		echo "aryaos-sdr: INDEX must be a number" >&2
+		exit 2
+	fi
+	local unit
+	for unit in ${SDR_UNITS}; do
+		systemctl is-active --quiet "${unit}" 2>/dev/null && systemctl stop "${unit}"
+	done
+	case "${mode}" in
+		rtltcp)
+			systemctl start "aryaos-rtltcp@${index}.service"
+			echo "Sharing RTL-SDR ${index} via rtl_tcp on port $((1234 + index))."
+			echo "UNAUTHENTICATED — open the firewall (aryaos-rtltcp) or set AOS_RTLTCP_BIND to a VPN address." ;;
+		soapy)
+			systemctl start aryaos-soapyremote.service
+			echo "Sharing SoapySDR devices via SoapyRemote on :55132 (client: driver=remote)."
+			echo "UNAUTHENTICATED — open the firewall (aryaos-soapyremote) or set AOS_SOAPY_BIND to a VPN address." ;;
+		off)
+			systemctl stop "aryaos-rtltcp@${index}.service" aryaos-soapyremote.service >/dev/null 2>&1 || true
+			echo "Network sharing stopped. Resume decoding with: aryaos-role set <role>." ;;
+		*)
+			echo "usage: aryaos-sdr share INDEX {rtltcp|soapy|off}" >&2; exit 2 ;;
+	esac
+}
+
+share_status() {
+	local rtltcp soapy
+	rtltcp="$(systemctl list-units 'aryaos-rtltcp@*' --state=active --no-legend 2>/dev/null | awk '{print $1}' | paste -sd, - )"
+	soapy="$(systemctl is-active aryaos-soapyremote 2>/dev/null || echo inactive)"
+	printf '{"rtltcp":"%s","soapyremote":"%s"}\n' "${rtltcp}" "${soapy}"
+}
+
 cmd="${1:-}"
 case "${cmd}" in
 	list)
@@ -115,6 +154,14 @@ case "${cmd}" in
 		require_tools
 		[[ $# -eq 3 ]] || usage
 		set_serial "$2" "$3"
+		;;
+	share)
+		require_root
+		[[ $# -eq 3 ]] || usage
+		share_sdr "$2" "$3"
+		;;
+	share-status)
+		share_status
 		;;
 	*)
 		usage

--- a/shared_files/aryaos/firewalld/services/aryaos-rtltcp.xml
+++ b/shared_files/aryaos/firewalld/services/aryaos-rtltcp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>AryaOS rtl_tcp SDR share</short>
+  <description>Raw RTL-SDR network servers (rtl_tcp), one per dongle at 1234+index. UNAUTHENTICATED — not opened on any zone by default; add to a zone only on a trusted/VPN network.</description>
+  <port protocol="tcp" port="1234-1237"/>
+</service>

--- a/shared_files/aryaos/firewalld/services/aryaos-soapyremote.xml
+++ b/shared_files/aryaos/firewalld/services/aryaos-soapyremote.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>AryaOS SoapyRemote SDR share</short>
+  <description>SoapyRemote server (all onboard SoapySDR devices). UNAUTHENTICATED — not opened on any zone by default; add to a zone only on a trusted/VPN network. UDP is device discovery.</description>
+  <port protocol="tcp" port="55132"/>
+  <port protocol="udp" port="55132"/>
+</service>

--- a/shared_files/aryaos/systemd/aryaos-rtltcp@.service
+++ b/shared_files/aryaos/systemd/aryaos-rtltcp@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=AryaOS rtl_tcp — share RTL-SDR %i over the network (port 1234+index)
+Documentation=https://github.com/snstac/aryaos
+# OFF by default. rtl_tcp is UNAUTHENTICATED — anyone who can reach the port gets
+# the raw IQ stream and full control of the dongle's tuning. Enable only on a
+# trusted / VPN network and open the firewall (aryaos-rtltcp) deliberately, or
+# bind to the VPN address via AOS_RTLTCP_BIND. A dongle cannot decode and be
+# shared at once — stop its decoder first (`aryaos-sdr share <index> rtltcp`).
+
+[Service]
+Type=simple
+# %i = RTL device index; port = 1234 + index (0->1234, 1->1235, ...).
+ExecStart=/bin/sh -c 'exec /usr/bin/rtl_tcp -d %i -a "${AOS_RTLTCP_BIND:-0.0.0.0}" -p $((1234 + %i))'
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/shared_files/aryaos/systemd/aryaos-soapyremote.service
+++ b/shared_files/aryaos/systemd/aryaos-soapyremote.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=AryaOS SoapyRemote server — share all onboard SoapySDR devices over the network
+Documentation=https://github.com/pothosware/SoapyRemote
+# OFF by default. SoapyRemote is UNAUTHENTICATED — serves every local SoapySDR
+# device (RTL / LimeSDR / Airspy / HackRF) to any client that can reach it
+# (SDR++/SDRangel/GQRX via driver=remote). Enable only on a trusted / VPN network
+# and open the firewall (aryaos-soapyremote) deliberately, or bind to the VPN
+# address via AOS_SOAPY_BIND. Decoders holding a dongle keep it from the server —
+# stop them first (`aryaos-sdr share <index> soapy`).
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'exec /usr/bin/SoapySDRServer --bind="${AOS_SOAPY_BIND:-0.0.0.0:55132}"'
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -178,6 +178,14 @@ install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-serial-assign" "${ROOTFS_DIR}/
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-serial-assign.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-serial-assign.service"
 
+## Network SDR sharing (on-demand via `aryaos-sdr share`; NOT enabled by default,
+## firewall NOT opened — see the network-SDR docs). rtl_tcp per-dongle template +
+## SoapyRemote (all SoapySDR devices); firewalld service defs auto-install above.
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-rtltcp@.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-rtltcp@.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-soapyremote.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-soapyremote.service"
+
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).
 install -v -m 0644 "${SHARED_FILES}/aryaos/zram-generator.conf" "${ROOTFS_DIR}/etc/systemd/zram-generator.conf"


### PR DESCRIPTION
Phase 1 of the dynamic-SDR-tasking work: serve an onboard SDR **raw over the network** so a remote operator can tune/demod it (SDR++/SDRangel/GQRX/dump1090) instead of decoding on the box. A dongle does one job, so sharing **stops its decoder** first.

- **`aryaos-sdr share INDEX {rtltcp|soapy|off}`** + `share-status`.
- **`aryaos-rtltcp@.service`** (per dongle, port `1234+index`) + **`aryaos-soapyremote.service`** (all SoapySDR devices, `:55132`). Both **off by default**; bind overridable via `AOS_RTLTCP_BIND`/`AOS_SOAPY_BIND` (VPN).
- **firewalld defs** ship but are attached to **no zone** — raw unauthenticated SDR is deliberate opt-in. verify-image asserts they arent opened on public/hotspot.
- docs: `config/network-sdr.md`.

**Validated on hardware** (`.224`): `share 0 rtltcp` → rtl_tcp listening `:1234`; `off` + `role set air` → decoders restored.

**Phase 2** (decoder re-tasking ADS-B↔AIS via an ais-catcher RTL-mode path, + SpyServer) follows once you nod on its design.