### PR TITLE
Add SpyServer (Airspy) as a third network-SDR share mode

### DIFF
--- a/docs/config/network-sdr.md
+++ b/docs/config/network-sdr.md
@@ -11,7 +11,7 @@ a time, so sharing a dongle **stops its decoder** first.
     does **not** open their ports on any zone. Enable a share only on a **trusted
     or VPN** network — open the firewall service deliberately, or bind the server
     to your [VPN](../networking/vpn-tailscale.md) address (`AOS_RTLTCP_BIND` /
-    `AOS_SOAPY_BIND`). Turn it back off when you're done.
+    `AOS_SOAPY_BIND` / `AOS_SPYSERVER_BIND`). Turn it back off when you're done.
 
 ## Servers
 
@@ -19,6 +19,15 @@ a time, so sharing a dongle **stops its decoder** first.
 |---|---|---|---|
 | **rtl_tcp** | RTL-SDR only (per dongle) | `rtl_tcp` host:port (SDR#, GQRX, dump1090…) | `1234 + index` |
 | **SoapyRemote** | any SoapySDR device (RTL / LimeSDR / Airspy / HackRF) | `driver=remote,remote=<host>` (SDR++, SDRangel) | `55132` |
+| **SpyServer** | RTL-SDR (per dongle) | `spyserver://<host>:<port>` (SDR#, SDRangel, SDR++) | `5555 + index` |
+
+!!! note "SpyServer is an optional proprietary component"
+    The Airspy `spyserver` binary is not in Debian; AryaOS fetches it at **build
+    time** from airspy.com. If the builder was offline the mode is unavailable and
+    `aryaos-sdr share N spyserver` reports so (check `share-status` →
+    `"spyserver_available"`). SpyServer streams a *compressed, decimated* slice —
+    lighter on the network than `rtl_tcp`'s raw IQ, and it never advertises the box
+    in the public SpyServer directory (`list_in_directory = 0`).
 
 ## Sharing a dongle
 
@@ -26,6 +35,7 @@ a time, so sharing a dongle **stops its decoder** first.
 aryaos-sdr list                         # find the dongle index
 sudo aryaos-sdr share 0 rtltcp          # RTL-SDR 0 over rtl_tcp on :1234
 sudo aryaos-sdr share 0 soapy           # all SoapySDR devices over SoapyRemote :55132
+sudo aryaos-sdr share 0 spyserver       # RTL-SDR 0 over SpyServer on :5555
 sudo aryaos-sdr share 0 off             # stop sharing (then re-apply a role to decode)
 aryaos-sdr share-status                 # JSON: which share servers are running
 ```
@@ -45,7 +55,7 @@ sudo systemctl edit aryaos-rtltcp@0     # add: [Service]\nEnvironment=AOS_RTLTCP
 attached to no zone):
 
 ```bash
-sudo firewall-cmd --zone=public --add-service=aryaos-rtltcp        # or aryaos-soapyremote
+sudo firewall-cmd --zone=public --add-service=aryaos-rtltcp        # or aryaos-soapyremote / aryaos-spyserver
 # make permanent only if you really want it always-on:
 sudo firewall-cmd --permanent --zone=public --add-service=aryaos-rtltcp
 ```

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -299,8 +299,17 @@ require_path /etc/firewalld/services/aryaos-soapyremote.xml
 require_grep 'task INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr task subcommand"
 require_unit ais-catcher-rtl@.service
 require_unit aryaos-sdr-tasks.service
+# SpyServer (Airspy) sharing (aryaos-sdr share N spyserver): runtime always ships;
+# config never lists in the public directory. The proprietary binary is a
+# best-effort build-time download, so its presence is NOT asserted here.
+require_grep 'spyserver' /usr/local/sbin/aryaos-sdr "aryaos-sdr spyserver share mode"
+require_unit aryaos-spyserver@.service
+require_path /usr/local/sbin/aryaos-spyserver-run
+require_path /usr/share/aryaos/spyserver.config.tmpl
+require_path /etc/firewalld/services/aryaos-spyserver.xml
+require_grep 'list_in_directory = 0' /usr/share/aryaos/spyserver.config.tmpl "SpyServer OPSEC (no public directory listing)"
 for z in public aryaos-hotspot; do
-	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
+	if grep -qsE '<service name="aryaos-(rtltcp|soapyremote|spyserver)"' "${MNT}/etc/firewalld/zones/${z}.xml"; then
 		fail "${z} zone exposes a raw SDR share server by default (must be opt-in)"
 	else
 		ok "${z} zone does not open SDR-share servers by default"

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -21,7 +21,7 @@ SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
-	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|off} | share-status}" >&2
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|spyserver|off} | share-status}" >&2
 	exit 2
 }
 
@@ -128,19 +128,32 @@ share_sdr() {
 			systemctl start aryaos-soapyremote.service
 			echo "Sharing SoapySDR devices via SoapyRemote on :55132 (client: driver=remote)."
 			echo "UNAUTHENTICATED — open the firewall (aryaos-soapyremote) or set AOS_SOAPY_BIND to a VPN address." ;;
+		spyserver)
+			if [[ ! -x /usr/bin/spyserver ]]; then
+				echo "aryaos-sdr: SpyServer is not installed on this image (build could not fetch the Airspy binary)." >&2
+				exit 1
+			fi
+			# rtl_tcp on the same dongle would fight for it; SpyServer takes over.
+			systemctl stop "aryaos-rtltcp@${index}.service" >/dev/null 2>&1 || true
+			systemctl start "aryaos-spyserver@${index}.service"
+			echo "Sharing RTL-SDR ${index} via SpyServer on port $((5555 + index)) (client: spyserver://<host>:$((5555 + index)) in SDR#/SDRangel)."
+			echo "UNAUTHENTICATED — open the firewall (aryaos-spyserver) or set AOS_SPYSERVER_BIND to a VPN address." ;;
 		off)
-			systemctl stop "aryaos-rtltcp@${index}.service" aryaos-soapyremote.service >/dev/null 2>&1 || true
+			systemctl stop "aryaos-rtltcp@${index}.service" "aryaos-spyserver@${index}.service" aryaos-soapyremote.service >/dev/null 2>&1 || true
 			echo "Network sharing stopped. Resume decoding with: aryaos-role set <role>." ;;
 		*)
-			echo "usage: aryaos-sdr share INDEX {rtltcp|soapy|off}" >&2; exit 2 ;;
+			echo "usage: aryaos-sdr share INDEX {rtltcp|soapy|spyserver|off}" >&2; exit 2 ;;
 	esac
 }
 
 share_status() {
-	local rtltcp soapy
+	local rtltcp soapy spyserver spyserver_avail
 	rtltcp="$(systemctl list-units 'aryaos-rtltcp@*' --state=active --no-legend 2>/dev/null | awk '{print $1}' | paste -sd, - )"
 	soapy="$(systemctl is-active aryaos-soapyremote 2>/dev/null || echo inactive)"
-	printf '{"rtltcp":"%s","soapyremote":"%s"}\n' "${rtltcp}" "${soapy}"
+	spyserver="$(systemctl list-units 'aryaos-spyserver@*' --state=active --no-legend 2>/dev/null | awk '{print $1}' | paste -sd, - )"
+	[[ -x /usr/bin/spyserver ]] && spyserver_avail=true || spyserver_avail=false
+	printf '{"rtltcp":"%s","soapyremote":"%s","spyserver":"%s","spyserver_available":%s}\n' \
+		"${rtltcp}" "${soapy}" "${spyserver}" "${spyserver_avail}"
 }
 
 # --- Decoder re-tasking: point a dongle at a different job (adsb/uat/ais). ---

--- a/shared_files/aryaos/aryaos-spyserver-run
+++ b/shared_files/aryaos/aryaos-spyserver-run
@@ -1,0 +1,27 @@
+#!/bin/sh
+# aryaos-spyserver-run INDEX — render a per-dongle SpyServer config and exec spyserver.
+#
+# Invoked by aryaos-spyserver@INDEX.service (started via `aryaos-sdr share N spyserver`).
+# Binds the Airspy SpyServer to RTL-SDR device INDEX on TCP port 5555+INDEX. Bind host
+# defaults to all interfaces; set AOS_SPYSERVER_BIND to pin to a VPN/loopback address.
+# Config is rendered to a tmpfs path each start so a re-task can't leave a stale file.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+index="${1:?usage: aryaos-spyserver-run INDEX}"
+case "${index}" in
+	''|*[!0-9]*) echo "aryaos-spyserver-run: INDEX must be a number" >&2; exit 2 ;;
+esac
+
+tmpl="/usr/share/aryaos/spyserver.config.tmpl"
+[ -r "${tmpl}" ] || { echo "aryaos-spyserver-run: missing ${tmpl}" >&2; exit 1; }
+[ -x /usr/bin/spyserver ] || { echo "aryaos-spyserver-run: SpyServer not installed" >&2; exit 1; }
+
+conf="/run/aryaos-spyserver-${index}.config"
+port=$((5555 + index))
+bind="${AOS_SPYSERVER_BIND:-0.0.0.0}"
+
+sed -e "s|@BIND@|${bind}|" -e "s|@PORT@|${port}|" -e "s|@SERIAL@|${index}|" "${tmpl}" > "${conf}"
+exec /usr/bin/spyserver "${conf}"

--- a/shared_files/aryaos/firewalld/services/aryaos-spyserver.xml
+++ b/shared_files/aryaos/firewalld/services/aryaos-spyserver.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>AryaOS SpyServer SDR share</short>
+  <description>Airspy SpyServer network receivers, one per dongle at 5555+index (SDR#/SDRangel clients). UNAUTHENTICATED — not opened on any zone by default; add to a zone only on a trusted/VPN network.</description>
+  <port protocol="tcp" port="5555-5558"/>
+</service>

--- a/shared_files/aryaos/spyserver.config.tmpl
+++ b/shared_files/aryaos/spyserver.config.tmpl
@@ -1,0 +1,23 @@
+# AryaOS SpyServer config — rendered per-dongle at start by aryaos-spyserver-run.
+# @BIND@/@PORT@/@SERIAL@ are substituted (bind host, TCP port, RTL device index).
+# Clients: SDR# / SDRangel / SDRPlusPlus via  spyserver://<host>:<port>
+bind_host = @BIND@
+bind_port = @PORT@
+
+# OPSEC: never advertise this receiver to the public SpyServer directory.
+list_in_directory = 0
+owner_name =
+owner_email =
+antenna_type =
+antenna_location =
+general_description =
+
+# RTL-SDR selected by device index (matches `aryaos-sdr list` / rtl_tcp -d N).
+device_type = RTL-SDR
+device_serial = @SERIAL@
+
+# Single controlling client; allow it to set gain/frequency.
+maximum_clients = 1
+allow_control = 1
+
+fft_fps = 15

--- a/shared_files/aryaos/systemd/aryaos-spyserver@.service
+++ b/shared_files/aryaos/systemd/aryaos-spyserver@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AryaOS SpyServer (Airspy) — share RTL-SDR %i over the network
+Documentation=https://airspy.com/quickstart/
+# Started on demand by `aryaos-sdr share %i spyserver`. NOT enabled at boot and the
+# firewall is NOT opened by default (opt-in like aryaos-rtltcp / aryaos-soapyremote) —
+# the SpyServer protocol is UNAUTHENTICATED. The rendered config never lists the box in
+# the public SpyServer directory. Absent unless the proprietary binary was fetched at
+# build (ConditionPathExists guards a no-binary image).
+After=local-fs.target
+ConditionPathExists=/usr/bin/spyserver
+
+[Service]
+Type=simple
+# %i = RTL device index (matches `aryaos-sdr list`). Root for reliable RTL USB access.
+ExecStart=/usr/local/sbin/aryaos-spyserver-run %i
+Restart=on-failure
+RestartSec=3

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -192,6 +192,29 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/ais-catcher-rtl@.service" \
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-sdr-tasks.service"
 
+## SpyServer (Airspy) network sharing (aryaos-sdr share <n> spyserver). Runtime
+## (config template, per-dongle wrapper, unit) always ships; the proprietary
+## spyserver binary is fetched at build (not in apt) and is best-effort — a
+## no-binary image simply reports the mode unavailable (unit ConditionPathExists).
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/spyserver.config.tmpl" \
+	"${ROOTFS_DIR}/usr/share/aryaos/spyserver.config.tmpl"
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-spyserver-run" \
+	"${ROOTFS_DIR}/usr/local/sbin/aryaos-spyserver-run"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-spyserver@.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-spyserver@.service"
+# Proprietary binary: aarch64 only. Non-fatal on fetch failure (offline builder,
+# airspy.com down) — the share mode is then unavailable, not a broken build.
+SPYSERVER_URL="${ARYAOS_SPYSERVER_URL:-https://airspy.com/downloads/spyserver-arm64.tgz}"
+SPYSERVER_TMP="$(mktemp -d)"
+if curl -fsSL -m 120 "${SPYSERVER_URL}" -o "${SPYSERVER_TMP}/ss.tgz" 2>/dev/null \
+	&& tar xzf "${SPYSERVER_TMP}/ss.tgz" -C "${SPYSERVER_TMP}" spyserver 2>/dev/null; then
+	install -v -m 0755 "${SPYSERVER_TMP}/spyserver" "${ROOTFS_DIR}/usr/bin/spyserver"
+	echo "AryaOS: installed SpyServer binary from ${SPYSERVER_URL}"
+else
+	echo "AryaOS: WARNING — could not fetch SpyServer (${SPYSERVER_URL}); 'aryaos-sdr share N spyserver' will be unavailable on this image." >&2
+fi
+rm -rf "${SPYSERVER_TMP}"
+
 ## Media longevity: zram swap (compressed RAM swap instead of a swapfile) +
 ## the packaged charontak.ini default (source of truth for factory reset).
 install -v -m 0644 "${SHARED_FILES}/aryaos/zram-generator.conf" "${ROOTFS_DIR}/etc/systemd/zram-generator.conf"


### PR DESCRIPTION
`aryaos-sdr share <index> spyserver` streams an RTL-SDR over the Airspy **SpyServer** protocol — a compressed/decimated stream (lighter on the network than `rtl_tcp`'s raw IQ), consumable by SDR#, SDRangel, and SDR++ via `spyserver://<host>:<port>`. Port is `5555 + index`. Completes the net-share trio (rtl_tcp / SoapyRemote / SpyServer).

## Backend
- **`aryaos-spyserver@.service`** (per-dongle) + **`aryaos-spyserver-run`** wrapper: renders a per-index config to tmpfs and execs `spyserver`.
- **`spyserver.config.tmpl`**: pins the RTL device by index; **`list_in_directory = 0`** — OPSEC: never advertises the box in the public SpyServer directory.
- **`aryaos-spyserver.xml`** firewalld def (5555-5558), attached to **no zone** by default. Unauthenticated → **opt-in only**, exactly like rtl_tcp/SoapyRemote (`AOS_SPYSERVER_BIND` to pin to a VPN address).
- **`aryaos-sdr`**: `share` / `share-status` / usage learn `spyserver`; `share-status` now reports `spyserver_available`.

## Binary sourcing
Runtime files (unit, wrapper, template) **always ship**. The proprietary `spyserver` binary is **not in Debian** — it's a **best-effort build-time fetch** from airspy.com (arm64). If the builder is offline the mode reports *unavailable* rather than breaking the build (unit `ConditionPathExists=/usr/bin/spyserver`; `ARYAOS_SPYSERVER_URL` overridable).

## Verify / docs
- `verify-image.sh` asserts the runtime + the OPSEC config + the opt-in firewall posture (binary presence intentionally not asserted).
- `docs/config/network-sdr.md`: SpyServer row, the "optional proprietary component" note, and a `share … spyserver` example.

## Cockpit surface
Driven by **ampledata/cockpit-spyserver#9** (starter-kit → SpyServer admin takeover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)