### PR TITLE
Wi-Fi Remote ID: opt-in dronecot-wifi instance + scapy (live-validated)

### DIFF
--- a/docs/deploy/counter-uas.md
+++ b/docs/deploy/counter-uas.md
@@ -14,6 +14,9 @@ AryaOS builds a C-UAS picture from two complementary detection sources:
 !!! info "Dedicated Remote ID receiver: DroneScout DS101"
     A **BlueMark DroneScout DS101 / DroneBeacon** — a standards-based Remote ID receiver — plugs in over USB-serial and emits detected Remote ID as **MAVLink** (`OPEN_DRONE_ID_MESSAGE_PACK` or `ADSB_VEHICLE`). It is an **ESP32-S3** device; AryaOS pins it to a stable `/dev/dronescout` symlink (its per-unit serial path is not portable) and ships a second, opt-in dronecot instance, **`dronecot-dronescout`**, that reads it and feeds the same Charontak hub. Enable it on a DS101 box with `sudo systemctl enable --now dronecot-dronescout` (requires `dronecot` ≥ 2.2.3). It runs alongside the AntSDR/DJI source for a multi-source Remote ID picture. *(Live-verified against a DroneBeacon DB120.)*
 
+!!! info "Wi-Fi Remote ID: monitor-mode adapter"
+    dronecot decodes Open Drone ID **directly off the air over Wi-Fi** (ASTM F3411 Beacon vendor IE *and* Wi-Fi Alliance NAN) using a **monitor-mode** USB adapter — an Atheros **AR9271 (`ath9k_htc`)** or Realtek **8821CU** works well. AryaOS ships an opt-in instance, **`dronecot-wifi`** (`FEED_URL=wifi://wlan1`, channel-hopping 1/6/11); enable it on a box with an external adapter: `sudo systemctl enable --now dronecot-wifi`. Use `wireless://wlan1` to run Wi-Fi + BLE together. *(Live-verified 2026-07-24: an AR9271 decoded a BlueMark DroneBeacon Wi-Fi squawk — the same aircraft the DS101 decoded over serial.)* `wlan0` is the on-board AP radio — always use the external adapter.
+
 !!! tip "Plug & play by design"
     AirTAK C-UAS is designed to work out of the box: power the device, connect a TAK EUD (ATAK, WinTAK, iTAK) to its Wi-Fi hotspot, and drone tracks flow with no extra configuration. *When in doubt, reboot.*
 

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -236,6 +236,11 @@ require_path /usr/local/sbin/aryaos-antsdr-health
 require_path /etc/systemd/system/aryaos-antsdr-health.timer
 require_grep '1a86' /etc/udev/rules.d/99-aryaos-antsdr-console.rules "AntSDR console udev rule present"
 require_path /usr/bin/tio
+# Wi-Fi Remote ID: opt-in dronecot instance (802.11 monitor-mode ODID capture).
+# Needs python3-scapy for dronecot's WifiWorker.
+require_path /etc/systemd/system/dronecot-wifi.service
+require_grep 'wifi://' /etc/default/dronecot-wifi "dronecot-wifi captures 802.11 Remote ID"
+require_path /usr/lib/python3/dist-packages/scapy/all.py
 require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service

--- a/shared_files/aryaos/aryaos-antsdr-health
+++ b/shared_files/aryaos/aryaos-antsdr-health
@@ -82,7 +82,13 @@ ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
 json="{\"status\":\"${status}\",\"antsdr_ip\":\"${ANTSDR_IP}\",\"feed_port\":${PORT},\"reachable\":${reachable},\"feed_established\":${feed},\"ts\":\"${ts}\"}"
 
 mkdir -p "${RUN_DIR}" 2>/dev/null
-printf '%s\n' "${json}" > "${STATE_FILE}" 2>/dev/null
+# Best-effort state file for Cockpit. Guard the write so a NON-root invocation
+# (e.g. Cockpit's superuser:"try" falling back to the session user) can't emit a
+# shell redirection error — the root-run timer keeps this file fresh regardless,
+# and the JSON is still returned on stdout for the caller either way.
+if [ -w "${RUN_DIR}" ] || [ -w "${STATE_FILE}" ]; then
+	printf '%s\n' "${json}" > "${STATE_FILE}" 2>/dev/null || true
+fi
 
 if [[ "${quiet}" != 1 && "${status}" != "${prev}" ]]; then
 	case "${status}" in

--- a/shared_files/aryaos/dronecot-wifi.default
+++ b/shared_files/aryaos/dronecot-wifi.default
@@ -1,0 +1,21 @@
+# AryaOS dronecot (Wi-Fi Remote ID) config — /etc/default/dronecot-wifi
+#
+# Captures Open Drone ID broadcast over Wi-Fi (ASTM F3411 Beacon + Wi-Fi Alliance
+# NAN) from a MONITOR-MODE adapter and forwards it to charontak as CoT. COT_URL
+# is inherited from aryaos-config.txt via the service EnvironmentFile.
+#
+# Enable on a box with a monitor-capable external Wi-Fi adapter:
+#   sudo systemctl enable --now dronecot-wifi
+#
+# WIFI_INTERFACE: the EXTERNAL adapter (wlan0 is the on-board AP/client radio —
+# do not use it). An Atheros AR9271/ath9k_htc or Realtek 8821CU is ideal. If your
+# adapter enumerates as wlan2, set both WIFI_INTERFACE and FEED_URL accordingly.
+# Use FEED_URL=wireless://wlan1 to also run the BLE (Sniffle) path in one instance.
+# Live-verified 2026-07-24: ath9k_htc (AR9271) decoded a BlueMark DroneBeacon
+# Wi-Fi squawk (ASTM Beacon, ch-hop 1/6/11).
+
+FEED_URL=wifi://wlan1
+WIFI_INTERFACE=wlan1
+WIFI_HOP_CHANNELS=1,6,11
+WIFI_HOP_DWELL=3,1
+SENSOR_ID=wifi-rid

--- a/shared_files/aryaos/systemd/dronecot-wifi.service
+++ b/shared_files/aryaos/systemd/dronecot-wifi.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=DroneCOT (Wi-Fi Remote ID) — Open Drone ID over 802.11 monitor mode to TAK
+Documentation=https://github.com/snstac/dronecot
+# A dronecot instance that captures Open Drone ID from Wi-Fi (ASTM F3411 Beacon
+# vendor IE + Wi-Fi Alliance NAN) using a MONITOR-MODE adapter — e.g. an Atheros
+# AR9271 (ath9k_htc) or a Realtek 8821CU. Decodes with dronecot's WifiWorker
+# (needs python3-scapy) and feeds the same charontak hub as the AntSDR/DJI and
+# DS101 sources. Off by default (opt-in) — enable on a box with a monitor-capable
+# external Wi-Fi adapter:
+#   sudo systemctl enable --now dronecot-wifi
+# Runs as root: monitor-mode setup (iw) and L2 capture need CAP_NET_ADMIN/RAW.
+# Targets wlan1 by default (wlan0 is the on-board AP/client radio) — override
+# WIFI_INTERFACE + FEED_URL in /etc/default/dronecot-wifi if it enumerates
+# differently. ConditionPathExists guards against starting with no adapter.
+Wants=network.target
+After=network.target
+ConditionPathExists=/sys/class/net/wlan1
+
+[Service]
+User=root
+ExecStart=/usr/bin/dronecot
+RuntimeDirectory=dronecot-wifi
+SyslogIdentifier=dronecot-wifi
+EnvironmentFile=-/etc/aryaos/aryaos-config.txt
+EnvironmentFile=/etc/default/dronecot-wifi
+Type=simple
+Restart=always
+RestartSec=20
+Nice=-1
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-dronecot/00-install/00-packages
+++ b/stages/stage-dronecot/00-install/00-packages
@@ -1,1 +1,2 @@
 tio
+python3-scapy

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -70,6 +70,15 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-dronescout.service" 
 	"${ROOTFS_DIR}/etc/systemd/system/dronecot-dronescout.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-dronescout.default" \
 	"${ROOTFS_DIR}/etc/default/dronecot-dronescout"
+
+# Wi-Fi Remote ID: an opt-in dronecot instance that decodes Open Drone ID from
+# 802.11 (ASTM Beacon + Wi-Fi Alliance NAN) via a monitor-mode adapter (ath9k_htc
+# / Realtek 8821CU). Needs python3-scapy (installed via 00-packages). Off by
+# default — enable on a box with an external monitor-capable Wi-Fi adapter.
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-wifi.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/dronecot-wifi.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-wifi.default" \
+	"${ROOTFS_DIR}/etc/default/dronecot-wifi"
 # Pin a stable /dev/dronescout symlink for the DS101's ESP32-S3 USB-serial (its
 # by-id path embeds the per-unit MAC, so it can't be hard-coded). The DS101 is
 # the ESP32-S3 CDC port (303a:1001), NOT a CH340 — verified live 2026-07-24.


### PR DESCRIPTION
Live-validated: an Atheros AR9271 (ath9k_htc) decoded a BlueMark DroneBeacon Wi-Fi Open Drone ID squawk via dronecot's parser — same aircraft the DS101 decoded over serial. The packaged WifiWorker needs scapy (wasn't shipped), so the Wi-Fi path couldn't start.

- **python3-scapy** added to stage-dronecot.
- **dronecot-wifi** opt-in instance: `FEED_URL=wifi://wlan1`, ch-hop 1/6/11, root (monitor mode), guarded on wlan1; leaves wlan0 (AP radio) alone.
- verify-image + counter-uas docs.
- Folds in the stranded antsdr-health non-root write guard (its PR was blocked by a GitHub API incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)