### PR TITLE
Bump sapientcot to v0.1.3 (RangeBearing resolution + sensor CoT)

### DIFF
--- a/stages/stage-aiscot/00-install/01-run-chroot.sh
+++ b/stages/stage-aiscot/00-install/01-run-chroot.sh
@@ -81,7 +81,7 @@ systemctl disable aprscot >/dev/null 2>&1 || true
 # SAPIENT C-UAS gateway (sapientcot): SAPIENT (BSI Flex 335) DetectionReports -> CoT.
 # sapientcot deb Depends only on pytak (apt); its sapient-msg protobuf binding is
 # NOT in Debian, so pip-install it (pure-python; pulls a matching protobuf).
-SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.2/sapientcot_0.1.2-1_all.deb'
+SAPIENTCOT_DEB_URL='https://github.com/snstac/sapientcot/releases/download/v0.1.3/sapientcot_0.1.3-1_all.deb'
 curl -fsSL -o /usr/src/sapientcot.deb "${SAPIENTCOT_DEB_URL}"
 dpkg -i /usr/src/sapientcot.deb || apt-get install -f -y
 pip3 install --break-system-packages --no-input sapient-msg || \


### PR DESCRIPTION
sapientcot **v0.1.3**: resolves RangeBearing detections (radar/RF/acoustic sensors report range+azimuth from themselves — projected to lat/lon via the node's StatusReport location, instead of being dropped) and emits **sensor-position CoT** so SAPIENT nodes appear on the map. Supersedes the v0.1.2 image (general-ISR classification mapping, also included). 🤖 Generated with [Claude Code](https://claude.com/claude-code)