### PR TITLE
Bump sapientcot to v0.1.1 (SAPIENT little-endian framing fix)

### DIFF
--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -75,7 +75,7 @@ systemctl disable aprscot >/dev/null 2>&1 || true
 # SAPIENT C-UAS gateway (sapientcot): SAPIENT (BSI Flex 335) DetectionReports -> CoT.
 # sapientcot deb Depends only on pytak (apt); its sapient-msg protobuf binding is
 # NOT in Debian, so pip-install it (pure-python; pulls a matching protobuf).
-SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.0/sapientcot_0.1.0-1_all.deb'
+SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.1/sapientcot_0.1.1-1_all.deb'
 curl -fsSL -o /usr/src/sapientcot.deb "${SAPIENTCOT_DEB_URL}"
 dpkg -i /usr/src/sapientcot.deb || apt-get install -f -y
 pip3 install --break-system-packages --no-input sapient-msg || \


### PR DESCRIPTION
sapientcot v0.1.0 framed the SAPIENT length prefix **big-endian** and would fail to decode a real feed. **v0.1.1** fixes it to **4-byte little-endian**, confirmed against the DSTL Apex middleware (`struct.pack("<I", len)` / `struct.unpack("<I", ...)`, explicitly "matching protobuf's little-endian convention"). Bumps the image's install URL to v0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)