### PR TITLE
Add cockpit-sapientcot plugin + sapientcot v0.1.2 (general ISR mapping)

### DIFF
--- a/docs/admin/gateways.md
+++ b/docs/admin/gateways.md
@@ -12,7 +12,7 @@ Open any of them from Cockpit's left menu.
 | aiscot | `aiscot` | `/etc/default/aiscot` | AIS vessels → CoT |
 | dronecot | `dronecot` | `/etc/default/dronecot` | Remote ID drones → CoT |
 | aprscot | `aprscot` | `/etc/default/aprscot` | APRS (KISS TNC / APRS-IS) → CoT |
-| — *(roadmap)* | `sapientcot` | `/etc/default/sapientcot` | SAPIENT (BSI Flex 335) C-UAS → CoT |
+| sapientcot | `sapientcot` | `/etc/default/sapientcot` | SAPIENT (BSI Flex 335) C-UAS / ISR → CoT |
 | lincot | `lincot` | `/etc/default/lincot` | This host's position/beacon → CoT |
 | gps | *(gpsd)* | — | On-board GNSS receiver |
 | gpstak | `gpstak` | `/etc/default/gpstak` | Network GPS to ATAK/WinTAK |

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -313,6 +313,8 @@ require_grep 'KISS_HOST=127.0.0.1' /etc/default/aprscot "aprscot reads local KIS
 # SAPIENT C-UAS gateway (sapientcot): BSI Flex 335 DetectionReports -> CoT; the
 # sapient-msg protobuf binding is pip-installed (not in Debian apt).
 require_pkg sapientcot
+require_pkg cockpit-sapientcot
+require_path /usr/share/cockpit/sapientcot/manifest.json
 require_path /etc/default/sapientcot
 require_grep 'SAPIENT_HOST' /etc/default/sapientcot "sapientcot SAPIENT node config"
 if compgen -G "${MNT}/usr/local/lib/python3*/dist-packages/sapient_msg" >/dev/null 2>&1 || \

--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -44,6 +44,12 @@ COCKPIT_APRSCOT_DEB_URL='https://github.com/snstac/cockpit-aprscot/releases/down
 curl -fsSL -o /usr/src/cockpit-aprscot.deb "${COCKPIT_APRSCOT_DEB_URL}"
 dpkg -i /usr/src/cockpit-aprscot.deb || apt-get install -f -y
 
+# cockpit-sapientcot: SAPIENT (BSI Flex 335) C-UAS/ISR gateway admin page
+# (manages the sapientcot service). Same install idiom as the other plugins.
+COCKPIT_SAPIENTCOT_DEB_URL='https://github.com/snstac/cockpit-sapientcot/releases/download/v0.1.0/cockpit-sapientcot_0.1.0-1_all.deb'
+curl -fsSL -o /usr/src/cockpit-sapientcot.deb "${COCKPIT_SAPIENTCOT_DEB_URL}"
+dpkg -i /usr/src/cockpit-sapientcot.deb || apt-get install -f -y
+
 # Ensure apt-listchanges stays off before export-image finalise (see stage-base note).
 if dpkg -s apt-listchanges >/dev/null 2>&1; then
 	echo 'apt-listchanges apt-listchanges/frontend select none' | debconf-set-selections
@@ -75,7 +81,7 @@ systemctl disable aprscot >/dev/null 2>&1 || true
 # SAPIENT C-UAS gateway (sapientcot): SAPIENT (BSI Flex 335) DetectionReports -> CoT.
 # sapientcot deb Depends only on pytak (apt); its sapient-msg protobuf binding is
 # NOT in Debian, so pip-install it (pure-python; pulls a matching protobuf).
-SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.1/sapientcot_0.1.1-1_all.deb'
+SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.2/sapientcot_0.1.2-1_all.deb'
 curl -fsSL -o /usr/src/sapientcot.deb "${SAPIENTCOT_DEB_URL}"
 dpkg -i /usr/src/sapientcot.deb || apt-get install -f -y
 pip3 install --break-system-packages --no-input sapient-msg || \


### PR DESCRIPTION
Completes the SAPIENT integration.

- **cockpit-sapientcot** ([snstac/cockpit-sapientcot v0.1.0](https://github.com/snstac/cockpit-sapientcot)) — Cockpit admin page for the sapientcot service (config editor + service control + logs), forked from cockpit-aprscot. Now every gateway has a plugin.
- **sapientcot → v0.1.2** — general ISR classification→CoT **battle-dimension** mapping (person→ground infantry, vehicle→ground vehicle, vessel→sea, drone→air; unclassified→unknown ground). SAPIENT isn't only C-UAS. `COT_TYPE` still forces one type for a pure C-UAS laydown.
- verify-image asserts the plugin + manifest; gateways doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)