### PR TITLE
Install the cockpit-spyserver plugin in the image

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -213,6 +213,8 @@ require_pkg cockpit-dronecot
 require_pkg cockpit-charontak
 require_pkg cockpit-gpstak
 require_pkg cockpit-aryaos
+require_pkg cockpit-spyserver
+require_path /usr/share/cockpit/spyserver/manifest.json
 require_pkg readsb
 require_pkg python3-gps
 require_pkg ais-catcher

--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -30,6 +30,14 @@ COCKPIT_AISCOT_DEB_URL='https://github.com/snstac/cockpit-aiscot/releases/downlo
 curl -fsSL -o /usr/src/cockpit-aiscot_1.1.0_all.deb "${COCKPIT_AISCOT_DEB_URL}"
 dpkg -i /usr/src/cockpit-aiscot_1.1.0_all.deb
 
+# cockpit-spyserver: SpyServer SDR-share admin page (drives `aryaos-sdr share
+# N spyserver`, shipped by the AryaOS overlay). Installed here — the last heavy
+# dpkg stage before export — alongside the other Cockpit plugins. Sourced from
+# the plugin's GitHub release (nfpm-built _all.deb), same idiom as cockpit-aiscot.
+COCKPIT_SPYSERVER_DEB_URL='https://github.com/ampledata/cockpit-spyserver/releases/download/v0.1.0/cockpit-spyserver_0.1.0-1_all.deb'
+curl -fsSL -o /usr/src/cockpit-spyserver.deb "${COCKPIT_SPYSERVER_DEB_URL}"
+dpkg -i /usr/src/cockpit-spyserver.deb || apt-get install -f -y
+
 # Ensure apt-listchanges stays off before export-image finalise (see stage-base note).
 if dpkg -s apt-listchanges >/dev/null 2>&1; then
 	echo 'apt-listchanges apt-listchanges/frontend select none' | debconf-set-selections


### PR DESCRIPTION
Ships the **SpyServer** admin page in Cockpit, pairing the UI with the `aryaos-sdr share N spyserver` backend already in the overlay (#176).

- Installs `cockpit-spyserver_0.1.0-1_all.deb` (nfpm-built, from [ampledata/cockpit-spyserver v0.1.0](https://github.com/ampledata/cockpit-spyserver/releases/tag/v0.1.0)) in the last heavy-dpkg stage — same idiom as the `cockpit-aiscot` install right above it.
- `verify-image` asserts `cockpit-spyserver` is installed and its Cockpit manifest ships.

The plugin lists RTL-SDR dongles, starts/stops a per-dongle SpyServer share, and shows the `spyserver://host:port` client URL.

Follow-up (tracked): the plugin currently lives under `ampledata/` — promote it to `snstac/` + the snstac apt repo for full fleet consistency (it's installed from a GitHub release URL for now, exactly like cockpit-aiscot was).

🤖 Generated with [Claude Code](https://claude.com/claude-code)