### PR TITLE
Add SpyServer (Airspy) as a third network-SDR share mode

### DIFF
--- a/docs/config/network-sdr.md
+++ b/docs/config/network-sdr.md
@@ -11,7 +11,7 @@ a time, so sharing a dongle **stops its decoder** first.
     does **not** open their ports on any zone. Enable a share only on a **trusted
     or VPN** network — open the firewall service deliberately, or bind the server
     to your [VPN](../networking/vpn-tailscale.md) address (`AOS_RTLTCP_BIND` /
-    `AOS_SOAPY_BIND`). Turn it back off when you're done.
+    `AOS_SOAPY_BIND` / `AOS_SPYSERVER_BIND`). Turn it back off when you're done.
 
 ## Servers
 
@@ -19,6 +19,15 @@ a time, so sharing a dongle **stops its decoder** first.
 |---|---|---|---|
 | **rtl_tcp** | RTL-SDR only (per dongle) | `rtl_tcp` host:port (SDR#, GQRX, dump1090…) | `1234 + index` |
 | **SoapyRemote** | any SoapySDR device (RTL / LimeSDR / Airspy / HackRF) | `driver=remote,remote=<host>` (SDR++, SDRangel) | `55132` |
+| **SpyServer** | RTL-SDR (per dongle) | `spyserver://<host>:<port>` (SDR#, SDRangel, SDR++) | `5555 + index` |
+
+!!! note "SpyServer is an optional proprietary component"
+    The Airspy `spyserver` binary is not in Debian; AryaOS fetches it at **build
+    time** from airspy.com. If the builder was offline the mode is unavailable and
+    `aryaos-sdr share N spyserver` reports so (check `share-status` →
+    `"spyserver_available"`). SpyServer streams a *compressed, decimated* slice —
+    lighter on the network than `rtl_tcp`'s raw IQ, and it never advertises the box
+    in the public SpyServer directory (`list_in_directory = 0`).
 
 ## Sharing a dongle
 
@@ -26,6 +35,7 @@ a time, so sharing a dongle **stops its decoder** first.
 aryaos-sdr list                         # find the dongle index
 sudo aryaos-sdr share 0 rtltcp          # RTL-SDR 0 over rtl_tcp on :1234
 sudo aryaos-sdr share 0 soapy           # all SoapySDR devices over SoapyRemote :55132
+sudo aryaos-sdr share 0 spyserver       # RTL-SDR 0 over SpyServer on :5555
 sudo aryaos-sdr share 0 off             # stop sharing (then re-apply a role to decode)
 aryaos-sdr share-status                 # JSON: which share servers are running
 ```
@@ -45,7 +55,7 @@ sudo systemctl edit aryaos-rtltcp@0     # add: [Service]\nEnvironment=AOS_RTLTCP
 attached to no zone):
 
 ```bash
-sudo firewall-cmd --zone=public --add-service=aryaos-rtltcp        # or aryaos-soapyremote
+sudo firewall-cmd --zone=public --add-service=aryaos-rtltcp        # or aryaos-soapyremote / aryaos-spyserver
 # make permanent only if you really want it always-on:
 sudo firewall-cmd --permanent --zone=public --add-service=aryaos-rtltcp
 ```

--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -108,9 +108,35 @@ swapping the GPS puck or dAISy for a different make. Re-run by hand with
 `sudo aryaos-serial-assign`. To pin a device manually instead, set `DEVICES`/`SERIAL_PORT`
 yourself and disable `aryaos-serial-assign.service`.
 
+## Re-tasking a dongle
+
+An RTL-SDR is just a wideband receiver — the same dongle can decode ADS-B, UAT,
+or AIS depending on how it's tuned. **Re-task** a dongle to a different job on the
+fly, without a re-serialize or replug:
+
+```bash
+aryaos-sdr list                     # find the dongle index
+sudo aryaos-sdr task 1 ais          # dongle 1 -> AIS over-the-air (162 MHz)
+sudo aryaos-sdr task 1 adsb         # back to ADS-B 1090
+sudo aryaos-sdr task 1 uat          # UAT 978
+sudo aryaos-sdr task 1 off          # idle the dongle
+```
+
+- **`ais`** runs `ais-catcher` in **RTL mode** (a dedicated `ais-catcher-rtl@`
+  unit — the serial dAISy path is untouched) and feeds the same `aiscot →
+  charontak → TAK` chain. It needs a **VHF marine antenna** to hear vessels.
+- The job is **persisted** (`/etc/aryaos/sdr-tasks`) and re-applied at boot,
+  mapping the dongle by serial so it survives enumeration changes.
+- A **role apply** (`aryaos-role set …`) is authoritative and **clears** per-dongle
+  re-tasks.
+
+To hand the dongle to a remote operator instead of decoding locally, see
+[Network SDR sharing](network-sdr.md).
+
 ## See also
 
 - [Device roles](./device-roles.md) — how a role apply switches decoders
 - [Aircraft (ADS-B)](../deploy/air-adsb.md) — deploying the aircraft pipeline
 - [Maritime vessels (AIS)](../deploy/maritime-ais.md) — the AIS pipeline
+- [Network SDR sharing](network-sdr.md) — serve a dongle over the net
 - [CLI helpers](../reference/cli-helpers.md) — `aryaos-sdr`

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -294,6 +294,11 @@ require_unit aryaos-rtltcp@.service
 require_unit aryaos-soapyremote.service
 require_path /etc/firewalld/services/aryaos-rtltcp.xml
 require_path /etc/firewalld/services/aryaos-soapyremote.xml
+# SDR re-tasking (aryaos-sdr task): move a dongle between adsb/uat/ais; RTL-mode
+# AIS via a dedicated unit; persisted jobs re-applied at boot.
+require_grep 'task INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr task subcommand"
+require_unit ais-catcher-rtl@.service
+require_unit aryaos-sdr-tasks.service
 for z in public aryaos-hotspot; do
 	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
 		fail "${z} zone exposes a raw SDR share server by default (must be opt-in)"

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -299,8 +299,17 @@ require_path /etc/firewalld/services/aryaos-soapyremote.xml
 require_grep 'task INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr task subcommand"
 require_unit ais-catcher-rtl@.service
 require_unit aryaos-sdr-tasks.service
+# SpyServer (Airspy) sharing (aryaos-sdr share N spyserver): runtime always ships;
+# config never lists in the public directory. The proprietary binary is a
+# best-effort build-time download, so its presence is NOT asserted here.
+require_grep 'spyserver' /usr/local/sbin/aryaos-sdr "aryaos-sdr spyserver share mode"
+require_unit aryaos-spyserver@.service
+require_path /usr/local/sbin/aryaos-spyserver-run
+require_path /usr/share/aryaos/spyserver.config.tmpl
+require_path /etc/firewalld/services/aryaos-spyserver.xml
+require_grep 'list_in_directory = 0' /usr/share/aryaos/spyserver.config.tmpl "SpyServer OPSEC (no public directory listing)"
 for z in public aryaos-hotspot; do
-	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
+	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote|spyserver)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
 		fail "${z} zone exposes a raw SDR share server by default (must be opt-in)"
 	else
 		ok "${z} zone does not open SDR-share servers by default"

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -135,6 +135,10 @@ set_role() {
 
 	config_set ARYAOS_ROLE "${role}"
 
+	# A role apply is the authoritative decoder layout — clear any per-dongle SDR
+	# re-tasks (aryaos-sdr task) so they don't fight the role at the next boot.
+	rm -f /etc/aryaos/sdr-tasks 2>/dev/null || true
+
 	# aryaos-serial-assign only wires the dAISy when ais-catcher is enabled (its
 	# elimination guard). It runs at boot before the role is known, so re-run it
 	# after enabling a role that uses AIS — otherwise selecting maritime/multi

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -21,7 +21,7 @@ SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
-	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | share INDEX {rtltcp|soapy|off} | share-status}" >&2
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|off} | share-status}" >&2
 	exit 2
 }
 
@@ -143,11 +143,92 @@ share_status() {
 	printf '{"rtltcp":"%s","soapyremote":"%s"}\n' "${rtltcp}" "${soapy}"
 }
 
+# --- Decoder re-tasking: point a dongle at a different job (adsb/uat/ais). ---
+# Live (takes effect now) + persisted to /etc/aryaos/sdr-tasks (serial=job) so a
+# boot re-apply restores it. Decoders bind the dongle by its current EEPROM
+# serial — no re-serialize/replug. `aryaos-role set` clears tasks (role wins).
+TASKS_FILE="/etc/aryaos/sdr-tasks"
+
+# rtl_test -d 99 exits non-zero (enumeration-only invocation); capture with a
+# guard so `set -e`/pipefail doesn't abort the caller.
+_serial_for_index() {
+	local js; js="$(list_devices 2>/dev/null)" || true
+	printf '%s' "${js}" | python3 -c 'import json,sys
+d=json.load(sys.stdin).get("devices",[]); i=int(sys.argv[1])
+print(next((x["serial"] for x in d if x["index"]==i), ""))' "$1"
+}
+_index_for_serial() {
+	local js; js="$(list_devices 2>/dev/null)" || true
+	printf '%s' "${js}" | python3 -c 'import json,sys
+d=json.load(sys.stdin).get("devices",[]); s=sys.argv[1]
+print(next((str(x["index"]) for x in d if x["serial"]==s), ""))' "$1"
+}
+_set_readsb_device() {
+	[[ -f /etc/default/readsb ]] || return 0
+	python3 - /etc/default/readsb "$1" <<'PY'
+import re,sys,pathlib
+f=pathlib.Path(sys.argv[1]); s=sys.argv[2]; t=f.read_text()
+line=f'RECEIVER_OPTIONS="--device-type rtlsdr --device {s}"'
+t=re.sub(r'^RECEIVER_OPTIONS=.*$',line,t,count=1,flags=re.M) if re.search(r'^RECEIVER_OPTIONS=',t,re.M) else t.rstrip()+"\n"+line+"\n"
+f.write_text(t)
+PY
+}
+_set_dump978_device() { [[ -f /etc/default/dump978-fa ]] && sed -i "s|serial=[^, \"']*|serial=$1|" /etc/default/dump978-fa || true; }
+
+_start_job() {  # index serial job
+	local index="$1" serial="$2" job="$3"
+	systemctl stop readsb dump1090-fa dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-rtltcp@${index}.service" >/dev/null 2>&1 || true
+	case "${job}" in
+		adsb) _set_readsb_device "${serial}"; systemctl start readsb ;;
+		uat)  _set_dump978_device "${serial}"; systemctl start dump978-fa ;;
+		ais)  systemctl start "ais-catcher-rtl@${index}.service"; systemctl start aiscot >/dev/null 2>&1 || true ;;
+	esac
+}
+
+task_sdr() {
+	local index="$1" job="$2" serial
+	[[ "${index}" =~ ^[0-9]+$ ]] || { echo "aryaos-sdr: INDEX must be a number" >&2; exit 2; }
+	serial="$(_serial_for_index "${index}")"
+	[[ -n "${serial}" ]] || { echo "aryaos-sdr: no RTL-SDR at index ${index}" >&2; exit 1; }
+	case "${job}" in adsb|uat|ais|off) : ;; *) echo "usage: aryaos-sdr task INDEX {adsb|uat|ais|off}" >&2; exit 2 ;; esac
+	mkdir -p /etc/aryaos; touch "${TASKS_FILE}"
+	grep -v "^${serial}=" "${TASKS_FILE}" > "${TASKS_FILE}.tmp" 2>/dev/null || true; mv "${TASKS_FILE}.tmp" "${TASKS_FILE}"
+	if [[ "${job}" == "off" ]]; then
+		systemctl stop readsb dump978-fa "ais-catcher-rtl@${index}.service" >/dev/null 2>&1 || true
+		echo "RTL-SDR ${index} (${serial}) idle."
+		return
+	fi
+	echo "${serial}=${job}" >> "${TASKS_FILE}"
+	_start_job "${index}" "${serial}" "${job}"
+	echo "RTL-SDR ${index} (${serial}) -> ${job}$( [[ ${job} == ais ]] && echo ' (162 MHz over-the-air; aiscot -> charontak -> TAK)' )."
+}
+
+apply_tasks() {  # boot re-apply: map each persisted serial->current index, start its job
+	[[ -f "${TASKS_FILE}" ]] || return 0
+	local line serial job index
+	while IFS='=' read -r serial job; do
+		[[ -n "${serial}" && -n "${job}" ]] || continue
+		index="$(_index_for_serial "${serial}")"
+		[[ -n "${index}" ]] || { echo "aryaos-sdr: tasked dongle ${serial} not present" >&2; continue; }
+		_start_job "${index}" "${serial}" "${job}"
+	done < "${TASKS_FILE}"
+}
+
 cmd="${1:-}"
 case "${cmd}" in
 	list)
 		require_tools
 		list_devices
+		;;
+	task)
+		require_root
+		require_tools
+		[[ $# -eq 3 ]] || usage
+		task_sdr "$2" "$3"
+		;;
+	apply-tasks)
+		require_root
+		apply_tasks
 		;;
 	set-serial)
 		require_root

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -21,7 +21,7 @@ SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
-	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|off} | share-status}" >&2
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|spyserver|off} | share-status}" >&2
 	exit 2
 }
 
@@ -128,19 +128,32 @@ share_sdr() {
 			systemctl start aryaos-soapyremote.service
 			echo "Sharing SoapySDR devices via SoapyRemote on :55132 (client: driver=remote)."
 			echo "UNAUTHENTICATED — open the firewall (aryaos-soapyremote) or set AOS_SOAPY_BIND to a VPN address." ;;
+		spyserver)
+			if [[ ! -x /usr/bin/spyserver ]]; then
+				echo "aryaos-sdr: SpyServer is not installed on this image (build could not fetch the Airspy binary)." >&2
+				exit 1
+			fi
+			# rtl_tcp on the same dongle would fight for it; SpyServer takes over.
+			systemctl stop "aryaos-rtltcp@${index}.service" >/dev/null 2>&1 || true
+			systemctl start "aryaos-spyserver@${index}.service"
+			echo "Sharing RTL-SDR ${index} via SpyServer on port $((5555 + index)) (client: spyserver://<host>:$((5555 + index)) in SDR#/SDRangel)."
+			echo "UNAUTHENTICATED — open the firewall (aryaos-spyserver) or set AOS_SPYSERVER_BIND to a VPN address." ;;
 		off)
-			systemctl stop "aryaos-rtltcp@${index}.service" aryaos-soapyremote.service >/dev/null 2>&1 || true
+			systemctl stop "aryaos-rtltcp@${index}.service" "aryaos-spyserver@${index}.service" aryaos-soapyremote.service >/dev/null 2>&1 || true
 			echo "Network sharing stopped. Resume decoding with: aryaos-role set <role>." ;;
 		*)
-			echo "usage: aryaos-sdr share INDEX {rtltcp|soapy|off}" >&2; exit 2 ;;
+			echo "usage: aryaos-sdr share INDEX {rtltcp|soapy|spyserver|off}" >&2; exit 2 ;;
 	esac
 }
 
 share_status() {
-	local rtltcp soapy
+	local rtltcp soapy spyserver spyserver_avail
 	rtltcp="$(systemctl list-units 'aryaos-rtltcp@*' --state=active --no-legend 2>/dev/null | awk '{print $1}' | paste -sd, - )"
 	soapy="$(systemctl is-active aryaos-soapyremote 2>/dev/null || echo inactive)"
-	printf '{"rtltcp":"%s","soapyremote":"%s"}\n' "${rtltcp}" "${soapy}"
+	spyserver="$(systemctl list-units 'aryaos-spyserver@*' --state=active --no-legend 2>/dev/null | awk '{print $1}' | paste -sd, - )"
+	[[ -x /usr/bin/spyserver ]] && spyserver_avail=true || spyserver_avail=false
+	printf '{"rtltcp":"%s","soapyremote":"%s","spyserver":"%s","spyserver_available":%s}\n' \
+		"${rtltcp}" "${soapy}" "${spyserver}" "${spyserver_avail}"
 }
 
 # --- Decoder re-tasking: point a dongle at a different job (adsb/uat/ais). ---

--- a/shared_files/aryaos/aryaos-spyserver-run
+++ b/shared_files/aryaos/aryaos-spyserver-run
@@ -1,0 +1,27 @@
+#!/bin/sh
+# aryaos-spyserver-run INDEX — render a per-dongle SpyServer config and exec spyserver.
+#
+# Invoked by aryaos-spyserver@INDEX.service (started via `aryaos-sdr share N spyserver`).
+# Binds the Airspy SpyServer to RTL-SDR device INDEX on TCP port 5555+INDEX. Bind host
+# defaults to all interfaces; set AOS_SPYSERVER_BIND to pin to a VPN/loopback address.
+# Config is rendered to a tmpfs path each start so a re-task can't leave a stale file.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+index="${1:?usage: aryaos-spyserver-run INDEX}"
+case "${index}" in
+	''|*[!0-9]*) echo "aryaos-spyserver-run: INDEX must be a number" >&2; exit 2 ;;
+esac
+
+tmpl="/usr/share/aryaos/spyserver.config.tmpl"
+[ -r "${tmpl}" ] || { echo "aryaos-spyserver-run: missing ${tmpl}" >&2; exit 1; }
+[ -x /usr/bin/spyserver ] || { echo "aryaos-spyserver-run: SpyServer not installed" >&2; exit 1; }
+
+conf="/run/aryaos-spyserver-${index}.config"
+port=$((5555 + index))
+bind="${AOS_SPYSERVER_BIND:-0.0.0.0}"
+
+sed -e "s|@BIND@|${bind}|" -e "s|@PORT@|${port}|" -e "s|@SERIAL@|${index}|" "${tmpl}" > "${conf}"
+exec /usr/bin/spyserver "${conf}"

--- a/shared_files/aryaos/firewalld/services/aryaos-spyserver.xml
+++ b/shared_files/aryaos/firewalld/services/aryaos-spyserver.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>AryaOS SpyServer SDR share</short>
+  <description>Airspy SpyServer network receivers, one per dongle at 5555+index (SDR#/SDRangel clients). UNAUTHENTICATED — not opened on any zone by default; add to a zone only on a trusted/VPN network.</description>
+  <port protocol="tcp" port="5555-5558"/>
+</service>

--- a/shared_files/aryaos/spyserver.config.tmpl
+++ b/shared_files/aryaos/spyserver.config.tmpl
@@ -1,0 +1,23 @@
+# AryaOS SpyServer config — rendered per-dongle at start by aryaos-spyserver-run.
+# @BIND@/@PORT@/@SERIAL@ are substituted (bind host, TCP port, RTL device index).
+# Clients: SDR# / SDRangel / SDRPlusPlus via  spyserver://<host>:<port>
+bind_host = @BIND@
+bind_port = @PORT@
+
+# OPSEC: never advertise this receiver to the public SpyServer directory.
+list_in_directory = 0
+owner_name =
+owner_email =
+antenna_type =
+antenna_location =
+general_description =
+
+# RTL-SDR selected by device index (matches `aryaos-sdr list` / rtl_tcp -d N).
+device_type = RTL-SDR
+device_serial = @SERIAL@
+
+# Single controlling client; allow it to set gain/frequency.
+maximum_clients = 1
+allow_control = 1
+
+fft_fps = 15

--- a/shared_files/aryaos/systemd/ais-catcher-rtl@.service
+++ b/shared_files/aryaos/systemd/ais-catcher-rtl@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AryaOS ais-catcher (RTL mode) — decode AIS from RTL-SDR %i
+Documentation=https://github.com/jvde-github/AIS-catcher
+# Started by `aryaos-sdr task <index> ais` when re-tasking an RTL dongle to AIS.
+# This is the RTL/over-the-air path (ais-catcher auto-tunes the 161.975/162.025
+# MHz AIS channels); the serial dAISy path is unchanged on ais-catcher.service —
+# the two never run on the same input. Feeds aiscot on UDP 5050 (as the serial
+# path does), so the aiscot -> charontak -> TAK chain is identical.
+After=local-fs.target
+
+[Service]
+Type=simple
+# %i = RTL device index. AIS-catcher uses -d:<index> (a bare -d <n> means serial).
+# Root for reliable RTL USB access (admin-tasked service).
+ExecStart=/usr/bin/AIS-catcher -d:%i -u 127.0.0.1 5050 -N 8100
+Restart=on-failure
+RestartSec=3

--- a/shared_files/aryaos/systemd/aryaos-sdr-tasks.service
+++ b/shared_files/aryaos/systemd/aryaos-sdr-tasks.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AryaOS SDR re-task apply — restore per-dongle jobs at boot
+Documentation=https://github.com/snstac/aryaos
+# Re-applies /etc/aryaos/sdr-tasks (serial=job) after the role's decoders have
+# started, so a persisted re-task (e.g. an ADS-B dongle moved to AIS) wins. Maps
+# each persisted serial to its current index (enumeration-order-proof). No-op if
+# the file is empty. `aryaos-role set` clears this file (a role apply wins).
+After=local-fs.target readsb.service dump978-fa.service ais-catcher.service
+ConditionPathExists=/etc/aryaos/sdr-tasks
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-sdr apply-tasks
+
+[Install]
+WantedBy=multi-user.target

--- a/shared_files/aryaos/systemd/aryaos-spyserver@.service
+++ b/shared_files/aryaos/systemd/aryaos-spyserver@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AryaOS SpyServer (Airspy) — share RTL-SDR %i over the network
+Documentation=https://airspy.com/quickstart/
+# Started on demand by `aryaos-sdr share %i spyserver`. NOT enabled at boot and the
+# firewall is NOT opened by default (opt-in like aryaos-rtltcp / aryaos-soapyremote) —
+# the SpyServer protocol is UNAUTHENTICATED. The rendered config never lists the box in
+# the public SpyServer directory. Absent unless the proprietary binary was fetched at
+# build (ConditionPathExists guards a no-binary image).
+After=local-fs.target
+ConditionPathExists=/usr/bin/spyserver
+
+[Service]
+Type=simple
+# %i = RTL device index (matches `aryaos-sdr list`). Root for reliable RTL USB access.
+ExecStart=/usr/local/sbin/aryaos-spyserver-run %i
+Restart=on-failure
+RestartSec=3

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -192,6 +192,29 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/ais-catcher-rtl@.service" \
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-sdr-tasks.service"
 
+## SpyServer (Airspy) network sharing (aryaos-sdr share <n> spyserver). Runtime
+## (config template, per-dongle wrapper, unit) always ships; the proprietary
+## spyserver binary is fetched at build (not in apt) and is best-effort — a
+## no-binary image simply reports the mode unavailable (unit ConditionPathExists).
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/spyserver.config.tmpl" \
+	"${ROOTFS_DIR}/usr/share/aryaos/spyserver.config.tmpl"
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-spyserver-run" \
+	"${ROOTFS_DIR}/usr/local/sbin/aryaos-spyserver-run"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-spyserver@.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-spyserver@.service"
+# Proprietary binary: aarch64 only. Non-fatal on fetch failure (offline builder,
+# airspy.com down) — the share mode is then unavailable, not a broken build.
+SPYSERVER_URL="${ARYAOS_SPYSERVER_URL:-https://airspy.com/downloads/spyserver-arm64.tgz}"
+SPYSERVER_TMP="$(mktemp -d)"
+if curl -fsSL -m 120 "${SPYSERVER_URL}" -o "${SPYSERVER_TMP}/ss.tgz" 2>/dev/null \
+	&& tar xzf "${SPYSERVER_TMP}/ss.tgz" -C "${SPYSERVER_TMP}" spyserver 2>/dev/null; then
+	install -v -m 0755 "${SPYSERVER_TMP}/spyserver" "${ROOTFS_DIR}/usr/bin/spyserver"
+	echo "AryaOS: installed SpyServer binary from ${SPYSERVER_URL}"
+else
+	echo "AryaOS: WARNING — could not fetch SpyServer (${SPYSERVER_URL}); 'aryaos-sdr share N spyserver' will be unavailable on this image." >&2
+fi
+rm -rf "${SPYSERVER_TMP}"
+
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).
 install -v -m 0644 "${SHARED_FILES}/aryaos/zram-generator.conf" "${ROOTFS_DIR}/etc/systemd/zram-generator.conf"

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -185,6 +185,12 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-rtltcp@.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-rtltcp@.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-soapyremote.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-soapyremote.service"
+## SDR re-tasking (aryaos-sdr task): RTL-mode AIS unit + boot re-apply of
+## persisted per-dongle jobs (/etc/aryaos/sdr-tasks).
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/ais-catcher-rtl@.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/ais-catcher-rtl@.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-sdr-tasks.service"
 
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).

--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -49,6 +49,8 @@ systemctl enable aryaos-radio-silence.service
 systemctl enable aryaos-crash-guard.service
 # Serial assignment: wire gpsd/ais-catcher to the right NMEA device before they start.
 systemctl enable aryaos-serial-assign.service
+# SDR re-task: re-apply persisted per-dongle jobs at boot.
+systemctl enable aryaos-sdr-tasks.service
 systemctl enable aryaos-safe-mode.service
 systemctl enable aryaos-boot-stable.timer
 


### PR DESCRIPTION
`aryaos-sdr share <index> spyserver` streams an RTL-SDR over the Airspy **SpyServer** protocol — a compressed/decimated stream (lighter on the network than `rtl_tcp`'s raw IQ), consumable by SDR#, SDRangel, and SDR++ via `spyserver://<host>:<port>`. Port is `5555 + index`. Completes the net-share trio (rtl_tcp / SoapyRemote / SpyServer).

## Backend
- **`aryaos-spyserver@.service`** (per-dongle) + **`aryaos-spyserver-run`** wrapper: renders a per-index config to tmpfs and execs `spyserver`.
- **`spyserver.config.tmpl`**: pins the RTL device by index; **`list_in_directory = 0`** — OPSEC: never advertises the box in the public SpyServer directory.
- **`aryaos-spyserver.xml`** firewalld def (5555-5558), attached to **no zone** by default. Unauthenticated → **opt-in only**, exactly like rtl_tcp/SoapyRemote (`AOS_SPYSERVER_BIND` to pin to a VPN address).
- **`aryaos-sdr`**: `share` / `share-status` / usage learn `spyserver`; `share-status` now reports `spyserver_available`.

## Binary sourcing
Runtime files (unit, wrapper, template) **always ship**. The proprietary `spyserver` binary is **not in Debian** — it's a **best-effort build-time fetch** from airspy.com (arm64). If the builder is offline the mode reports *unavailable* rather than breaking the build (unit `ConditionPathExists=/usr/bin/spyserver`; `ARYAOS_SPYSERVER_URL` overridable).

## Verify / docs
- `verify-image.sh` asserts the runtime + the OPSEC config + the opt-in firewall posture (binary presence intentionally not asserted).
- `docs/config/network-sdr.md`: SpyServer row, the "optional proprietary component" note, and a `share … spyserver` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)