### PR TITLE
Fix DS101 port: it's the ESP32-S3, not the CH340 (live-verified vs DB120)

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -225,8 +225,11 @@ require_unit aiscot.service
 require_unit dronecot.service
 require_unit sikw00fcot.service
 # DroneScout DS101: 2nd dronecot instance (MAVLink Remote ID over serial), opt-in.
+# The DS101 is an ESP32-S3 (303a:1001) pinned to /dev/dronescout by udev, NOT a
+# CH340 — verified live 2026-07-24 against a DroneBeacon DB120.
 require_path /etc/systemd/system/dronecot-dronescout.service
-require_grep 'serial://' /etc/default/dronecot-dronescout "dronecot-dronescout reads MAVLink serial"
+require_grep '/dev/dronescout' /etc/default/dronecot-dronescout "dronecot-dronescout reads the DS101 ESP32-S3 (/dev/dronescout)"
+require_grep '303a' /etc/udev/rules.d/99-aryaos-dronescout.rules "DS101 udev symlink rule present"
 require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -40,6 +40,16 @@ wait_for_serial() {
 	return 0
 }
 
+# True for an ESP32-based Remote ID receiver (BlueMark DroneScout DS101 /
+# DroneBeacon, SiKW00F) — these speak binary MAVLink, never NMEA, so they must
+# NOT be probed or assigned as a GPS/dAISy (they'd otherwise be swept up as a
+# silent "leftover" and mis-assigned by elimination). dronecot handles them.
+is_rid_device() {
+	local dev="$1" vid
+	vid="$(udevadm info -q property -n "$dev" 2>/dev/null | sed -n 's/^ID_VENDOR_ID=//p')"
+	[[ "$vid" == "303a" ]]  # Espressif
+}
+
 # Classify one device: prints "gps:<baud>", "ais:<baud>", "busy", or "" (silent).
 classify() {
 	local dev="$1" b data
@@ -73,6 +83,10 @@ main() {
 
 	shopt -s nullglob
 	for dev in /dev/serial/by-id/*; do
+		if is_rid_device "$dev"; then
+			log "skip $dev (ESP32 Remote ID receiver — MAVLink, handled by dronecot, not GPS/AIS)"
+			continue
+		fi
 		cls="$(classify "$dev")"
 		case "$cls" in
 			busy)  log "skip $dev (held by a running service)";;

--- a/shared_files/aryaos/dronecot-dronescout.default
+++ b/shared_files/aryaos/dronecot-dronescout.default
@@ -1,13 +1,20 @@
 # AryaOS dronecot (DroneScout DS101) config — /etc/default/dronecot-dronescout
 #
-# A BlueMark DroneScout Bridge (DS101) emits detected Remote ID as MAVLink over
-# its USB-serial. dronecot's SerialWorker reads it (OPEN_DRONE_ID_MESSAGE_PACK
+# A BlueMark DroneScout DS101 / DroneBeacon emits detected Remote ID as MAVLink
+# over its USB-serial. dronecot's SerialWorker reads it (OPEN_DRONE_ID_MESSAGE_PACK
 # and, as of dronecot 2.2.3, ADSB_VEHICLE) and forwards to charontak as CoT.
 # COT_URL is inherited from aryaos-config.txt via the service EnvironmentFile.
 #
 # Enable on a box with a DS101:  sudo systemctl enable --now dronecot-dronescout
-# The by-id path is stable for a single CH340; if you have more than one CH340,
-# pin the correct one (ls -l /dev/serial/by-id/).
+#
+# PORT: the DS101 is an ESP32-S3 (udev "Espressif USB JTAG/serial debug unit",
+# 303a:1001). Its /dev/serial/by-id path embeds the per-unit MAC, so AryaOS pins
+# a stable /dev/dronescout symlink via 99-aryaos-dronescout.rules — that is what
+# FEED_URL points at below. If the box has more than one ESP32-S3 (e.g. a DS101
+# AND a SiKW00F), the symlink is ambiguous: set FEED_URL to the specific
+# /dev/serial/by-id/usb-Espressif_USB_JTAG_serial_debug_unit_<MAC>-if00 path
+# (see `ls -l /dev/serial/by-id/`). Live-verified 2026-07-24 against a DroneBeacon
+# DB120 (OPEN_DRONE_ID_MESSAGE_PACK @115200 on the ESP32-S3 CDC port).
 
-FEED_URL=serial:///dev/serial/by-id/usb-1a86_USB_Serial-if00-port0:115200
+FEED_URL=serial:///dev/dronescout:115200
 SENSOR_ID=dronescout

--- a/shared_files/aryaos/systemd/dronecot-dronescout.service
+++ b/shared_files/aryaos/systemd/dronecot-dronescout.service
@@ -1,16 +1,17 @@
 [Unit]
 Description=DroneCOT (DroneScout DS101) — MAVLink Remote ID over serial to TAK
 Documentation=https://github.com/snstac/dronecot
-# A SECOND dronecot instance dedicated to a BlueMark DroneScout Bridge (DS101),
-# which emits detected Remote ID as MAVLink (OPEN_DRONE_ID_MESSAGE_PACK or
-# ADSB_VEHICLE) over its USB-serial (CH340). Runs alongside the AntSDR/DJI
-# dronecot.service and sikw00fcot; all feed the same charontak hub. Off by
-# default (opt-in for a DS101 laydown) — enable with:
+# A SECOND dronecot instance dedicated to a BlueMark DroneScout DS101 /
+# DroneBeacon, which emits detected Remote ID as MAVLink (OPEN_DRONE_ID_MESSAGE_PACK
+# or ADSB_VEHICLE) over its ESP32-S3 USB-serial (pinned to /dev/dronescout by
+# 99-aryaos-dronescout.rules). Runs alongside the AntSDR/DJI dronecot.service;
+# both feed the same charontak hub. Off by default (opt-in for a DS101 laydown)
+# — enable with:
 #   sudo systemctl enable --now dronecot-dronescout
-# The ConditionPathExists guards against starting with no serial device present.
+# The ConditionPathExists guards against starting with no DS101 present.
 Wants=network.target
 After=network.target local-fs.target
-ConditionPathExists=/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+ConditionPathExists=/dev/dronescout
 
 [Service]
 User=dronecot

--- a/shared_files/aryaos/udev/99-aryaos-dronescout.rules
+++ b/shared_files/aryaos/udev/99-aryaos-dronescout.rules
@@ -1,0 +1,15 @@
+# AryaOS — BlueMark DroneScout DS101 / DroneBeacon Remote ID receiver.
+#
+# These present as an ESP32-S3 native USB CDC-ACM device — udev names it
+# "Espressif USB JTAG/serial debug unit" (VID:PID 303a:1001). The stable
+# /dev/serial/by-id/ path embeds the module's per-unit MAC, so it cannot be
+# hard-coded in a shipped image. This rule pins a stable /dev/dronescout symlink
+# for the (opt-in) dronecot-dronescout instance to consume, and keeps
+# ModemManager off the port.
+#
+# CAVEAT: 303a:1001 is the GENERIC ESP32-S3 native-USB id, shared by ANY ESP32-S3
+# board (including a SiKW00F). On a box carrying more than one ESP32-S3, this
+# symlink is ambiguous — disambiguate by the per-unit serial and point
+# dronecot-dronescout's FEED_URL at the specific /dev/serial/by-id/... path
+# instead (see `ls -l /dev/serial/by-id/`).
+SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", SYMLINK+="dronescout", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -70,3 +70,8 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-dronescout.service" 
 	"${ROOTFS_DIR}/etc/systemd/system/dronecot-dronescout.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-dronescout.default" \
 	"${ROOTFS_DIR}/etc/default/dronecot-dronescout"
+# Pin a stable /dev/dronescout symlink for the DS101's ESP32-S3 USB-serial (its
+# by-id path embeds the per-unit MAC, so it can't be hard-coded). The DS101 is
+# the ESP32-S3 CDC port (303a:1001), NOT a CH340 — verified live 2026-07-24.
+install -v -m 0644 "${SHARED_FILES}/aryaos/udev/99-aryaos-dronescout.rules" \
+	"${ROOTFS_DIR}/etc/udev/rules.d/99-aryaos-dronescout.rules"


### PR DESCRIPTION
## What
Live HIL test with a **DroneBeacon DB120** transmitting Remote ID nearby proved the **DroneScout DS101 is the ESP32-S3 native-USB CDC port** (udev `Espressif USB JTAG/serial debug unit`, `303a:1001`) — streaming `OPEN_DRONE_ID_MESSAGE_PACK` MAVLink @115200. The **CH340** (`usb-1a86`) that `dronecot-dronescout` previously targeted is **silent — not the DS101**.

This also caught that `aryaos-serial-assign` (the GPS/AIS NMEA sniffer) was **grabbing the DS101's ESP32 port** and could mis-assign it as a silent dAISy by elimination.

## Changes
- **`99-aryaos-dronescout.rules`** (new): pin a stable `/dev/dronescout` symlink for the ESP32-S3 (its `/dev/serial/by-id` path embeds the per-unit MAC, so it can't be hard-coded). Installed by `stage-dronecot`.
- **`dronecot-dronescout`**: `FEED_URL` + `ConditionPathExists` → `/dev/dronescout` (was the dead CH340 by-id).
- **`aryaos-serial-assign`**: skip Espressif `303a` devices (ESP32 Remote ID receivers speak binary MAVLink, never NMEA).
- **`verify-image.sh`**: assert `/dev/dronescout` + the udev rule.

## Caveat
`303a:1001` is the generic ESP32-S3 native-USB id (shared with SiKW00F). On a box with more than one ESP32-S3, pin the specific by-id serial in `FEED_URL` instead — documented in the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)