### PR TITLE
dronecot-wifi: prep monitor mode via ExecStartPre (fix live capture)

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -241,6 +241,8 @@ require_path /usr/bin/tio
 require_path /etc/systemd/system/dronecot-wifi.service
 require_grep 'wifi://' /etc/default/dronecot-wifi "dronecot-wifi captures 802.11 Remote ID"
 require_path /usr/lib/python3/dist-packages/scapy/all.py
+require_path /usr/local/sbin/aryaos-wifi-monitor
+require_grep 'aryaos-wifi-monitor' /etc/systemd/system/dronecot-wifi.service "dronecot-wifi preps monitor mode via ExecStartPre"
 require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service

--- a/shared_files/aryaos/aryaos-wifi-monitor
+++ b/shared_files/aryaos/aryaos-wifi-monitor
@@ -1,0 +1,42 @@
+#!/bin/bash
+# aryaos-wifi-monitor — put a Wi-Fi adapter into monitor mode for dronecot-wifi.
+#
+# dronecot's WifiSniffer.set_monitor_mode() runs `iw set type monitor` WITHOUT
+# bringing the interface down first (so it silently no-ops on an up interface)
+# and does NOT release the adapter from NetworkManager (so NM flaps it down under
+# the scapy sniffer → "[Errno 100] Network is down"). This helper does the full,
+# correct sequence as an ExecStartPre so the packaged WifiWorker starts on a
+# stable monitor interface. Idempotent and non-fatal (never blocks startup).
+#
+# Live-verified 2026-07-24 on an Atheros AR9271 (ath9k_htc): after this prep a
+# raw capture saw 821 frames / 10 ODID frames from a live squawk.
+#
+# Usage: aryaos-wifi-monitor <iface> [channel]
+# Copyright Sensors & Signals LLC https://www.snstac.com/  — Apache-2.0
+
+set -u
+IF="${1:-wlan1}"
+CH="${2:-6}"
+
+[ -e "/sys/class/net/${IF}" ] || { echo "aryaos-wifi-monitor: ${IF} not present" >&2; exit 0; }
+
+# 1) Release from NetworkManager so it stops managing/flapping the adapter.
+if command -v nmcli >/dev/null 2>&1; then
+	nmcli dev set "${IF}" managed no 2>/dev/null || true
+fi
+# 2) Kill any wpa_supplicant holding the iface (managed-mode client).
+pkill -f "wpa_supplicant.*${IF}" 2>/dev/null || true
+
+# 3) down -> monitor -> up -> channel. `set monitor none` works on ath9k_htc and
+#    most drivers; fall back to `set type monitor`. Interface MUST be down first.
+ip link set "${IF}" down 2>/dev/null || true
+iw dev "${IF}" set monitor none 2>/dev/null || iw dev "${IF}" set type monitor 2>/dev/null || true
+ip link set "${IF}" up 2>/dev/null || true
+iw dev "${IF}" set channel "${CH}" 2>/dev/null || true
+
+if iw dev "${IF}" info 2>/dev/null | grep -qi "type monitor"; then
+	echo "aryaos-wifi-monitor: ${IF} in monitor mode (ch ${CH})"
+else
+	echo "aryaos-wifi-monitor: ${IF} monitor-mode prep attempted (driver may not support monitor)" >&2
+fi
+exit 0

--- a/shared_files/aryaos/systemd/dronecot-wifi.service
+++ b/shared_files/aryaos/systemd/dronecot-wifi.service
@@ -18,6 +18,11 @@ ConditionPathExists=/sys/class/net/wlan1
 
 [Service]
 User=root
+# Put the adapter into monitor mode BEFORE dronecot starts: dronecot's own
+# set_monitor_mode() doesn't down the iface first (so `iw set type monitor`
+# no-ops on an up iface) nor release it from NetworkManager (which then flaps it
+# down under the sniffer). This helper does the full sequence. Non-fatal.
+ExecStartPre=/usr/local/sbin/aryaos-wifi-monitor ${WIFI_INTERFACE}
 ExecStart=/usr/bin/dronecot
 RuntimeDirectory=dronecot-wifi
 SyslogIdentifier=dronecot-wifi

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -79,6 +79,10 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-wifi.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/dronecot-wifi.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-wifi.default" \
 	"${ROOTFS_DIR}/etc/default/dronecot-wifi"
+# Monitor-mode prep helper (dronecot's own set_monitor_mode doesn't down the
+# iface first nor release it from NetworkManager) — used as ExecStartPre.
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-wifi-monitor" \
+	"${ROOTFS_DIR}/usr/local/sbin/aryaos-wifi-monitor"
 # Pin a stable /dev/dronescout symlink for the DS101's ESP32-S3 USB-serial (its
 # by-id path embeds the per-unit MAC, so it can't be hard-coded). The DS101 is
 # the ESP32-S3 CDC port (303a:1001), NOT a CH340 — verified live 2026-07-24.


### PR DESCRIPTION
On AR9271/ath9k_htc the packaged WifiWorker started but captured nothing — dronecot's set_monitor_mode() doesn't down the iface before `iw set type monitor` and doesn't release it from NetworkManager (NM flaps it → [Errno 100]). Adds `aryaos-wifi-monitor` (nmcli unmanage → down → monitor → up → channel) as ExecStartPre. Live-verified on .60: 821 frames/10 ODID captured on the prepped iface; service starts on stable monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)