### PR TITLE
Add APRS-over-RF gateway (aryaos-sdr task N aprs)

### DIFF
--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -117,6 +117,7 @@ fly, without a re-serialize or replug:
 ```bash
 aryaos-sdr list                     # find the dongle index
 sudo aryaos-sdr task 1 ais          # dongle 1 -> AIS over-the-air (162 MHz)
+sudo aryaos-sdr task 1 aprs         # dongle 1 -> APRS over-the-air (144.39 MHz)
 sudo aryaos-sdr task 1 adsb         # back to ADS-B 1090
 sudo aryaos-sdr task 1 uat          # UAT 978
 sudo aryaos-sdr task 1 off          # idle the dongle
@@ -125,6 +126,11 @@ sudo aryaos-sdr task 1 off          # idle the dongle
 - **`ais`** runs `ais-catcher` in **RTL mode** (a dedicated `ais-catcher-rtl@`
   unit — the serial dAISy path is untouched) and feeds the same `aiscot →
   charontak → TAK` chain. It needs a **VHF marine antenna** to hear vessels.
+- **`aprs`** decodes 1200-baud packet **APRS on 144.39 MHz** (North America):
+  `rtl_fm` → **Dire Wolf** (`aryaos-direwolf@N`, KISS TNC on `:8001`, receive-only)
+  → **aprscot** (KISS input, ≥ 8.2.0) → `charontak → TAK`. Fully **offline** — no
+  APRS-IS internet. Needs a **2 m (VHF) antenna**. Single dongle at a time (one
+  APRS channel).
 - The job is **persisted** (`/etc/aryaos/sdr-tasks`) and re-applied at boot,
   mapping the dongle by serial so it survives enumeration changes.
 - A **role apply** (`aryaos-role set …`) is authoritative and **clears** per-dongle

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -301,6 +301,13 @@ require_path /etc/firewalld/services/aryaos-soapyremote.xml
 require_grep 'task INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr task subcommand"
 require_unit ais-catcher-rtl@.service
 require_unit aryaos-sdr-tasks.service
+# APRS over RF (aryaos-sdr task N aprs): rtl_fm + Dire Wolf -> KISS -> aprscot -> CoT.
+require_grep 'aprs' /usr/local/sbin/aryaos-sdr "aryaos-sdr aprs task job"
+require_pkg direwolf
+require_pkg aprscot
+require_unit aryaos-direwolf@.service
+require_path /etc/aryaos/direwolf.conf
+require_grep 'KISS_HOST=127.0.0.1' /etc/default/aprscot "aprscot reads local KISS TNC (offline, not APRS-IS)"
 # SpyServer (Airspy) sharing (aryaos-sdr share N spyserver): runtime always ships;
 # config never lists in the public directory. The proprietary binary is a
 # best-effort build-time download, so its presence is NOT asserted here.

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -305,6 +305,8 @@ require_unit aryaos-sdr-tasks.service
 require_grep 'aprs' /usr/local/sbin/aryaos-sdr "aryaos-sdr aprs task job"
 require_pkg direwolf
 require_pkg aprscot
+require_pkg cockpit-aprscot
+require_path /usr/share/cockpit/aprscot/manifest.json
 require_unit aryaos-direwolf@.service
 require_path /etc/aryaos/direwolf.conf
 require_grep 'KISS_HOST=127.0.0.1' /etc/default/aprscot "aprscot reads local KISS TNC (offline, not APRS-IS)"

--- a/shared_files/aryaos/aprscot.default
+++ b/shared_files/aryaos/aprscot.default
@@ -1,0 +1,14 @@
+# AryaOS aprscot config — /etc/default/aprscot
+#
+# aprscot reads APRS from the local Dire Wolf KISS TNC (started by
+# `aryaos-sdr task <index> aprs` on 144.39 MHz) and forwards it to the charontak
+# hub as CoT. KISS_HOST set => aprscot uses the offline RF path, NOT APRS-IS
+# (no internet; EMCON-friendly). COT_URL is inherited from aryaos-config.txt via
+# the service's EnvironmentFile; charontak fans out to Mesh SA / TAK Server.
+#
+# aprscot is NOT enabled at boot — it is started/stopped by aryaos-sdr task aprs
+# (and re-applied at boot by aryaos-sdr-tasks when an APRS re-task is persisted).
+
+# Read from the local Dire Wolf KISS-over-TCP TNC (aryaos-direwolf@N serves :8001).
+KISS_HOST=127.0.0.1
+KISS_PORT=8001

--- a/shared_files/aryaos/aryaos-safe-mode
+++ b/shared_files/aryaos/aryaos-safe-mode
@@ -42,7 +42,7 @@ THRESHOLD=3
 
 # Sensor/SDR services whose USB peripherals draw the current that browns the box
 # out. Keep in sync with aryaos-role's all_managed_units.
-MANAGED_UNITS="readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot"
+MANAGED_UNITS="readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot aprscot dronecot sikw00fcot"
 
 require_root() {
 	if [[ "$(id -u)" != "0" ]]; then

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -21,7 +21,7 @@ SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
-	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|off} | apply-tasks | share INDEX {rtltcp|soapy|spyserver|off} | share-status}" >&2
+	echo "usage: aryaos-sdr {list | set-serial INDEX SERIAL | task INDEX {adsb|uat|ais|aprs|off} | apply-tasks | share INDEX {rtltcp|soapy|spyserver|off} | share-status}" >&2
 	exit 2
 }
 
@@ -190,11 +190,12 @@ _set_dump978_device() { [[ -f /etc/default/dump978-fa ]] && sed -i "s|serial=[^,
 
 _start_job() {  # index serial job
 	local index="$1" serial="$2" job="$3"
-	systemctl stop readsb dump1090-fa dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-rtltcp@${index}.service" >/dev/null 2>&1 || true
+	systemctl stop readsb dump1090-fa dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-rtltcp@${index}.service" "aryaos-direwolf@${index}.service" aprscot >/dev/null 2>&1 || true
 	case "${job}" in
 		adsb) _set_readsb_device "${serial}"; systemctl start readsb ;;
 		uat)  _set_dump978_device "${serial}"; systemctl start dump978-fa ;;
 		ais)  systemctl start "ais-catcher-rtl@${index}.service"; systemctl start aiscot >/dev/null 2>&1 || true ;;
+		aprs) systemctl start "aryaos-direwolf@${index}.service"; systemctl start aprscot >/dev/null 2>&1 || true ;;
 	esac
 }
 
@@ -203,17 +204,20 @@ task_sdr() {
 	[[ "${index}" =~ ^[0-9]+$ ]] || { echo "aryaos-sdr: INDEX must be a number" >&2; exit 2; }
 	serial="$(_serial_for_index "${index}")"
 	[[ -n "${serial}" ]] || { echo "aryaos-sdr: no RTL-SDR at index ${index}" >&2; exit 1; }
-	case "${job}" in adsb|uat|ais|off) : ;; *) echo "usage: aryaos-sdr task INDEX {adsb|uat|ais|off}" >&2; exit 2 ;; esac
+	case "${job}" in adsb|uat|ais|aprs|off) : ;; *) echo "usage: aryaos-sdr task INDEX {adsb|uat|ais|aprs|off}" >&2; exit 2 ;; esac
 	mkdir -p /etc/aryaos; touch "${TASKS_FILE}"
 	grep -v "^${serial}=" "${TASKS_FILE}" > "${TASKS_FILE}.tmp" 2>/dev/null || true; mv "${TASKS_FILE}.tmp" "${TASKS_FILE}"
 	if [[ "${job}" == "off" ]]; then
-		systemctl stop readsb dump978-fa "ais-catcher-rtl@${index}.service" >/dev/null 2>&1 || true
+		systemctl stop readsb dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-direwolf@${index}.service" aprscot >/dev/null 2>&1 || true
 		echo "RTL-SDR ${index} (${serial}) idle."
 		return
 	fi
 	echo "${serial}=${job}" >> "${TASKS_FILE}"
 	_start_job "${index}" "${serial}" "${job}"
-	echo "RTL-SDR ${index} (${serial}) -> ${job}$( [[ ${job} == ais ]] && echo ' (162 MHz over-the-air; aiscot -> charontak -> TAK)' )."
+	local note=""
+	[[ ${job} == ais ]] && note=' (162 MHz over-the-air; aiscot -> charontak -> TAK)'
+	[[ ${job} == aprs ]] && note=' (144.39 MHz over-the-air; direwolf -> aprscot -> charontak -> TAK)'
+	echo "RTL-SDR ${index} (${serial}) -> ${job}${note}."
 }
 
 apply_tasks() {  # boot re-apply: map each persisted serial->current index, start its job

--- a/shared_files/aryaos/direwolf.conf
+++ b/shared_files/aryaos/direwolf.conf
@@ -1,0 +1,23 @@
+# AryaOS Dire Wolf config — SDR APRS receive-only, KISS-over-TCP out.
+#
+# Used by aryaos-direwolf@N.service, which pipes rtl_fm audio into direwolf:
+#   rtl_fm -f 144.39M -s 24000 ... - | direwolf -c /etc/aryaos/direwolf.conf -r 24000 -t 0 -
+# Audio comes from stdin (direwolf started with the `-` argument), so no ADEVICE
+# line here. Decoded APRS frames are served as KISS over TCP :8001, which aprscot
+# reads (KISS_HOST/KISS_PORT) and forwards to TAK as CoT. Receive-only: no PTT,
+# no digipeat, no IGate (offline/EMCON-friendly — nothing is transmitted).
+
+# One 1200-baud AFSK channel (VHF APRS, 144.39 MHz in North America).
+ACHANNELS 1
+CHANNEL 0
+MODEM 1200
+
+# No transmit hardware — receive/decode only.
+PTT OFF
+
+# KISS TCP server for the CoT gateway (aprscot). AGW server left off.
+KISSPORT 8001
+AGWPORT 0
+
+# Station identity is informational only (never transmitted in RX-only mode).
+MYCALL N0CALL

--- a/shared_files/aryaos/systemd/aryaos-direwolf@.service
+++ b/shared_files/aryaos/systemd/aryaos-direwolf@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=AryaOS APRS receiver — rtl_fm + Dire Wolf on RTL-SDR %i (KISS :8001)
+Documentation=https://github.com/wb2osz/direwolf
+# Started on demand by `aryaos-sdr task %i aprs`. Tunes RTL-SDR %i to 144.39 MHz
+# (North America VHF APRS), FM-demodulates with rtl_fm, and hands 24 kHz audio to
+# Dire Wolf which decodes 1200-baud AFSK APRS and serves it as KISS over TCP :8001.
+# aprscot (aprscot.service, KISS_HOST=127.0.0.1 KISS_PORT=8001) turns that into CoT
+# for charontak -> TAK. Receive-only; nothing is transmitted. Off by default.
+After=local-fs.target
+ConditionPathExists=/usr/bin/direwolf
+
+[Service]
+Type=simple
+# %i = RTL device index (matches `aryaos-sdr list`). rtl_fm emits 24 kHz s16 mono on
+# stdout; direwolf reads it from stdin (`-`) and matches with -r 24000. -t 0 disables
+# color codes so journald stays clean. APRS RX frequency is 144.390 MHz (US/NA).
+ExecStart=/bin/sh -c 'exec /usr/bin/rtl_fm -d %i -f 144.39M -s 24000 -o 4 - | /usr/bin/direwolf -c /etc/aryaos/direwolf.conf -r 24000 -D 1 -t 0 -'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -34,7 +34,7 @@ dpkg -i /usr/src/cockpit-aiscot_1.1.0_all.deb
 # N spyserver`, shipped by the AryaOS overlay). Installed here — the last heavy
 # dpkg stage before export — alongside the other Cockpit plugins. Sourced from
 # the plugin's GitHub release (nfpm-built _all.deb), same idiom as cockpit-aiscot.
-COCKPIT_SPYSERVER_DEB_URL='https://github.com/ampledata/cockpit-spyserver/releases/download/v0.1.0/cockpit-spyserver_0.1.0-1_all.deb'
+COCKPIT_SPYSERVER_DEB_URL='https://github.com/snstac/cockpit-spyserver/releases/download/v0.1.0/cockpit-spyserver_0.1.0-1_all.deb'
 curl -fsSL -o /usr/src/cockpit-spyserver.deb "${COCKPIT_SPYSERVER_DEB_URL}"
 dpkg -i /usr/src/cockpit-spyserver.deb || apt-get install -f -y
 
@@ -52,3 +52,17 @@ systemctl enable cockpit.socket
 grep -qxF "EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/aiscot.service || \
 grep -qxF "EnvironmentFile=-/etc/aryaos/aryaos-config.txt" /lib/systemd/system/aiscot.service || \
 sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=\/etc\/aryaos\/aryaos-config.txt" /lib/systemd/system/aiscot.service
+
+# APRS over RF (aryaos-sdr task N aprs): Dire Wolf decodes 144.39 MHz APRS to a
+# KISS TNC; aprscot (>= 8.2.0, KISS input) forwards it to charontak as CoT.
+# direwolf from Debian; aprscot from the snstac apt repo. Both are OFF by default
+# (task-driven) — aprscot must NOT auto-connect to APRS-IS over the internet.
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends direwolf aprscot
+# aprscot reads the local Dire Wolf KISS TNC (offline), not APRS-IS.
+install -v -m 0644 /aryaos/shared_files/aryaos/aprscot.default /etc/default/aprscot 2>/dev/null || \
+	install -v -m 0644 "${SHARED_FILES:-/aryaos/shared_files}/aryaos/aprscot.default" /etc/default/aprscot
+# Inherit COT_URL (charontak) from the site config, like aiscot.
+grep -qxF "EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/aprscot.service || \
+sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=\/etc\/aryaos\/aryaos-config.txt" /lib/systemd/system/aprscot.service
+# Task-driven only: do not start aprscot at boot (would hit APRS-IS with no KISS peer).
+systemctl disable aprscot >/dev/null 2>&1 || true

--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -38,6 +38,12 @@ COCKPIT_SPYSERVER_DEB_URL='https://github.com/snstac/cockpit-spyserver/releases/
 curl -fsSL -o /usr/src/cockpit-spyserver.deb "${COCKPIT_SPYSERVER_DEB_URL}"
 dpkg -i /usr/src/cockpit-spyserver.deb || apt-get install -f -y
 
+# cockpit-aprscot: APRS-to-TAK gateway admin page (manages the aprscot service
+# used by `aryaos-sdr task N aprs`). Same install idiom as the other plugins.
+COCKPIT_APRSCOT_DEB_URL='https://github.com/snstac/cockpit-aprscot/releases/download/v0.1.0/cockpit-aprscot_0.1.0-1_all.deb'
+curl -fsSL -o /usr/src/cockpit-aprscot.deb "${COCKPIT_APRSCOT_DEB_URL}"
+dpkg -i /usr/src/cockpit-aprscot.deb || apt-get install -f -y
+
 # Ensure apt-listchanges stays off before export-image finalise (see stage-base note).
 if dpkg -s apt-listchanges >/dev/null 2>&1; then
 	echo 'apt-listchanges apt-listchanges/frontend select none' | debconf-set-selections

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -166,7 +166,7 @@ for unit in aryaos-crash-guard.service aryaos-safe-mode.service aryaos-boot-stab
 done
 # Safe-mode gate: sensor/SDR services must not start while /etc/aryaos/safe-mode
 # exists (kept in sync with aryaos-safe-mode MANAGED_UNITS / aryaos-role).
-for svc in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot; do
+for svc in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot aprscot dronecot sikw00fcot; do
 	install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/safe-mode.conf" \
 		"${ROOTFS_DIR}/etc/systemd/system/${svc}.service.d/safe-mode.conf"
 done
@@ -191,6 +191,16 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/ais-catcher-rtl@.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/ais-catcher-rtl@.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-sdr-tasks.service"
+
+## APRS over RF (aryaos-sdr task <index> aprs): rtl_fm + Dire Wolf decode 144.39
+## MHz to a KISS TNC, which aprscot reads and forwards to charontak as CoT. The
+## direwolf + aprscot packages are installed in stage-aiscot (apt). Off by default
+## (task-driven). aprscot.default points aprscot at the local KISS TNC (offline,
+## not APRS-IS). aprscot's own service/config come from its deb; the KISS drop-in
+## and COT_URL inheritance are wired in stage-aiscot.
+install -v -m 0644 "${SHARED_FILES}/aryaos/direwolf.conf" "${ROOTFS_DIR}/etc/aryaos/direwolf.conf"
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-direwolf@.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-direwolf@.service"
 
 ## SpyServer (Airspy) network sharing (aryaos-sdr share <n> spyserver). Runtime
 ## (config template, per-dongle wrapper, unit) always ships; the proprietary


### PR DESCRIPTION
Re-task an RTL-SDR to receive **1200-baud APRS on 144.39 MHz** and forward it to TAK, **fully offline**:

```
rtl_fm | Dire Wolf (KISS TNC :8001, RX-only) → aprscot (KISS input) → charontak → TAK
```

## Changes
- **`aryaos-sdr`**: new `aprs` task job (`sudo aryaos-sdr task N aprs`) — start/stop/boot-apply, added to stop-lists + usage.
- **`aryaos-direwolf@.service`** + **`direwolf.conf`**: per-dongle `rtl_fm | direwolf`, **receive-only** (no PTT/IGate — nothing transmits, EMCON-safe), KISS on `:8001`.
- **stage-aiscot**: installs `direwolf` (Debian) + `aprscot` (snstac apt repo); **disables aprscot at boot** (task-driven, must not hit APRS-IS); `/etc/default/aprscot` sets `KISS_HOST=127.0.0.1`; aprscot inherits `COT_URL` (charontak) from the site config like aiscot.
- Safe-mode gate + `MANAGED_UNITS` include `aprscot`.
- `verify-image` asserts the package/unit/config; `radios-sdr.md` documents the `aprs` task.
- Also flips the **cockpit-spyserver** deb URL `ampledata` → `snstac` (repo was promoted this session).

## Depends on
**aprscot v8.2.0** (KISS input, snstac/aprscot#18) published to the apt repo — merge/release that first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)