### PR TITLE
feat(sdr): re-task a dongle between ADS-B / UAT / AIS (aryaos-sdr task)

### DIFF
--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -108,9 +108,35 @@ swapping the GPS puck or dAISy for a different make. Re-run by hand with
 `sudo aryaos-serial-assign`. To pin a device manually instead, set `DEVICES`/`SERIAL_PORT`
 yourself and disable `aryaos-serial-assign.service`.
 
+## Re-tasking a dongle
+
+An RTL-SDR is just a wideband receiver — the same dongle can decode ADS-B, UAT,
+or AIS depending on how it's tuned. **Re-task** a dongle to a different job on the
+fly, without a re-serialize or replug:
+
+```bash
+aryaos-sdr list                     # find the dongle index
+sudo aryaos-sdr task 1 ais          # dongle 1 -> AIS over-the-air (162 MHz)
+sudo aryaos-sdr task 1 adsb         # back to ADS-B 1090
+sudo aryaos-sdr task 1 uat          # UAT 978
+sudo aryaos-sdr task 1 off          # idle the dongle
+```
+
+- **`ais`** runs `ais-catcher` in **RTL mode** (a dedicated `ais-catcher-rtl@`
+  unit — the serial dAISy path is untouched) and feeds the same `aiscot →
+  charontak → TAK` chain. It needs a **VHF marine antenna** to hear vessels.
+- The job is **persisted** (`/etc/aryaos/sdr-tasks`) and re-applied at boot,
+  mapping the dongle by serial so it survives enumeration changes.
+- A **role apply** (`aryaos-role set …`) is authoritative and **clears** per-dongle
+  re-tasks.
+
+To hand the dongle to a remote operator instead of decoding locally, see
+[Network SDR sharing](network-sdr.md).
+
 ## See also
 
 - [Device roles](./device-roles.md) — how a role apply switches decoders
 - [Aircraft (ADS-B)](../deploy/air-adsb.md) — deploying the aircraft pipeline
 - [Maritime vessels (AIS)](../deploy/maritime-ais.md) — the AIS pipeline
+- [Network SDR sharing](network-sdr.md) — serve a dongle over the net
 - [CLI helpers](../reference/cli-helpers.md) — `aryaos-sdr`

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -294,6 +294,11 @@ require_unit aryaos-rtltcp@.service
 require_unit aryaos-soapyremote.service
 require_path /etc/firewalld/services/aryaos-rtltcp.xml
 require_path /etc/firewalld/services/aryaos-soapyremote.xml
+# SDR re-tasking (aryaos-sdr task): move a dongle between adsb/uat/ais; RTL-mode
+# AIS via a dedicated unit; persisted jobs re-applied at boot.
+require_grep 'task INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr task subcommand"
+require_unit ais-catcher-rtl@.service
+require_unit aryaos-sdr-tasks.service
 for z in public aryaos-hotspot; do
 	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
 		fail "${z} zone exposes a raw SDR share server by default (must be opt-in)"

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -135,6 +135,10 @@ set_role() {
 
 	config_set ARYAOS_ROLE "${role}"
 
+	# A role apply is the authoritative decoder layout — clear any per-dongle SDR
+	# re-tasks (aryaos-sdr task) so they don't fight the role at the next boot.
+	rm -f /etc/aryaos/sdr-tasks 2>/dev/null || true
+
 	# aryaos-serial-assign only wires the dAISy when ais-catcher is enabled (its
 	# elimination guard). It runs at boot before the role is known, so re-run it
 	# after enabling a role that uses AIS — otherwise selecting maritime/multi

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -21,7 +21,7 @@ SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
-	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | share INDEX {rtltcp|soapy|off} | share-status}" >&2
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|off} | share-status}" >&2
 	exit 2
 }
 
@@ -143,11 +143,92 @@ share_status() {
 	printf '{"rtltcp":"%s","soapyremote":"%s"}\n' "${rtltcp}" "${soapy}"
 }
 
+# --- Decoder re-tasking: point a dongle at a different job (adsb/uat/ais). ---
+# Live (takes effect now) + persisted to /etc/aryaos/sdr-tasks (serial=job) so a
+# boot re-apply restores it. Decoders bind the dongle by its current EEPROM
+# serial — no re-serialize/replug. `aryaos-role set` clears tasks (role wins).
+TASKS_FILE="/etc/aryaos/sdr-tasks"
+
+# rtl_test -d 99 exits non-zero (enumeration-only invocation); capture with a
+# guard so `set -e`/pipefail doesn't abort the caller.
+_serial_for_index() {
+	local js; js="$(list_devices 2>/dev/null)" || true
+	printf '%s' "${js}" | python3 -c 'import json,sys
+d=json.load(sys.stdin).get("devices",[]); i=int(sys.argv[1])
+print(next((x["serial"] for x in d if x["index"]==i), ""))' "$1"
+}
+_index_for_serial() {
+	local js; js="$(list_devices 2>/dev/null)" || true
+	printf '%s' "${js}" | python3 -c 'import json,sys
+d=json.load(sys.stdin).get("devices",[]); s=sys.argv[1]
+print(next((str(x["index"]) for x in d if x["serial"]==s), ""))' "$1"
+}
+_set_readsb_device() {
+	[[ -f /etc/default/readsb ]] || return 0
+	python3 - /etc/default/readsb "$1" <<'PY'
+import re,sys,pathlib
+f=pathlib.Path(sys.argv[1]); s=sys.argv[2]; t=f.read_text()
+line=f'RECEIVER_OPTIONS="--device-type rtlsdr --device {s}"'
+t=re.sub(r'^RECEIVER_OPTIONS=.*$',line,t,count=1,flags=re.M) if re.search(r'^RECEIVER_OPTIONS=',t,re.M) else t.rstrip()+"\n"+line+"\n"
+f.write_text(t)
+PY
+}
+_set_dump978_device() { [[ -f /etc/default/dump978-fa ]] && sed -i "s|serial=[^, \"']*|serial=$1|" /etc/default/dump978-fa || true; }
+
+_start_job() {  # index serial job
+	local index="$1" serial="$2" job="$3"
+	systemctl stop readsb dump1090-fa dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-rtltcp@${index}.service" >/dev/null 2>&1 || true
+	case "${job}" in
+		adsb) _set_readsb_device "${serial}"; systemctl start readsb ;;
+		uat)  _set_dump978_device "${serial}"; systemctl start dump978-fa ;;
+		ais)  systemctl start "ais-catcher-rtl@${index}.service"; systemctl start aiscot >/dev/null 2>&1 || true ;;
+	esac
+}
+
+task_sdr() {
+	local index="$1" job="$2" serial
+	[[ "${index}" =~ ^[0-9]+$ ]] || { echo "aryaos-sdr: INDEX must be a number" >&2; exit 2; }
+	serial="$(_serial_for_index "${index}")"
+	[[ -n "${serial}" ]] || { echo "aryaos-sdr: no RTL-SDR at index ${index}" >&2; exit 1; }
+	case "${job}" in adsb|uat|ais|off) : ;; *) echo "usage: aryaos-sdr task INDEX {adsb|uat|ais|off}" >&2; exit 2 ;; esac
+	mkdir -p /etc/aryaos; touch "${TASKS_FILE}"
+	grep -v "^${serial}=" "${TASKS_FILE}" > "${TASKS_FILE}.tmp" 2>/dev/null || true; mv "${TASKS_FILE}.tmp" "${TASKS_FILE}"
+	if [[ "${job}" == "off" ]]; then
+		systemctl stop readsb dump978-fa "ais-catcher-rtl@${index}.service" >/dev/null 2>&1 || true
+		echo "RTL-SDR ${index} (${serial}) idle."
+		return
+	fi
+	echo "${serial}=${job}" >> "${TASKS_FILE}"
+	_start_job "${index}" "${serial}" "${job}"
+	echo "RTL-SDR ${index} (${serial}) -> ${job}$( [[ ${job} == ais ]] && echo ' (162 MHz over-the-air; aiscot -> charontak -> TAK)' )."
+}
+
+apply_tasks() {  # boot re-apply: map each persisted serial->current index, start its job
+	[[ -f "${TASKS_FILE}" ]] || return 0
+	local line serial job index
+	while IFS='=' read -r serial job; do
+		[[ -n "${serial}" && -n "${job}" ]] || continue
+		index="$(_index_for_serial "${serial}")"
+		[[ -n "${index}" ]] || { echo "aryaos-sdr: tasked dongle ${serial} not present" >&2; continue; }
+		_start_job "${index}" "${serial}" "${job}"
+	done < "${TASKS_FILE}"
+}
+
 cmd="${1:-}"
 case "${cmd}" in
 	list)
 		require_tools
 		list_devices
+		;;
+	task)
+		require_root
+		require_tools
+		[[ $# -eq 3 ]] || usage
+		task_sdr "$2" "$3"
+		;;
+	apply-tasks)
+		require_root
+		apply_tasks
 		;;
 	set-serial)
 		require_root

--- a/shared_files/aryaos/systemd/ais-catcher-rtl@.service
+++ b/shared_files/aryaos/systemd/ais-catcher-rtl@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AryaOS ais-catcher (RTL mode) — decode AIS from RTL-SDR %i
+Documentation=https://github.com/jvde-github/AIS-catcher
+# Started by `aryaos-sdr task <index> ais` when re-tasking an RTL dongle to AIS.
+# This is the RTL/over-the-air path (ais-catcher auto-tunes the 161.975/162.025
+# MHz AIS channels); the serial dAISy path is unchanged on ais-catcher.service —
+# the two never run on the same input. Feeds aiscot on UDP 5050 (as the serial
+# path does), so the aiscot -> charontak -> TAK chain is identical.
+After=local-fs.target
+
+[Service]
+Type=simple
+# %i = RTL device index. AIS-catcher uses -d:<index> (a bare -d <n> means serial).
+# Root for reliable RTL USB access (admin-tasked service).
+ExecStart=/usr/bin/AIS-catcher -d:%i -u 127.0.0.1 5050 -N 8100
+Restart=on-failure
+RestartSec=3

--- a/shared_files/aryaos/systemd/aryaos-sdr-tasks.service
+++ b/shared_files/aryaos/systemd/aryaos-sdr-tasks.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AryaOS SDR re-task apply — restore per-dongle jobs at boot
+Documentation=https://github.com/snstac/aryaos
+# Re-applies /etc/aryaos/sdr-tasks (serial=job) after the role's decoders have
+# started, so a persisted re-task (e.g. an ADS-B dongle moved to AIS) wins. Maps
+# each persisted serial to its current index (enumeration-order-proof). No-op if
+# the file is empty. `aryaos-role set` clears this file (a role apply wins).
+After=local-fs.target readsb.service dump978-fa.service ais-catcher.service
+ConditionPathExists=/etc/aryaos/sdr-tasks
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-sdr apply-tasks
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -185,6 +185,12 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-rtltcp@.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-rtltcp@.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-soapyremote.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-soapyremote.service"
+## SDR re-tasking (aryaos-sdr task): RTL-mode AIS unit + boot re-apply of
+## persisted per-dongle jobs (/etc/aryaos/sdr-tasks).
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/ais-catcher-rtl@.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/ais-catcher-rtl@.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-sdr-tasks.service"
 
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).

--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -49,6 +49,8 @@ systemctl enable aryaos-radio-silence.service
 systemctl enable aryaos-crash-guard.service
 # Serial assignment: wire gpsd/ais-catcher to the right NMEA device before they start.
 systemctl enable aryaos-serial-assign.service
+# SDR re-task: re-apply persisted per-dongle jobs at boot.
+systemctl enable aryaos-sdr-tasks.service
 systemctl enable aryaos-safe-mode.service
 systemctl enable aryaos-boot-stable.timer
 


### PR DESCRIPTION
Phase 2a and the headline ask: **move an onboard RTL-SDR to a different job on the fly** — no re-serialize/replug.

- **`aryaos-sdr task INDEX {adsb|uat|ais|off}`** — resolves the dongle by its current serial, stops conflicting decoders, starts the target, **persists** to `/etc/aryaos/sdr-tasks`. `apply-tasks` re-applies at boot (serial→index mapped, enumeration-proof) via `aryaos-sdr-tasks.service`.
- **AIS from an RTL dongle** runs a dedicated `ais-catcher-rtl@<idx>` unit (`-d:<index>`, 162 MHz OTA) into the same `aiscot → charontak → TAK` chain; the serial dAISy path is **untouched**.
- `aryaos-role set` **clears** tasks (role apply is authoritative). verify-image + docs.

**Validated on hardware** (`.224`): `task 1 ais` re-tasked the ADS-B dongle (`stx:1090:0`) → AIS (ais-catcher **RTL tuner open**, aiscot active); `role air` restored ADS-B+UAT.

Follows Phase 1 (net-share #173). **SpyServer + APRS(direwolf)** tasking to follow.