### PR TITLE
Add DroneScout DS101 Remote ID receiver (dronecot-dronescout)

### DIFF
--- a/docs/deploy/counter-uas.md
+++ b/docs/deploy/counter-uas.md
@@ -6,10 +6,13 @@ Detect and track drones for counter-UAS (C-UAS) awareness. Select the **`cuas`**
 
 AryaOS builds a C-UAS picture from two complementary detection sources:
 
-- **Remote ID / Open Drone ID** — the FAA-mandated broadcast that compliant drones emit over Wi-Fi/Bluetooth. Decoded by **`dronecot`**.
+- **Remote ID / Open Drone ID** — the FAA-mandated broadcast that compliant drones emit over Wi-Fi/Bluetooth. Decoded by **`dronecot`** (on-board Wi-Fi/BLE, or a dedicated receiver — see below).
 - **DJI DroneID** — DJI's proprietary telemetry, received over the air with an SDR (for example an **AntSDR**) and decoded by **DJICOT**.
 
 `sikw00fcot` additionally converts SiK-radio MAVLink drone telemetry to CoT when you have that link.
+
+!!! info "Dedicated Remote ID receiver: DroneScout DS101"
+    A **BlueMark DroneScout Bridge (DS101)** — a standards-based Remote ID receiver — plugs in over USB-serial and emits detected Remote ID as **MAVLink** (`OPEN_DRONE_ID_MESSAGE_PACK` or `ADSB_VEHICLE`). AryaOS ships a second, opt-in dronecot instance for it, **`dronecot-dronescout`**, that reads the MAVLink serial and feeds the same Charontak hub. Enable it on a DS101 box with `sudo systemctl enable --now dronecot-dronescout` (requires `dronecot` ≥ 2.2.3). This runs alongside the AntSDR/DJI and SiKW00F sources for a multi-source Remote ID picture.
 
 !!! tip "Plug & play by design"
     AirTAK C-UAS is designed to work out of the box: power the device, connect a TAK EUD (ATAK, WinTAK, iTAK) to its Wi-Fi hotspot, and drone tracks flow with no extra configuration. *When in doubt, reboot.*

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -224,6 +224,9 @@ require_unit adsbcot.service
 require_unit aiscot.service
 require_unit dronecot.service
 require_unit sikw00fcot.service
+# DroneScout DS101: 2nd dronecot instance (MAVLink Remote ID over serial), opt-in.
+require_path /etc/systemd/system/dronecot-dronescout.service
+require_grep 'serial://' /etc/default/dronecot-dronescout "dronecot-dronescout reads MAVLink serial"
 require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service

--- a/shared_files/aryaos/dronecot-dronescout.default
+++ b/shared_files/aryaos/dronecot-dronescout.default
@@ -1,0 +1,13 @@
+# AryaOS dronecot (DroneScout DS101) config — /etc/default/dronecot-dronescout
+#
+# A BlueMark DroneScout Bridge (DS101) emits detected Remote ID as MAVLink over
+# its USB-serial. dronecot's SerialWorker reads it (OPEN_DRONE_ID_MESSAGE_PACK
+# and, as of dronecot 2.2.3, ADSB_VEHICLE) and forwards to charontak as CoT.
+# COT_URL is inherited from aryaos-config.txt via the service EnvironmentFile.
+#
+# Enable on a box with a DS101:  sudo systemctl enable --now dronecot-dronescout
+# The by-id path is stable for a single CH340; if you have more than one CH340,
+# pin the correct one (ls -l /dev/serial/by-id/).
+
+FEED_URL=serial:///dev/serial/by-id/usb-1a86_USB_Serial-if00-port0:115200
+SENSOR_ID=dronescout

--- a/shared_files/aryaos/systemd/dronecot-dronescout.service
+++ b/shared_files/aryaos/systemd/dronecot-dronescout.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=DroneCOT (DroneScout DS101) — MAVLink Remote ID over serial to TAK
+Documentation=https://github.com/snstac/dronecot
+# A SECOND dronecot instance dedicated to a BlueMark DroneScout Bridge (DS101),
+# which emits detected Remote ID as MAVLink (OPEN_DRONE_ID_MESSAGE_PACK or
+# ADSB_VEHICLE) over its USB-serial (CH340). Runs alongside the AntSDR/DJI
+# dronecot.service and sikw00fcot; all feed the same charontak hub. Off by
+# default (opt-in for a DS101 laydown) — enable with:
+#   sudo systemctl enable --now dronecot-dronescout
+# The ConditionPathExists guards against starting with no serial device present.
+Wants=network.target
+After=network.target local-fs.target
+ConditionPathExists=/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+
+[Service]
+User=dronecot
+ExecStart=/usr/bin/dronecot
+RuntimeDirectory=dronecot-dronescout
+SyslogIdentifier=dronecot-dronescout
+EnvironmentFile=-/etc/aryaos/aryaos-config.txt
+EnvironmentFile=/etc/default/dronecot-dronescout
+Type=simple
+Restart=always
+RestartSec=20
+Nice=-1
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-charontak/00-install/01-run-chroot.sh
+++ b/stages/stage-charontak/00-install/01-run-chroot.sh
@@ -52,5 +52,9 @@ for svc in adsbcot aiscot dronecot sikw00fcot lincot aircot; do
 	install_after_charontak "${svc}"
 done
 
+# The dronecot-dronescout instance (DroneScout DS101) runs as user dronecot and
+# reads MAVLink Remote ID from a USB-serial device — grant serial access.
+usermod -aG dialout dronecot 2>/dev/null || true
+
 systemctl daemon-reload || true
 systemctl enable charontak.service 2>/dev/null || true

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -61,3 +61,12 @@ if [[ -f "${ROOTFS_DIR}/lib/systemd/system/dronecot.service" ]]; then
 	grep -qF "EnvironmentFile=-/etc/aryaos/aryaos-config.txt" "${ROOTFS_DIR}/lib/systemd/system/dronecot.service" || \
 		sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=-/etc/aryaos/aryaos-config.txt" "${ROOTFS_DIR}/lib/systemd/system/dronecot.service"
 fi
+
+# DroneScout DS101: a SECOND dronecot instance reading MAVLink Remote ID from the
+# DS101's USB-serial (dronecot >= 2.2.3 handles OpenDroneID packs + ADSB_VEHICLE).
+# Off by default (opt-in for a DS101 laydown; guarded by ConditionPathExists on
+# the serial device). Feeds the same charontak hub as the AntSDR/DJI dronecot.
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-dronescout.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/dronecot-dronescout.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-dronescout.default" \
+	"${ROOTFS_DIR}/etc/default/dronecot-dronescout"


### PR DESCRIPTION
A **BlueMark DroneScout Bridge (DS101)** — a standards-based Remote ID receiver — emits detected Remote ID as **MAVLink** over USB-serial. This ships a second, opt-in dronecot instance for it, so a box can fuse **three** Remote ID sources: AntSDR (DJI DroneID) + SiKW00F + **DroneScout (Open Drone ID)**.

- **`dronecot-dronescout.service`** — runs dronecot on the DS101 serial (`FEED_URL=serial://…`). Off by default (opt-in), `ConditionPathExists` guards the serial device; feeds the same charontak hub.
- dronecot ≥ **2.2.3** (snstac/dronecot#4) decodes the DS101's MAVLink — `OPEN_DRONE_ID_MESSAGE_PACK` (already) **+ `ADSB_VEHICLE`** (new).
- dronecot user added to `dialout`; verify-image asserts the unit + config; counter-uas docs updated.

Enable on a DS101 box: `sudo systemctl enable --now dronecot-dronescout`. **Depends on dronecot ≥ 2.2.3 in the apt repo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)