### PR TITLE
aryaos-sdr: universal SoapySDR support (Airspy/HackRF/Lime, not just RTL)

### DIFF
--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -108,24 +108,33 @@ swapping the GPS puck or dAISy for a different make. Re-run by hand with
 `sudo aryaos-serial-assign`. To pin a device manually instead, set `DEVICES`/`SERIAL_PORT`
 yourself and disable `aryaos-serial-assign.service`.
 
-## Re-tasking a dongle
+## Re-tasking an SDR
 
-An RTL-SDR is just a wideband receiver — the same dongle can decode ADS-B, UAT,
-or AIS depending on how it's tuned. **Re-task** a dongle to a different job on the
-fly, without a re-serialize or replug:
+An SDR is just a wideband receiver — the same radio can decode ADS-B, UAT, AIS,
+or APRS depending on how it's tuned. **Re-task** it to a different job on the fly,
+without a re-serialize or replug:
 
 ```bash
-aryaos-sdr list                     # find the dongle index
-sudo aryaos-sdr task 1 ais          # dongle 1 -> AIS over-the-air (162 MHz)
-sudo aryaos-sdr task 1 aprs         # dongle 1 -> APRS over-the-air (144.39 MHz)
+aryaos-sdr list                     # find the SDR index (shows driver + serial)
+sudo aryaos-sdr task 1 ais          # SDR 1 -> AIS over-the-air (162 MHz)
+sudo aryaos-sdr task 1 aprs         # SDR 1 -> APRS over-the-air (144.39 MHz)
 sudo aryaos-sdr task 1 adsb         # back to ADS-B 1090
 sudo aryaos-sdr task 1 uat          # UAT 978
-sudo aryaos-sdr task 1 off          # idle the dongle
+sudo aryaos-sdr task 1 off          # idle the SDR
 ```
 
-- **`ais`** runs `ais-catcher` in **RTL mode** (a dedicated `ais-catcher-rtl@`
-  unit — the serial dAISy path is untouched) and feeds the same `aiscot →
-  charontak → TAK` chain. It needs a **VHF marine antenna** to hear vessels.
+!!! info "Any SDR, not just RTL-SDR (DragonEgg)"
+    `aryaos-sdr` enumerates and tasks **any SoapySDR device** — RTL-SDR, **Airspy**,
+    HackRF, LimeSDR — via `SoapySDRUtil`, not only RTL dongles. `list` reports each
+    device's **driver** and **serial**; tasking builds the right decoder invocation
+    (native `rtlsdr`, or `--device-type soapy driver=<drv>` for the rest).
+    Current coverage: **ADS-B** and **AIS** work on any SDR; **UAT** and **APRS**
+    are RTL-SDR only for now (UAT needs `dump978-fa`; APRS needs an FM demod —
+    `rx_tools` for non-RTL is a roadmap item).
+
+- **`ais`** runs `ais-catcher` on the tasked SDR (`aryaos-ais-sdr` for any device;
+  the serial dAISy path is untouched) and feeds the same `aiscot → charontak → TAK`
+  chain. It needs a **VHF marine antenna** to hear vessels.
 - **`aprs`** decodes 1200-baud packet **APRS on 144.39 MHz** (North America):
   `rtl_fm` → **Dire Wolf** (`aryaos-direwolf@N`, KISS TNC on `:8001`, receive-only)
   → **aprscot** (KISS input, ≥ 8.2.0) → `charontak → TAK`. Fully **offline** — no

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -301,6 +301,12 @@ require_path /etc/firewalld/services/aryaos-soapyremote.xml
 require_grep 'task INDEX' /usr/local/sbin/aryaos-sdr "aryaos-sdr task subcommand"
 require_unit ais-catcher-rtl@.service
 require_unit aryaos-sdr-tasks.service
+# Universal SDR (DragonEgg): aryaos-sdr enumerates/tasks any SoapySDR device
+# (Airspy/HackRF/Lime), not just RTL. Generic AIS unit for non-RTL SDRs.
+require_grep 'SoapySDRUtil' /usr/local/sbin/aryaos-sdr "aryaos-sdr universal SoapySDR enumeration"
+require_grep 'device-type soapy' /usr/local/sbin/aryaos-sdr "aryaos-sdr tasks non-RTL SDRs via SoapySDR"
+require_unit aryaos-ais-sdr.service
+require_pkg soapysdr-tools
 # APRS over RF (aryaos-sdr task N aprs): rtl_fm + Dire Wolf -> KISS -> aprscot -> CoT.
 require_grep 'aprs' /usr/local/sbin/aryaos-sdr "aryaos-sdr aprs task job"
 require_pkg direwolf

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -16,8 +16,8 @@
 
 set -euo pipefail
 
-# Units that claim RTL-SDR devices; stopped/restarted around EEPROM writes.
-SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher"
+# Units that claim SDR devices; stopped/restarted around EEPROM writes / shares.
+SDR_UNITS="readsb dump1090-fa dump978-fa ais-catcher aryaos-ais-sdr"
 SERIAL_RE='^[A-Za-z0-9:._-]{1,32}$'
 
 usage() {
@@ -33,19 +33,52 @@ require_root() {
 }
 
 require_tools() {
-	if ! command -v rtl_test >/dev/null 2>&1 || ! command -v rtl_eeprom >/dev/null 2>&1; then
-		echo "aryaos-sdr: rtl-sdr tools not installed (apt install rtl-sdr)" >&2
+	# Enumeration/tasking needs a Soapy enumerator or (legacy) rtl_test.
+	if ! command -v SoapySDRUtil >/dev/null 2>&1 && ! command -v rtl_test >/dev/null 2>&1; then
+		echo "aryaos-sdr: no SDR enumerator (apt install soapysdr-tools or rtl-sdr)" >&2
 		exit 1
 	fi
 }
 
-# rtl_test with an out-of-range index prints the enumeration to stderr and
-# exits without claiming any device:
-#   Found 2 device(s):
-#     0:  Realtek, RTL2838UHIDIR, SN: stx:1090:0
-#     1:  Realtek, RTL2838UHIDIR, SN: stx:978:0
+require_rtl_eeprom() {
+	if ! command -v rtl_eeprom >/dev/null 2>&1; then
+		echo "aryaos-sdr: rtl_eeprom not installed (apt install rtl-sdr) — RTL-SDR only" >&2
+		exit 1
+	fi
+}
+
+# Universal SDR enumeration via SoapySDR — covers every driver with a Soapy
+# module installed (rtlsdr, airspy, hackrf, lms7/LimeSDR, ...), not just RTL, so
+# a DragonEgg with an Airspy/HackRF/Lime is listed too. Each `Found device N`
+# block yields driver + serial + label. Falls back to rtl_test on hosts without
+# SoapySDRUtil. `product`/`vendor` kept (from label) for backward compatibility.
 list_devices() {
-	rtl_test -d 99 2>&1 | python3 -c '
+	if command -v SoapySDRUtil >/dev/null 2>&1; then
+		SoapySDRUtil --find 2>/dev/null | python3 -c '
+import json
+import re
+import sys
+
+devices = []
+cur = None
+for line in sys.stdin:
+    m = re.match(r"\s*Found device (\d+)", line)
+    if m:
+        cur = {"index": int(m.group(1)), "driver": "", "serial": "",
+               "label": "", "product": "", "vendor": ""}
+        devices.append(cur)
+        continue
+    if cur is None:
+        continue
+    km = re.match(r"\s*(driver|serial|label|product|manufacturer)\s*=\s*(.*)$", line.rstrip())
+    if km:
+        key = "vendor" if km.group(1) == "manufacturer" else km.group(1)
+        cur[key] = km.group(2).strip()
+print(json.dumps({"devices": devices}))
+'
+	else
+		# Legacy RTL-only fallback: rtl_test -d 99 lists dongles on stderr.
+		rtl_test -d 99 2>&1 | python3 -c '
 import json
 import re
 import sys
@@ -56,16 +89,19 @@ for line in sys.stdin:
     if m:
         devices.append({
             "index": int(m.group(1)),
+            "driver": "rtlsdr",
             "vendor": m.group(2).strip(),
             "product": m.group(3).strip(),
             "serial": m.group(4).strip(),
         })
 print(json.dumps({"devices": devices}))
 '
+	fi
 }
 
 set_serial() {
 	local index="$1" serial="$2"
+	require_rtl_eeprom  # EEPROM serials are an RTL-SDR concept only.
 	if [[ ! "${index}" =~ ^[0-9]+$ ]]; then
 		echo "aryaos-sdr: INDEX must be a number" >&2
 		exit 2
@@ -125,8 +161,10 @@ share_sdr() {
 			echo "Sharing RTL-SDR ${index} via rtl_tcp on port $((1234 + index))."
 			echo "UNAUTHENTICATED — open the firewall (aryaos-rtltcp) or set AOS_RTLTCP_BIND to a VPN address." ;;
 		soapy)
+			# SoapyRemote exposes ALL local SoapySDR devices (RTL-SDR, Airspy,
+			# HackRF, LimeSDR, ...) — the universal network-share for any SDR.
 			systemctl start aryaos-soapyremote.service
-			echo "Sharing SoapySDR devices via SoapyRemote on :55132 (client: driver=remote)."
+			echo "Sharing all SoapySDR devices (RTL/Airspy/HackRF/Lime) via SoapyRemote on :55132 (client: driver=remote,remote=<host>)."
 			echo "UNAUTHENTICATED — open the firewall (aryaos-soapyremote) or set AOS_SOAPY_BIND to a VPN address." ;;
 		spyserver)
 			if [[ ! -x /usr/bin/spyserver ]]; then
@@ -164,70 +202,113 @@ TASKS_FILE="/etc/aryaos/sdr-tasks"
 
 # rtl_test -d 99 exits non-zero (enumeration-only invocation); capture with a
 # guard so `set -e`/pipefail doesn't abort the caller.
-_serial_for_index() {
+# Look up a field (serial / driver / index) from the enumeration by another.
+_field_for_index() {  # index field
 	local js; js="$(list_devices 2>/dev/null)" || true
 	printf '%s' "${js}" | python3 -c 'import json,sys
-d=json.load(sys.stdin).get("devices",[]); i=int(sys.argv[1])
-print(next((x["serial"] for x in d if x["index"]==i), ""))' "$1"
+d=json.load(sys.stdin).get("devices",[]); i=int(sys.argv[1]); f=sys.argv[2]
+print(next((str(x.get(f,"")) for x in d if x["index"]==i), ""))' "$1" "$2"
 }
+_serial_for_index() { _field_for_index "$1" serial; }
+_driver_for_index() { _field_for_index "$1" driver; }
 _index_for_serial() {
 	local js; js="$(list_devices 2>/dev/null)" || true
 	printf '%s' "${js}" | python3 -c 'import json,sys
 d=json.load(sys.stdin).get("devices",[]); s=sys.argv[1]
 print(next((str(x["index"]) for x in d if x["serial"]==s), ""))' "$1"
 }
-_set_readsb_device() {
+_driver_for_serial() {
+	local js; js="$(list_devices 2>/dev/null)" || true
+	printf '%s' "${js}" | python3 -c 'import json,sys
+d=json.load(sys.stdin).get("devices",[]); s=sys.argv[1]
+print(next((x.get("driver","") for x in d if x["serial"]==s), ""))' "$1"
+}
+
+# readsb device string: native rtlsdr for RTL, else SoapySDR (airspy/hackrf/lime).
+_set_readsb_device() {  # driver serial
 	[[ -f /etc/default/readsb ]] || return 0
-	python3 - /etc/default/readsb "$1" <<'PY'
+	python3 - /etc/default/readsb "$1" "$2" <<'PY'
 import re,sys,pathlib
-f=pathlib.Path(sys.argv[1]); s=sys.argv[2]; t=f.read_text()
-line=f'RECEIVER_OPTIONS="--device-type rtlsdr --device {s}"'
+f=pathlib.Path(sys.argv[1]); driver=sys.argv[2]; serial=sys.argv[3]; t=f.read_text()
+if driver == "rtlsdr":
+    dev=f'--device-type rtlsdr --device {serial}'
+else:
+    dev=f'--device-type soapy --device driver={driver},serial={serial}'
+line=f'RECEIVER_OPTIONS="{dev}"'
 t=re.sub(r'^RECEIVER_OPTIONS=.*$',line,t,count=1,flags=re.M) if re.search(r'^RECEIVER_OPTIONS=',t,re.M) else t.rstrip()+"\n"+line+"\n"
 f.write_text(t)
 PY
 }
 _set_dump978_device() { [[ -f /etc/default/dump978-fa ]] && sed -i "s|serial=[^, \"']*|serial=$1|" /etc/default/dump978-fa || true; }
 
-_start_job() {  # index serial job
-	local index="$1" serial="$2" job="$3"
-	systemctl stop readsb dump1090-fa dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-rtltcp@${index}.service" "aryaos-direwolf@${index}.service" aprscot >/dev/null 2>&1 || true
+# ais-catcher device args: rtl/airspy select by serial (native); other Soapy
+# drivers via the generic SOAPYSDR backend. Read by aryaos-ais-sdr.service.
+_set_ais_device() {  # driver serial
+	local driver="$1" serial="$2" args
+	case "${driver}" in
+		rtlsdr|airspy) args="-d ${serial}" ;;
+		*) args="-gu SOAPYSDR device driver=${driver},serial=${serial}" ;;
+	esac
+	mkdir -p /etc/default
+	printf 'AIS_CATCHER_DEVICE_ARGS="%s"\n' "${args}" > /etc/default/aryaos-ais-sdr
+}
+
+_start_job() {  # driver serial index job
+	local driver="$1" serial="$2" index="$3" job="$4"
+	systemctl stop readsb dump1090-fa dump978-fa aryaos-ais-sdr "ais-catcher-rtl@${index}.service" "aryaos-rtltcp@${index}.service" "aryaos-direwolf@${index}.service" aprscot >/dev/null 2>&1 || true
 	case "${job}" in
-		adsb) _set_readsb_device "${serial}"; systemctl start readsb ;;
-		uat)  _set_dump978_device "${serial}"; systemctl start dump978-fa ;;
-		ais)  systemctl start "ais-catcher-rtl@${index}.service"; systemctl start aiscot >/dev/null 2>&1 || true ;;
-		aprs) systemctl start "aryaos-direwolf@${index}.service"; systemctl start aprscot >/dev/null 2>&1 || true ;;
+		adsb) _set_readsb_device "${driver}" "${serial}"; systemctl start readsb ;;
+		uat)
+			if [[ "${driver}" == "rtlsdr" ]]; then
+				_set_dump978_device "${serial}"; systemctl start dump978-fa
+			else
+				echo "aryaos-sdr: UAT (978 MHz) currently supports RTL-SDR only (device is ${driver})." >&2; return 1
+			fi ;;
+		ais)  _set_ais_device "${driver}" "${serial}"; systemctl start aryaos-ais-sdr; systemctl start aiscot >/dev/null 2>&1 || true ;;
+		aprs)
+			if [[ "${driver}" == "rtlsdr" ]]; then
+				systemctl start "aryaos-direwolf@${index}.service"; systemctl start aprscot >/dev/null 2>&1 || true
+			else
+				echo "aryaos-sdr: APRS on ${driver} needs an FM demod (rx_tools rx_fm); RTL-SDR only for now." >&2; return 1
+			fi ;;
 	esac
 }
 
 task_sdr() {
-	local index="$1" job="$2" serial
+	local index="$1" job="$2" serial driver
 	[[ "${index}" =~ ^[0-9]+$ ]] || { echo "aryaos-sdr: INDEX must be a number" >&2; exit 2; }
 	serial="$(_serial_for_index "${index}")"
-	[[ -n "${serial}" ]] || { echo "aryaos-sdr: no RTL-SDR at index ${index}" >&2; exit 1; }
+	driver="$(_driver_for_index "${index}")"
+	[[ -n "${serial}" ]] || { echo "aryaos-sdr: no SDR at index ${index} (see: aryaos-sdr list)" >&2; exit 1; }
 	case "${job}" in adsb|uat|ais|aprs|off) : ;; *) echo "usage: aryaos-sdr task INDEX {adsb|uat|ais|aprs|off}" >&2; exit 2 ;; esac
 	mkdir -p /etc/aryaos; touch "${TASKS_FILE}"
 	grep -v "^${serial}=" "${TASKS_FILE}" > "${TASKS_FILE}.tmp" 2>/dev/null || true; mv "${TASKS_FILE}.tmp" "${TASKS_FILE}"
 	if [[ "${job}" == "off" ]]; then
-		systemctl stop readsb dump978-fa "ais-catcher-rtl@${index}.service" "aryaos-direwolf@${index}.service" aprscot >/dev/null 2>&1 || true
-		echo "RTL-SDR ${index} (${serial}) idle."
+		systemctl stop readsb dump978-fa aryaos-ais-sdr "ais-catcher-rtl@${index}.service" "aryaos-direwolf@${index}.service" aprscot >/dev/null 2>&1 || true
+		echo "SDR ${index} (${driver}:${serial}) idle."
 		return
 	fi
+	if ! _start_job "${driver}" "${serial}" "${index}" "${job}"; then
+		# Job not supported on this device — do not persist a failing task.
+		grep -v "^${serial}=" "${TASKS_FILE}" > "${TASKS_FILE}.tmp" 2>/dev/null || true; mv "${TASKS_FILE}.tmp" "${TASKS_FILE}"
+		exit 1
+	fi
 	echo "${serial}=${job}" >> "${TASKS_FILE}"
-	_start_job "${index}" "${serial}" "${job}"
 	local note=""
 	[[ ${job} == ais ]] && note=' (162 MHz over-the-air; aiscot -> charontak -> TAK)'
 	[[ ${job} == aprs ]] && note=' (144.39 MHz over-the-air; direwolf -> aprscot -> charontak -> TAK)'
-	echo "RTL-SDR ${index} (${serial}) -> ${job}${note}."
+	echo "SDR ${index} (${driver}:${serial}) -> ${job}${note}."
 }
 
-apply_tasks() {  # boot re-apply: map each persisted serial->current index, start its job
+apply_tasks() {  # boot re-apply: map each persisted serial->current index+driver, start its job
 	[[ -f "${TASKS_FILE}" ]] || return 0
-	local line serial job index
+	local line serial job index driver
 	while IFS='=' read -r serial job; do
 		[[ -n "${serial}" && -n "${job}" ]] || continue
 		index="$(_index_for_serial "${serial}")"
-		[[ -n "${index}" ]] || { echo "aryaos-sdr: tasked dongle ${serial} not present" >&2; continue; }
-		_start_job "${index}" "${serial}" "${job}"
+		driver="$(_driver_for_serial "${serial}")"
+		[[ -n "${index}" ]] || { echo "aryaos-sdr: tasked SDR ${serial} not present" >&2; continue; }
+		_start_job "${driver}" "${serial}" "${index}" "${job}" || true
 	done < "${TASKS_FILE}"
 }
 

--- a/shared_files/aryaos/systemd/aryaos-ais-sdr.service
+++ b/shared_files/aryaos/systemd/aryaos-ais-sdr.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AryaOS ais-catcher (any SDR) — decode AIS from the tasked SDR
+Documentation=https://github.com/jvde-github/AIS-catcher
+# Started by `aryaos-sdr task <index> ais` for ANY SDR (RTL-SDR, Airspy, HackRF,
+# LimeSDR, ...). The device selector is written to /etc/default/aryaos-ais-sdr by
+# aryaos-sdr (`-d <serial>` for RTL/Airspy, `-gu SOAPYSDR ...` for other Soapy
+# drivers). Feeds aiscot on UDP 5050 (the aiscot -> charontak -> TAK chain is
+# identical to the serial dAISy / RTL paths). Generalizes ais-catcher-rtl@.
+After=local-fs.target
+ConditionPathExists=/etc/default/aryaos-ais-sdr
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/aryaos-ais-sdr
+# Root for reliable USB access (admin-tasked service). Device args are
+# word-split intentionally (may be "-d <serial>" or "-gu SOAPYSDR ...").
+ExecStart=/bin/sh -c 'exec /usr/bin/AIS-catcher ${AIS_CATCHER_DEVICE_ARGS} -u 127.0.0.1 5050 -N 8100'
+Restart=on-failure
+RestartSec=3

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -189,6 +189,9 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-soapyremote.service" \
 ## persisted per-dongle jobs (/etc/aryaos/sdr-tasks).
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/ais-catcher-rtl@.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/ais-catcher-rtl@.service"
+# Generic AIS decoder for any SDR (RTL/Airspy/HackRF/Lime) via aryaos-sdr task ais.
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-ais-sdr.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-ais-sdr.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-sdr-tasks.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-sdr-tasks.service"
 


### PR DESCRIPTION
For the **DragonEgg** line (AryaOS + *any* SDR). Testing the Airspy box (.209) surfaced that `aryaos-sdr` was **RTL-only** — `list` used `rtl_test` (empty for an Airspy), `task` built `--device-type rtlsdr`. This generalizes it to any **SoapySDR** device.

## Changes
- **`list`** → enumerate via **`SoapySDRUtil --find`** (driver + serial + label): rtlsdr / airspy / hackrf / lms7(Lime). An Airspy now shows up (`driver=airspy, serial=…`). `rtl_test` kept as fallback.
- **`task`** → decoder invocation built from the device driver:
  - **ADS-B** → `readsb` native `rtlsdr`, else `--device-type soapy --device driver=<drv>,serial=<sn>` (readsb is built `ENABLE_SOAPYSDR`).
  - **AIS** → new generic **`aryaos-ais-sdr.service`**: `ais-catcher -d <serial>` (RTL/Airspy native) or `-gu SOAPYSDR …` (other Soapy).
  - **UAT** and **APRS** remain **RTL-only** (dump978-fa; APRS needs an FM demod — `rx_tools` for non-RTL is a roadmap item) and fail gracefully without persisting a bad task.
- **`share soapy`** → SoapyRemote already exposes **all** Soapy devices; messaged as the universal network share (rtl_tcp=RTL, SpyServer=Airspy).
- `set-serial` guarded to RTL-only (EEPROM concept).

## Validation
Enumeration parser + per-driver command construction validated against **real** Airspy + RTL `SoapySDRUtil` output. `verify-image` asserts SoapySDR enumeration, the generic AIS unit, and `soapysdr-tools`. Full Airspy *decode* path validates on hardware once .209 gets adequate power (Pi 5 + Airspy needs a 5V/5A supply).

Fits the product model: DragonEgg = AryaOS + any SDR, network-shared (SoapyRemote) or tasked as an ADS-B/AIS/… feed into a CoT/TAK gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)