### PR TITLE
fix(aprs): stage aprscot.default into rootfs (chroot path bug)

### DIFF
--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -65,8 +65,7 @@ sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=\/etc\/aryaos\/ar
 # (task-driven) — aprscot must NOT auto-connect to APRS-IS over the internet.
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends direwolf aprscot
 # aprscot reads the local Dire Wolf KISS TNC (offline), not APRS-IS.
-install -v -m 0644 /aryaos/shared_files/aryaos/aprscot.default /etc/default/aprscot 2>/dev/null || \
-	install -v -m 0644 "${SHARED_FILES:-/aryaos/shared_files}/aryaos/aprscot.default" /etc/default/aprscot
+install -v -m 0644 /usr/share/aryaos/aprscot.default /etc/default/aprscot
 # Inherit COT_URL (charontak) from the site config, like aiscot.
 grep -qxF "EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/aprscot.service || \
 sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=\/etc\/aryaos\/aryaos-config.txt" /lib/systemd/system/aprscot.service

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -201,6 +201,11 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
 install -v -m 0644 "${SHARED_FILES}/aryaos/direwolf.conf" "${ROOTFS_DIR}/etc/aryaos/direwolf.conf"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-direwolf@.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-direwolf@.service"
+# Stage the aprscot KISS drop-in into the rootfs; stage-aiscot (chroot, where
+# shared_files is not mounted) copies it over /etc/default/aprscot AFTER the
+# aprscot deb lands (so it wins over the deb's APRS-IS default).
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/aprscot.default" \
+	"${ROOTFS_DIR}/usr/share/aryaos/aprscot.default"
 
 ## SpyServer (Airspy) network sharing (aryaos-sdr share <n> spyserver). Runtime
 ## (config template, per-dongle wrapper, unit) always ships; the proprietary


### PR DESCRIPTION
The APRS image build (#178) failed: the stage-aiscot **chroot** script installed `aprscot.default` from `/aryaos/shared_files/…`, which isn't mounted inside the chroot — `install` errored under `bash -e` and aborted the build.

Fix: stage the file into the rootfs (`/usr/share/aryaos/aprscot.default`) from the host-side `stage-aryaos/00-run.sh`, and copy it over `/etc/default/aprscot` from that in-rootfs path in the chroot (after the aprscot deb lands, so the KISS drop-in wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)