### PR TITLE
Product-line + capability model, capability beacon, GPS-race + wpa_supplicant fixes

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -132,6 +132,7 @@ require_path /etc/sudoers.d/aryaos
 require_path /usr/local/sbin/aryaos-firstboot.sh
 require_path /usr/local/sbin/aryaos-lincot-remarks
 require_path /usr/local/sbin/aryaos-cot-detail
+require_grep 'capabilities' /usr/local/sbin/aryaos-cot-detail "beacon advertises product + capabilities (v2)"
 require_path /usr/local/sbin/aryaos-neighbord
 require_path /etc/systemd/system/aryaos-firstboot.service
 require_path /etc/systemd/system/aryaos-neighbord.service
@@ -243,6 +244,10 @@ require_grep 'wifi://' /etc/default/dronecot-wifi "dronecot-wifi captures 802.11
 require_path /usr/lib/python3/dist-packages/scapy/all.py
 require_path /usr/local/sbin/aryaos-wifi-monitor
 require_grep 'aryaos-wifi-monitor' /etc/systemd/system/dronecot-wifi.service "dronecot-wifi preps monitor mode via ExecStartPre"
+require_grep 'SENSOR_TYPE' /etc/default/dronecot-wifi "dronecot-wifi carries SIGINT sensor detail"
+# Capability model + zero-warnings: gpsd race ordering drop-in.
+require_path /etc/systemd/system/gpsd.socket.d/after-serial-assign.conf
+require_grep 'ARYAOS_CAPABILITIES' /usr/local/sbin/aryaos-role "aryaos-role has the capability model"
 require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -10,7 +10,31 @@ import time
 import xml.etree.ElementTree as ET
 
 
-SERVICES = ("charontak", "lincot", "adsbcot", "aiscot", "dronecot")
+SERVICES = (
+    "charontak",
+    "lincot",
+    "adsbcot",
+    "aiscot",
+    "dronecot",
+    "dronecot-wifi",
+    "dronecot-dronescout",
+    "sapientcot",
+)
+
+SITE_CONFIG = "/etc/aryaos/aryaos-config.txt"
+DEFAULT_PRODUCT = "DragonEgg"
+
+# Capability key -> (human label, capability unit, default sensor description).
+# Mirrors the capability registry in aryaos-role.
+CAPABILITIES = {
+    "adsb": ("ADS-B / UAT", "adsbcot", "RTL-SDR / SoapySDR receiver"),
+    "ais": ("AIS", "aiscot", "AIS receiver"),
+    "dji": ("DJI DroneID", "dronecot", "AntSDR (DJI OcuSync)"),
+    "wifi-rid": ("Wi-Fi Remote ID", "dronecot-wifi", "Wi-Fi monitor-mode adapter"),
+    "ds101": ("DroneScout DS101", "dronecot-dronescout", "BlueMark DS101 (OpenDroneID)"),
+    "sik": ("SiK Telemetry", "sikw00fcot", "SiK radio"),
+    "sapient": ("SAPIENT C-UAS", "sapientcot", "SAPIENT sensor (BSI Flex 335)"),
+}
 
 
 def _read(path: str) -> str:
@@ -107,15 +131,64 @@ def _roles() -> dict[str, str]:
     return {
         "adsb": str(_service_state("adsbcot") == "active").lower(),
         "ais": str(_service_state("aiscot") == "active").lower(),
-        "uas": str(_service_state("dronecot") == "active").lower(),
+        "uas": str(
+            _service_state("dronecot") == "active"
+            or _service_state("dronecot-wifi") == "active"
+            or _service_state("dronecot-dronescout") == "active"
+        ).lower(),
     }
+
+
+def _config(key: str) -> str:
+    """Read a KEY="value" from the AryaOS site config."""
+    for line in _read(SITE_CONFIG).splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line.split("=", 1)[1].strip().strip("\"'")
+    return ""
+
+
+def _wifi_adapter() -> str:
+    """Best-effort model of the attached Wi-Fi monitor adapter (for wifi-rid)."""
+    lsusb = _run(["/usr/bin/lsusb"], timeout=1.0)
+    for line in lsusb.splitlines():
+        low = line.lower()
+        if "ar9271" in low or ("atheros" in low and "802.11" in low):
+            return "Atheros AR9271"
+        if "8812" in low or "8814" in low or "8821" in low or "realtek" in low and "wlan" in low:
+            return "Realtek Wi-Fi adapter"
+    return ""
+
+
+def _capabilities() -> list[dict[str, str]]:
+    """Active capabilities from site config, with label + live state + sensor."""
+    caps = _config("ARYAOS_CAPABILITIES").replace(",", " ").split()
+    out: list[dict[str, str]] = []
+    for key in caps:
+        label, unit, sensor = CAPABILITIES.get(key, (key, "", ""))
+        if key == "wifi-rid":
+            sensor = _wifi_adapter() or sensor
+        out.append(
+            {
+                "key": key,
+                "label": label,
+                "active": str(bool(unit) and _service_state(unit) == "active").lower(),
+                "sensor": sensor,
+            }
+        )
+    return out
 
 
 def main() -> int:
     hostname = socket.gethostname().split(".", 1)[0]
     load1, load5, load15 = _loadavg()
 
-    root = ET.Element("__aryaos", {"version": "1"})
+    root = ET.Element("__aryaos", {"version": "2"})
+    ET.SubElement(
+        root,
+        "product",
+        {"line": _config("ARYAOS_PRODUCT") or DEFAULT_PRODUCT},
+    )
     ET.SubElement(
         root,
         "host",
@@ -144,7 +217,13 @@ def main() -> int:
     )
     services = ET.SubElement(root, "services")
     for svc in SERVICES:
-        services.set(svc, _service_state(svc))
+        # XML attribute names can't contain '-'; normalize for the services map.
+        services.set(svc.replace("-", "_"), _service_state(svc))
+    # Advertised capabilities (what this box can receive), plus the legacy
+    # <roles> block for older neighbor caches.
+    caps_el = ET.SubElement(root, "capabilities")
+    for cap in _capabilities():
+        ET.SubElement(caps_el, "capability", cap)
     ET.SubElement(root, "roles", _roles())
     print(ET.tostring(root, encoding="unicode", short_empty_elements=True))
     return 0

--- a/shared_files/aryaos/aryaos-neighbord
+++ b/shared_files/aryaos/aryaos-neighbord
@@ -37,6 +37,14 @@ def _child_attrs(parent: ET.Element, name: str) -> dict[str, str]:
     return {}
 
 
+def _capabilities(parent: ET.Element) -> list[dict[str, str]]:
+    """Parse the <capabilities><capability .../></capabilities> block (beacon v2)."""
+    for child in parent:
+        if _strip_ns(child.tag) == "capabilities":
+            return [dict(c.attrib) for c in child if _strip_ns(c.tag) == "capability"]
+    return []
+
+
 def _aryaos_detail(root: ET.Element) -> ET.Element | None:
     detail = None
     for child in root:
@@ -211,6 +219,8 @@ def _parse_event(data: bytes, source_ip: str) -> tuple[str, dict] | None:
     system = _child_attrs(aryaos, "system")
     services = _child_attrs(aryaos, "services")
     roles = _child_attrs(aryaos, "roles")
+    product = _child_attrs(aryaos, "product")
+    capabilities = _capabilities(aryaos)
     point = _point(root)
     name = host.get("name") or root.attrib.get("uid") or source_ip
     now = int(time.time())
@@ -225,6 +235,8 @@ def _parse_event(data: bytes, source_ip: str) -> tuple[str, dict] | None:
         "system": system,
         "services": services,
         "roles": roles,
+        "product": product,
+        "capabilities": capabilities,
         "point": point,
     }
     return name, item

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -1,15 +1,25 @@
 #!/bin/bash
-# aryaos-role — switch the device's sensor role at runtime.
+# aryaos-role — set the device's product line + sensor capabilities at runtime.
+#
+# AryaOS boxes are modeled as a PRODUCT LINE (identity/branding) carrying a set
+# of CAPABILITIES (what receivers are attached and active):
+#   - AryaAir   — airspace SA (ADS-B/UAT, Wi-Fi/DJI drone Remote ID)
+#   - AryaSea   — maritime SA (AIS)
+#   - DragonEgg — general-purpose SIGINT + TAK gateway (any capability)
+#
+# Capabilities map to sensor systemd units; a capability set enables the union of
+# those units and disables the rest. The CoT core (charontak, lincot, gpstak,
+# gpsd) is never touched — it always runs.
 #
 # Subcommands:
-#   list        JSON: available roles, their units, and the current role.
-#   set ROLE    Enable/start the role's sensor units, disable/stop the rest,
-#               and persist ARYAOS_ROLE in /etc/aryaos/aryaos-config.txt.
+#   list                 JSON: product, capabilities, available caps/units, roles.
+#   product LINE         Set the product line and apply its default capabilities.
+#   caps CAP...          Set the active capability set (space/comma separated).
+#   set ROLE             Back-compat: apply a legacy role as a capability preset.
 #
-# Roles select which *sensor* pipelines run; the CoT core (charontak, lincot,
-# gpstak, gpsd) is never touched. The ADS-B decoder unit follows
-# ARYAOS_ADSB_DECODER (readsb | dump1090_fa). Units missing from the image
-# (e.g. optional decoders) are skipped, not errors.
+# Capability keys: adsb ais dji wifi-rid ds101 sik sapient
+# The ADS-B decoder unit follows ARYAOS_ADSB_DECODER (readsb | dump1090_fa).
+# Units missing from the image are skipped, not errors.
 #
 # Backend for the "Device role" card in Cockpit -> AryaOS Site.
 #
@@ -19,11 +29,16 @@
 set -euo pipefail
 
 SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
-ROLES="multi air maritime cuas relay"
-DEFAULT_ROLE="multi"
+PRODUCTS="AryaAir AryaSea DragonEgg"
+CAPS="adsb ais dji wifi-rid ds101 sik sapient"
+LEGACY_ROLES="multi air maritime cuas relay"
+DEFAULT_PRODUCT="DragonEgg"
 
 usage() {
-	echo "usage: aryaos-role {list | set ROLE}  (roles: ${ROLES})" >&2
+	echo "usage: aryaos-role {list | product LINE | caps CAP... | set ROLE}" >&2
+	echo "  products: ${PRODUCTS}" >&2
+	echo "  caps:     ${CAPS}" >&2
+	echo "  roles:    ${LEGACY_ROLES}  (legacy presets)" >&2
 	exit 2
 }
 
@@ -43,9 +58,9 @@ config_get() {
 config_set() {
 	local key="$1" value="$2"
 	if grep -qE "^#?\s*${key}=" "${SITE_CONFIG}"; then
-		sed -i "s|^#\?\s*${key}=.*|${key}=${value}|" "${SITE_CONFIG}"
+		sed -i "s|^#\?\s*${key}=.*|${key}=\"${value}\"|" "${SITE_CONFIG}"
 	else
-		printf '%s=%s\n' "${key}" "${value}" >> "${SITE_CONFIG}"
+		printf '%s="%s"\n' "${key}" "${value}" >> "${SITE_CONFIG}"
 	fi
 }
 
@@ -59,68 +74,108 @@ adsb_decoder_unit() {
 	fi
 }
 
-# Sensor unit sets per role. The unused ADS-B decoder is always disabled so a
-# decoder switch in site config takes effect on the next role apply.
-role_units() {
-	local role="$1"
-	local adsb_units ais_units drone_units
-	adsb_units="$(adsb_decoder_unit) dump978-fa adsbcot gdltak"
-	ais_units="ais-catcher aiscot"
-	drone_units="dronecot sikw00fcot sapientcot"
-	case "${role}" in
-		multi)    echo "${adsb_units} ${ais_units} ${drone_units}" ;;
-		air)      echo "${adsb_units}" ;;
-		maritime) echo "${ais_units}" ;;
-		cuas)     echo "${drone_units}" ;;
+# Capability -> systemd sensor units.
+cap_units() {
+	case "$1" in
+		adsb)     echo "$(adsb_decoder_unit) dump978-fa adsbcot gdltak" ;;
+		ais)      echo "ais-catcher aiscot" ;;
+		dji)      echo "dronecot" ;;
+		wifi-rid) echo "dronecot-wifi" ;;
+		ds101)    echo "dronecot-dronescout" ;;
+		sik)      echo "sikw00fcot" ;;
+		sapient)  echo "sapientcot" ;;
+		*)        return 1 ;;
+	esac
+}
+
+# Capability -> human-readable label (used by the beacon and Cockpit).
+cap_label() {
+	case "$1" in
+		adsb)     echo "ADS-B / UAT" ;;
+		ais)      echo "AIS" ;;
+		dji)      echo "DJI DroneID" ;;
+		wifi-rid) echo "Wi-Fi Remote ID" ;;
+		ds101)    echo "DroneScout DS101" ;;
+		sik)      echo "SiK Telemetry" ;;
+		sapient)  echo "SAPIENT C-UAS" ;;
+		*)        echo "$1" ;;
+	esac
+}
+
+# Product line -> default capability set applied by `product`.
+product_default_caps() {
+	case "$1" in
+		AryaAir)   echo "adsb" ;;
+		AryaSea)   echo "ais" ;;
+		DragonEgg) echo "" ;;
+		*)         return 1 ;;
+	esac
+}
+
+# Legacy role -> capability set (back-compat for `set` and Cockpit's role card).
+role_caps() {
+	case "$1" in
+		multi)    echo "adsb ais dji sik sapient" ;;
+		air)      echo "adsb" ;;
+		maritime) echo "ais" ;;
+		cuas)     echo "dji sik sapient" ;;
 		relay)    echo "" ;;
 		*)        return 1 ;;
 	esac
 }
 
 all_managed_units() {
-	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot dronecot sikw00fcot sapientcot"
+	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot \
+		dronecot dronecot-wifi dronecot-dronescout sikw00fcot sapientcot"
+}
+
+# Expand a capability list to the (deduplicated) union of its units.
+units_for_caps() {
+	local cap u seen=" "
+	for cap in $1; do
+		for u in $(cap_units "${cap}" 2>/dev/null || true); do
+			[[ "${seen}" == *" ${u} "* ]] || { printf '%s ' "${u}"; seen="${seen}${u} "; }
+		done
+	done
+}
+
+NM_UNMANAGE_CONF="/etc/NetworkManager/conf.d/99-aryaos-wifi-rid-unmanaged.conf"
+
+# The Wi-Fi Remote ID monitor adapter must not be managed by NetworkManager /
+# wpa_supplicant: on an ath9k_htc monitor interface wpa_supplicant logs
+# "Registration to specific type not supported", and NM flaps the link out from
+# under the dronecot-wifi sniffer. Persist an unmanaged marker while the wifi-rid
+# capability is active; remove it otherwise. Gated on the capability so boxes
+# that use the adapter as a normal client are unaffected.
+wifi_rid_nm_unmanage() {
+	local active="$1" iface="wlan1"
+	if [[ -r /etc/default/dronecot-wifi ]]; then
+		iface="$(sed -n 's/^WIFI_INTERFACE=//p' /etc/default/dronecot-wifi | tail -1 | tr -d '"' | xargs || true)"
+	fi
+	iface="${iface:-wlan1}"
+	if [[ "${active}" == 1 ]]; then
+		install -d -m 0755 /etc/NetworkManager/conf.d 2>/dev/null || true
+		printf '# Managed by aryaos-role (wifi-rid capability). Do not edit.\n[keyfile]\nunmanaged-devices=interface-name:%s\n' \
+			"${iface}" > "${NM_UNMANAGE_CONF}"
+	else
+		rm -f "${NM_UNMANAGE_CONF}" 2>/dev/null || true
+	fi
+	systemctl reload NetworkManager 2>/dev/null || nmcli general reload 2>/dev/null || true
 }
 
 unit_exists() {
 	# Capture and test rather than `systemctl ... | grep -q .`: under
 	# `set -o pipefail`, grep -q closes the pipe on its first match, systemctl
 	# gets SIGPIPE, and the pipeline reports failure — which would make this
-	# return false for units that exist, so `set` would enable nothing.
+	# return false for units that exist, so `apply` would enable nothing.
 	local out
 	out="$(systemctl list-unit-files --no-legend "$1.service" 2>/dev/null || true)"
 	[[ -n "${out}" ]]
 }
 
-list_json() {
-	local current
-	current="$(config_get ARYAOS_ROLE)"
-	[[ -n "${current}" ]] || current="${DEFAULT_ROLE}"
-	local role units first=1
-	printf '{"current": "%s", "roles": {' "${current}"
-	for role in ${ROLES}; do
-		units="$(role_units "${role}")"
-		[[ "${first}" == "1" ]] || printf ', '
-		first=0
-		printf '"%s": {"units": [' "${role}"
-		local u sep=""
-		for u in ${units}; do
-			printf '%s"%s"' "${sep}" "${u}"
-			sep=", "
-		done
-		printf ']}'
-	done
-	printf '}}\n'
-}
-
-set_role() {
-	local role="$1"
-	local wanted
-	if ! wanted="$(role_units "${role}")"; then
-		echo "aryaos-role: unknown role '${role}' (roles: ${ROLES})" >&2
-		exit 2
-	fi
-
-	local unit
+# Enable the wanted units, disable every other managed unit.
+apply_units() {
+	local wanted="$1" unit
 	for unit in $(all_managed_units); do
 		unit_exists "${unit}" || continue
 		if [[ " ${wanted} " == *" ${unit} "* ]]; then
@@ -132,28 +187,106 @@ set_role() {
 			systemctl disable --now "${unit}" >/dev/null 2>&1 || true
 		fi
 	done
+}
 
-	config_set ARYAOS_ROLE "${role}"
-
-	# A role apply is the authoritative decoder layout — clear any per-dongle SDR
-	# re-tasks (aryaos-sdr task) so they don't fight the role at the next boot.
+# Persist caps + a nearest-legacy-role alias, clear SDR re-tasks, re-run
+# serial-assign when AIS is now active (its dAISy elimination guard runs at boot
+# before the capability set is known).
+persist_and_settle() {
+	local caps="$1" wanted="$2"
+	config_set ARYAOS_CAPABILITIES "${caps}"
+	local r
+	for r in ${LEGACY_ROLES}; do
+		[[ "$(role_caps "${r}")" == "${caps}" ]] && { config_set ARYAOS_ROLE "${r}"; break; }
+	done
 	rm -f /etc/aryaos/sdr-tasks 2>/dev/null || true
-
-	# aryaos-serial-assign only wires the dAISy when ais-catcher is enabled (its
-	# elimination guard). It runs at boot before the role is known, so re-run it
-	# after enabling a role that uses AIS — otherwise selecting maritime/multi
-	# leaves ais-catcher with an empty SERIAL_PORT until the next boot.
 	if [[ " ${wanted} " == *" ais-catcher "* ]] && [[ -x /usr/local/sbin/aryaos-serial-assign ]]; then
 		/usr/local/sbin/aryaos-serial-assign || true
 	fi
+}
 
+set_caps() {
+	local caps
+	caps="$(echo "$1" | tr ',' ' ' | xargs || true)"
+	local cap
+	for cap in ${caps}; do
+		cap_units "${cap}" >/dev/null 2>&1 || { echo "aryaos-role: unknown capability '${cap}' (caps: ${CAPS})" >&2; exit 2; }
+	done
+	local wanted
+	wanted="$(units_for_caps "${caps}" | xargs || true)"
+	apply_units "${wanted}"
+	if [[ " ${caps} " == *" wifi-rid "* ]]; then wifi_rid_nm_unmanage 1; else wifi_rid_nm_unmanage 0; fi
+	persist_and_settle "${caps}" "${wanted}"
+	echo "Capabilities set to: ${caps:-<none>}"
+}
+
+set_product() {
+	local product="$1" defaults
+	if ! defaults="$(product_default_caps "${product}")"; then
+		echo "aryaos-role: unknown product '${product}' (products: ${PRODUCTS})" >&2
+		exit 2
+	fi
+	config_set ARYAOS_PRODUCT "${product}"
+	set_caps "${defaults}"
+	echo "Product line set to '${product}'."
+}
+
+set_role() {
+	local role="$1" caps
+	if ! caps="$(role_caps "${role}")"; then
+		echo "aryaos-role: unknown role '${role}' (roles: ${LEGACY_ROLES})" >&2
+		exit 2
+	fi
+	set_caps "${caps}"
 	echo "Device role set to '${role}'."
+}
+
+list_json() {
+	local product caps
+	product="$(config_get ARYAOS_PRODUCT)"; [[ -n "${product}" ]] || product="${DEFAULT_PRODUCT}"
+	caps="$(config_get ARYAOS_CAPABILITIES)"
+	printf '{"product": "%s", "products": [' "${product}"
+	local p sep=""
+	for p in ${PRODUCTS}; do printf '%s"%s"' "${sep}" "${p}"; sep=", "; done
+	printf '], "capabilities": "%s", "caps": {' "${caps}"
+	local c first=1
+	for c in ${CAPS}; do
+		[[ "${first}" == "1" ]] || printf ', '
+		first=0
+		printf '"%s": {"label": "%s", "units": [' "${c}" "$(cap_label "${c}")"
+		local u csep=""
+		for u in $(cap_units "${c}"); do printf '%s"%s"' "${csep}" "${u}"; csep=", "; done
+		printf ']}'
+	done
+	# Legacy roles block so the existing Cockpit role card keeps working.
+	printf '}, "current": "%s", "roles": {' "$(config_get ARYAOS_ROLE)"
+	local rfirst=1
+	for p in ${LEGACY_ROLES}; do
+		[[ "${rfirst}" == "1" ]] || printf ', '
+		rfirst=0
+		printf '"%s": {"units": [' "${p}"
+		local u rsep=""
+		for u in $(units_for_caps "$(role_caps "${p}")"); do printf '%s"%s"' "${rsep}" "${u}"; rsep=", "; done
+		printf ']}'
+	done
+	printf '}}\n'
 }
 
 cmd="${1:-}"
 case "${cmd}" in
 	list)
 		list_json
+		;;
+	product)
+		require_root
+		[[ $# -eq 2 ]] || usage
+		set_product "$2"
+		;;
+	caps)
+		require_root
+		[[ $# -ge 2 ]] || usage
+		shift
+		set_caps "$*"
 		;;
 	set)
 		require_root

--- a/shared_files/aryaos/aryaos-wifi-monitor
+++ b/shared_files/aryaos/aryaos-wifi-monitor
@@ -34,6 +34,27 @@ iw dev "${IF}" set monitor none 2>/dev/null || iw dev "${IF}" set type monitor 2
 ip link set "${IF}" up 2>/dev/null || true
 iw dev "${IF}" set channel "${CH}" 2>/dev/null || true
 
+# 4) Record the detected adapter model in the dronecot-wifi env so the CoT
+#    payload's SIGINT/sensor detail reflects the real receiver hardware.
+DEF="/etc/default/dronecot-wifi"
+if [ -w "${DEF}" ] || [ -w "$(dirname "${DEF}")" ]; then
+	drv="$(basename "$(readlink -f "/sys/class/net/${IF}/device/driver" 2>/dev/null)" 2>/dev/null)"
+	model=""
+	case "${drv}" in
+		ath9k_htc) model="Atheros AR9271 (ath9k_htc)" ;;
+		*8821*|*8812*|*8814*|rtw*|rtl8*) model="Realtek ${drv}" ;;
+		"" ) : ;;
+		*) model="${drv}" ;;
+	esac
+	if [ -n "${model}" ]; then
+		if grep -q '^SENSOR_MODEL=' "${DEF}" 2>/dev/null; then
+			sed -i "s|^SENSOR_MODEL=.*|SENSOR_MODEL=${model}|" "${DEF}"
+		else
+			printf 'SENSOR_MODEL=%s\n' "${model}" >> "${DEF}"
+		fi
+	fi
+fi
+
 if iw dev "${IF}" info 2>/dev/null | grep -qi "type monitor"; then
 	echo "aryaos-wifi-monitor: ${IF} in monitor mode (ch ${CH})"
 else

--- a/shared_files/aryaos/dronecot-wifi.default
+++ b/shared_files/aryaos/dronecot-wifi.default
@@ -19,3 +19,10 @@ WIFI_INTERFACE=wlan1
 WIFI_HOP_CHANNELS=1,6,11
 WIFI_HOP_DWELL=3,1
 SENSOR_ID=wifi-rid
+
+# SIGINT / receiver detail carried in the CoT payload (dronecot >= 2.2.5):
+# SENSOR_TYPE = detection method/capability; SENSOR_MODEL = receiver hardware.
+# SENSOR_MODEL is auto-updated by aryaos-wifi-monitor (ExecStartPre) to the
+# detected adapter (e.g. "Atheros AR9271"); the value below is the fallback.
+SENSOR_TYPE=Wi-Fi Open Drone ID
+SENSOR_MODEL=Wi-Fi monitor adapter

--- a/shared_files/aryaos/systemd/aryaos-serial-assign.service
+++ b/shared_files/aryaos/systemd/aryaos-serial-assign.service
@@ -5,7 +5,12 @@ Documentation=https://github.com/snstac/aryaos
 # /etc/default/{gpsd,ais-catcher} before those services read it. It also
 # try-restarts them afterward, so it is correct even if they started first.
 After=local-fs.target
-Before=ais-catcher.service gpsd.service
+# Order before gpsd.socket too: gpsd is socket-activated, so a client (portal
+# CGI, Cockpit, gpstak) connecting to the socket triggers gpsd to open the GPS
+# tty WHILE this service is still probing it for NMEA — which logs a spurious
+# "Device or resource busy" error. Holding the socket until assignment is done
+# eliminates that race.
+Before=ais-catcher.service gpsd.service gpsd.socket
 
 [Service]
 Type=oneshot

--- a/shared_files/aryaos/systemd/gpsd.socket.d/after-serial-assign.conf
+++ b/shared_files/aryaos/systemd/gpsd.socket.d/after-serial-assign.conf
@@ -1,0 +1,9 @@
+# Don't accept gpsd clients until aryaos-serial-assign has finished probing the
+# GPS tty — otherwise an early client (Cockpit / portal CGI / gpstak) activates
+# gpsd mid-probe and it logs a spurious "/dev/ttyACM0: Device or resource busy".
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+[Unit]
+Wants=aryaos-serial-assign.service
+After=aryaos-serial-assign.service

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -376,6 +376,10 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/lighttpd.service.d/aryaos-net
 install -d -m 0755 "${ROOTFS_DIR}/etc/systemd/system/gpsd.socket.d"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/gpsd.socket.d/socket-group.conf" \
 	"${ROOTFS_DIR}/etc/systemd/system/gpsd.socket.d/socket-group.conf"
+# Order gpsd.socket after aryaos-serial-assign so socket-activation can't open the
+# GPS tty while it's still being probed ("Device or resource busy" boot warning).
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/gpsd.socket.d/after-serial-assign.conf" \
+	"${ROOTFS_DIR}/etc/systemd/system/gpsd.socket.d/after-serial-assign.conf"
 
 
 # WiFi


### PR DESCRIPTION
Models boxes as product line (AryaAir/AryaSea/DragonEgg) × capabilities; `aryaos-role` gains product/caps. Beacon v2 advertises product + capabilities (adapter auto-detected). Zero-warnings: gpsd socket-activation race + NM-unmanage the wifi-rid monitor adapter (kills wpa_supplicant warning). Validated live on .60. Pairs with dronecot 2.2.5 (SIGINT payload), lincot (nerdy GPS CoT), cockpit-aryaos (nerdy GPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)