### PR TITLE
fix(sdr): SoapySDR ADS-B + Airspy AIS (hardware-found)

### DIFF
--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -127,7 +127,7 @@ sudo aryaos-sdr task 1 off          # idle the SDR
     `aryaos-sdr` enumerates and tasks **any SoapySDR device** — RTL-SDR, **Airspy**,
     HackRF, LimeSDR — via `SoapySDRUtil`, not only RTL dongles. `list` reports each
     device's **driver** and **serial**; tasking builds the right decoder invocation
-    (native `rtlsdr`, or `--device-type soapy driver=<drv>` for the rest).
+    (native `rtlsdr`, or `--device-type soapysdr driver=<drv>` for the rest).
     Current coverage: **ADS-B** and **AIS** work on any SDR; **UAT** and **APRS**
     are RTL-SDR only for now (UAT needs `dump978-fa`; APRS needs an FM demod —
     `rx_tools` for non-RTL is a roadmap item).

--- a/shared_files/aryaos/aryaos-sdr
+++ b/shared_files/aryaos/aryaos-sdr
@@ -233,7 +233,9 @@ f=pathlib.Path(sys.argv[1]); driver=sys.argv[2]; serial=sys.argv[3]; t=f.read_te
 if driver == "rtlsdr":
     dev=f'--device-type rtlsdr --device {serial}'
 else:
-    dev=f'--device-type soapy --device driver={driver},serial={serial}'
+    # readsb's SoapySDR backend is "soapysdr" (not "soapy"); device string is
+    # the Soapy args (driver=airspy,serial=...).
+    dev=f'--device-type soapysdr --device driver={driver},serial={serial}'
 line=f'RECEIVER_OPTIONS="{dev}"'
 t=re.sub(r'^RECEIVER_OPTIONS=.*$',line,t,count=1,flags=re.M) if re.search(r'^RECEIVER_OPTIONS=',t,re.M) else t.rstrip()+"\n"+line+"\n"
 f.write_text(t)
@@ -241,13 +243,18 @@ PY
 }
 _set_dump978_device() { [[ -f /etc/default/dump978-fa ]] && sed -i "s|serial=[^, \"']*|serial=$1|" /etc/default/dump978-fa || true; }
 
-# ais-catcher device args: rtl/airspy select by serial (native); other Soapy
-# drivers via the generic SOAPYSDR backend. Read by aryaos-ais-sdr.service.
+# ais-catcher device args, per driver (ais-catcher selects by serial, natively):
+#   rtlsdr : serial matches SoapySDR's rtlsdr serial as-is.
+#   airspy : ais-catcher's native Airspy serial is UPPERCASE; SoapySDR reports it
+#            lowercase and the `-d` search is case-sensitive — so upper-case it.
+#   other  : the generic SOAPYSDR backend (HackRF/Lime — validated on Airspy/RTL;
+#            other Soapy drivers are best-effort until hardware-tested).
 _set_ais_device() {  # driver serial
 	local driver="$1" serial="$2" args
 	case "${driver}" in
-		rtlsdr|airspy) args="-d ${serial}" ;;
-		*) args="-gu SOAPYSDR device driver=${driver},serial=${serial}" ;;
+		rtlsdr) args="-d ${serial}" ;;
+		airspy) args="-d ${serial^^}" ;;
+		*) args="-d SOAPYSDR -gs SOAPYSDR device:driver=${driver},serial=${serial}" ;;
 	esac
 	mkdir -p /etc/default
 	printf 'AIS_CATCHER_DEVICE_ARGS="%s"\n' "${args}" > /etc/default/aryaos-ais-sdr


### PR DESCRIPTION
Live-testing the new universal `aryaos-sdr` by tasking an **Airspy** surfaced two bugs, both now fixed and validated on the hardware:

- **ADS-B**: readsb's SoapySDR device-type is **`soapysdr`**, not `soapy` (readsb told us: *supported SDR types are: rtlsdr, soapysdr*). Fixed → readsb opens the Airspy at **1090 MHz / 2.4 MSPS**.
- **AIS**: ais-catcher's native Airspy `-d` serial is **UPPERCASE**, but SoapySDR reports it lowercase and the search is case-sensitive (*cannot find device with SN 258c…*). Fixed by upper-casing the Airspy serial (`${serial^^}`) — the uppercased form opened the Airspy at 2.5 MSPS.

Enumeration + ADS-B + AIS now validated **end-to-end on real Airspy hardware**. (The test box thermally throttles at 85 °C with no heatsink — a cooling issue, not software; the power was fixed with a 5V/5A supply.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)