### PR TITLE
Add SAPIENT C-UAS gateway (sapientcot) to the image

### DIFF
--- a/docs/admin/gateways.md
+++ b/docs/admin/gateways.md
@@ -11,6 +11,8 @@ Open any of them from Cockpit's left menu.
 | adsbcot | `adsbcot` | `/etc/default/adsbcot` | ADS-B aircraft → CoT |
 | aiscot | `aiscot` | `/etc/default/aiscot` | AIS vessels → CoT |
 | dronecot | `dronecot` | `/etc/default/dronecot` | Remote ID drones → CoT |
+| aprscot | `aprscot` | `/etc/default/aprscot` | APRS (KISS TNC / APRS-IS) → CoT |
+| — *(roadmap)* | `sapientcot` | `/etc/default/sapientcot` | SAPIENT (BSI Flex 335) C-UAS → CoT |
 | lincot | `lincot` | `/etc/default/lincot` | This host's position/beacon → CoT |
 | gps | *(gpsd)* | — | On-board GNSS receiver |
 | gpstak | `gpstak` | `/etc/default/gpstak` | Network GPS to ATAK/WinTAK |

--- a/docs/config/device-roles.md
+++ b/docs/config/device-roles.md
@@ -20,7 +20,7 @@ Roles only toggle the **sensor** units on top of that core. This means a unit al
 | `multi` | All pipelines (default) | ADS-B + AIS + drones |
 | `air` | Aircraft only (ADS-B 1090/978) | `<decoder>`, `dump978-fa`, `adsbcot`, `gdltak` |
 | `maritime` | Vessels only (AIS) | `ais-catcher`, `aiscot` |
-| `cuas` | Counter-UAS (drones) | `dronecot`, `sikw00fcot` |
+| `cuas` | Counter-UAS (drones) | `dronecot`, `sikw00fcot`, `sapientcot` |
 | `relay` | CoT routing only | *(none)* |
 
 `<decoder>` is the 1090 MHz decoder chosen by [`ARYAOS_ADSB_DECODER`](./site-config.md#ads-b-radios): `readsb` (default) or `dump1090-fa`.
@@ -31,10 +31,12 @@ The exact unit sets, from `aryaos-role`:
 |-------|-------|
 | ADS-B (`air`, `multi`) | `readsb` **or** `dump1090-fa`, `dump978-fa`, `adsbcot`, `gdltak` |
 | AIS (`maritime`, `multi`) | `ais-catcher`, `aiscot` |
-| Drones (`cuas`, `multi`) | `dronecot`, `sikw00fcot` |
+| Drones / C-UAS (`cuas`, `multi`) | `dronecot`, `sikw00fcot`, `sapientcot` |
 
 !!! note "Units missing from your image are skipped"
-    Applying a role enables the role's units and disables all other managed units. Optional units that are not installed on your image (for example a decoder you did not build) are simply skipped — not errors. The full managed set the helper touches is: `readsb`, `dump1090-fa`, `dump978-fa`, `adsbcot`, `gdltak`, `ais-catcher`, `aiscot`, `dronecot`, `sikw00fcot`.
+    Applying a role enables the role's units and disables all other managed units. Optional units that are not installed on your image (for example a decoder you did not build) are simply skipped — not errors. The full managed set the helper touches is: `readsb`, `dump1090-fa`, `dump978-fa`, `adsbcot`, `gdltak`, `ais-catcher`, `aiscot`, `dronecot`, `sikw00fcot`, `sapientcot`.
+
+    `sapientcot` bridges a [SAPIENT (BSI Flex 335)](https://github.com/snstac/sapientcot) C-UAS sensor/fusion network into TAK. Point `SAPIENT_HOST`/`SAPIENT_PORT` in `/etc/default/sapientcot` at your SAPIENT node; with no reachable node it simply retries.
 
 !!! tip "The unused ADS-B decoder is always disabled"
     Applying a role also disables whichever 1090 MHz decoder you are *not* using. That is why re-applying the role is the way to make a decoder change in the site config take effect — see [Radios & SDRs](./radios-sdr.md).

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -310,6 +310,17 @@ require_path /usr/share/cockpit/aprscot/manifest.json
 require_unit aryaos-direwolf@.service
 require_path /etc/aryaos/direwolf.conf
 require_grep 'KISS_HOST=127.0.0.1' /etc/default/aprscot "aprscot reads local KISS TNC (offline, not APRS-IS)"
+# SAPIENT C-UAS gateway (sapientcot): BSI Flex 335 DetectionReports -> CoT; the
+# sapient-msg protobuf binding is pip-installed (not in Debian apt).
+require_pkg sapientcot
+require_path /etc/default/sapientcot
+require_grep 'SAPIENT_HOST' /etc/default/sapientcot "sapientcot SAPIENT node config"
+if compgen -G "${MNT}/usr/local/lib/python3*/dist-packages/sapient_msg" >/dev/null 2>&1 || \
+   compgen -G "${MNT}/usr/lib/python3*/dist-packages/sapient_msg" >/dev/null 2>&1; then
+	ok "sapient-msg protobuf bindings installed"
+else
+	fail "sapient-msg python bindings not found (pip install in stage-aiscot)"
+fi
 # SpyServer (Airspy) sharing (aryaos-sdr share N spyserver): runtime always ships;
 # config never lists in the public directory. The proprietary binary is a
 # best-effort build-time download, so its presence is NOT asserted here.

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -66,7 +66,7 @@ role_units() {
 	local adsb_units ais_units drone_units
 	adsb_units="$(adsb_decoder_unit) dump978-fa adsbcot gdltak"
 	ais_units="ais-catcher aiscot"
-	drone_units="dronecot sikw00fcot"
+	drone_units="dronecot sikw00fcot sapientcot"
 	case "${role}" in
 		multi)    echo "${adsb_units} ${ais_units} ${drone_units}" ;;
 		air)      echo "${adsb_units}" ;;
@@ -78,7 +78,7 @@ role_units() {
 }
 
 all_managed_units() {
-	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot"
+	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot sapientcot"
 }
 
 unit_exists() {

--- a/shared_files/aryaos/aryaos-safe-mode
+++ b/shared_files/aryaos/aryaos-safe-mode
@@ -42,7 +42,7 @@ THRESHOLD=3
 
 # Sensor/SDR services whose USB peripherals draw the current that browns the box
 # out. Keep in sync with aryaos-role's all_managed_units.
-MANAGED_UNITS="readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot aprscot dronecot sikw00fcot"
+MANAGED_UNITS="readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot aprscot dronecot sikw00fcot sapientcot"
 
 require_root() {
 	if [[ "$(id -u)" != "0" ]]; then

--- a/shared_files/aryaos/sapientcot.default
+++ b/shared_files/aryaos/sapientcot.default
@@ -1,0 +1,15 @@
+# AryaOS sapientcot config — /etc/default/sapientcot
+#
+# sapientcot reads SAPIENT (BSI Flex 335) DetectionReports from a C-UAS Fusion /
+# HLDMM node and forwards them to charontak as CoT. COT_URL is inherited from
+# aryaos-config.txt via the service's EnvironmentFile (charontak -> Mesh SA / TAK).
+#
+# Point SAPIENT_HOST/PORT at your SAPIENT fusion node before enabling. Part of the
+# cuas / multi roles; with no reachable node it simply retries (harmless).
+
+# SAPIENT Fusion/HLDMM node to read from (set this to your C-UAS network).
+SAPIENT_HOST=127.0.0.1
+SAPIENT_PORT=5010
+
+# SAPIENT standard version: v2 (BSI Flex 335 v2.0) or v1.
+SAPIENT_VERSION=v2

--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -71,3 +71,17 @@ grep -qxF "EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/ap
 sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=\/etc\/aryaos\/aryaos-config.txt" /lib/systemd/system/aprscot.service
 # Task-driven only: do not start aprscot at boot (would hit APRS-IS with no KISS peer).
 systemctl disable aprscot >/dev/null 2>&1 || true
+
+# SAPIENT C-UAS gateway (sapientcot): SAPIENT (BSI Flex 335) DetectionReports -> CoT.
+# sapientcot deb Depends only on pytak (apt); its sapient-msg protobuf binding is
+# NOT in Debian, so pip-install it (pure-python; pulls a matching protobuf).
+SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.0/sapientcot_0.1.0-1_all.deb'
+curl -fsSL -o /usr/src/sapientcot.deb "${SAPIENTCOT_DEB_URL}"
+dpkg -i /usr/src/sapientcot.deb || apt-get install -f -y
+pip3 install --break-system-packages --no-input sapient-msg || \
+	python3 -m pip install --break-system-packages --no-input sapient-msg
+install -v -m 0644 /usr/share/aryaos/sapientcot.default /etc/default/sapientcot
+grep -qxF "EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/sapientcot.service || \
+sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=\/etc\/aryaos\/aryaos-config.txt" /lib/systemd/system/sapientcot.service
+# Off at boot; the cuas/multi role (or the operator) starts it once a SAPIENT node is set.
+systemctl disable sapientcot >/dev/null 2>&1 || true

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -166,7 +166,7 @@ for unit in aryaos-crash-guard.service aryaos-safe-mode.service aryaos-boot-stab
 done
 # Safe-mode gate: sensor/SDR services must not start while /etc/aryaos/safe-mode
 # exists (kept in sync with aryaos-safe-mode MANAGED_UNITS / aryaos-role).
-for svc in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot aprscot dronecot sikw00fcot; do
+for svc in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot aprscot dronecot sikw00fcot sapientcot; do
 	install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/safe-mode.conf" \
 		"${ROOTFS_DIR}/etc/systemd/system/${svc}.service.d/safe-mode.conf"
 done
@@ -206,6 +206,13 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-direwolf@.service" \
 # aprscot deb lands (so it wins over the deb's APRS-IS default).
 install -v -D -m 0644 "${SHARED_FILES}/aryaos/aprscot.default" \
 	"${ROOTFS_DIR}/usr/share/aryaos/aprscot.default"
+
+## SAPIENT C-UAS (sapientcot): SAPIENT (BSI Flex 335) DetectionReports -> CoT.
+## sapientcot + its sapient-msg python dep are installed in stage-aiscot (apt +
+## pip). Stage the config into the rootfs; the chroot copies it over
+## /etc/default/sapientcot after the deb lands (same pattern as aprscot.default).
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/sapientcot.default" \
+	"${ROOTFS_DIR}/usr/share/aryaos/sapientcot.default"
 
 ## SpyServer (Airspy) network sharing (aryaos-sdr share <n> spyserver). Runtime
 ## (config template, per-dongle wrapper, unit) always ships; the proprietary


### PR DESCRIPTION
Wires **[snstac/sapientcot v0.1.0](https://github.com/snstac/sapientcot)** (SAPIENT BSI Flex 335 DetectionReports → CoT) into AryaOS as a C-UAS gateway alongside dronecot.

- **stage-aiscot** installs the sapientcot deb (release URL) + **pip-installs `sapient-msg`** (its protobuf binding isn't in Debian apt), copies the config over `/etc/default/sapientcot` (staged host-side into the rootfs to avoid the chroot `shared_files` path bug), inherits `COT_URL` from the site config, disabled at boot.
- **aryaos-role**: `sapientcot` joins the **cuas + multi** roles and the managed set.
- **Safe-mode** gate + `MANAGED_UNITS` include it.
- **verify-image** asserts the package, config, and the pip-installed `sapient_msg` bindings.
- **Docs**: device-roles + gateways tables.

Operator points `SAPIENT_HOST`/`SAPIENT_PORT` at their fusion node; with no reachable node it retries harmlessly. cockpit-sapientcot plugin is a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)