### PR TITLE
Revert gpsd.socket ordering (caused a boot cycle + failed unit); pause gpsd in-script

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -245,8 +245,7 @@ require_path /usr/lib/python3/dist-packages/scapy/all.py
 require_path /usr/local/sbin/aryaos-wifi-monitor
 require_grep 'aryaos-wifi-monitor' /etc/systemd/system/dronecot-wifi.service "dronecot-wifi preps monitor mode via ExecStartPre"
 require_grep 'SENSOR_TYPE' /etc/default/dronecot-wifi "dronecot-wifi carries SIGINT sensor detail"
-# Capability model + zero-warnings: gpsd race ordering drop-in.
-require_path /etc/systemd/system/gpsd.socket.d/after-serial-assign.conf
+# Capability model.
 require_grep 'ARYAOS_CAPABILITIES' /usr/local/sbin/aryaos-role "aryaos-role has the capability model"
 require_unit gdltak.service
 require_unit lincot.service

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -40,6 +40,30 @@ wait_for_serial() {
 	return 0
 }
 
+# gpsd can grab the GPS tty while we are probing it, and then logs
+# "Device or resource busy" — it recovers, but it is a scary boot error for
+# something that is working fine. gpsd is both socket-activated AND hotplug
+# started (udev calls gpsdctl on add), so unit ordering cannot close this race:
+# ordering gpsd.socket after this unit forms a sockets.target/basic.target cycle
+# that systemd breaks by failing the socket. Instead, hold gpsd off for the few
+# seconds we need the port, and ALWAYS put it back.
+GPSD_PAUSED=0
+
+pause_gpsd() {
+	command -v systemctl >/dev/null 2>&1 || return 0
+	GPSD_PAUSED=1
+	systemctl stop gpsd.service gpsd.socket >/dev/null 2>&1 || true
+}
+
+resume_gpsd() {
+	[[ "${GPSD_PAUSED}" == 1 ]] || return 0
+	GPSD_PAUSED=0
+	# Start the socket (it is enabled; this is just early) and let anything that
+	# was already using gpsd pick the new device up.
+	systemctl start gpsd.socket >/dev/null 2>&1 || true
+	systemctl try-restart gpsd.service >/dev/null 2>&1 || true
+}
+
 # True for an ESP32-based Remote ID receiver (BlueMark DroneScout DS101 /
 # DroneBeacon, SiKW00F) — these speak binary MAVLink, never NMEA, so they must
 # NOT be probed or assigned as a GPS/dAISy (they'd otherwise be swept up as a
@@ -94,6 +118,11 @@ main() {
 	local gps_dev="" ais_dev="" ais_baud="$AIS_BAUD_DEFAULT" cls dev
 	local -a leftover=()
 
+	# Keep gpsd off the ports while we probe, and restore it no matter how we
+	# leave (error, signal, or success) — a half-run must never strand gpsd.
+	trap resume_gpsd EXIT INT TERM
+	pause_gpsd
+
 	shopt -s nullglob
 	for dev in /dev/serial/by-id/*; do
 		if is_rid_device "$dev"; then
@@ -138,9 +167,12 @@ main() {
 	fi
 	[[ -z "$gps_dev$ais_dev" ]] && log "no GPS or AIS serial identified"
 
+	# Devices are free again: let gpsd back in (with the new DEVICES) before
+	# touching the other consumers.
+	resume_gpsd
+
 	# Pick up new assignments if the consumers are already running.
 	if [[ "$changed" == 1 ]]; then
-		systemctl try-restart gpsd.service >/dev/null 2>&1 || true
 		systemctl try-restart ais-catcher.service >/dev/null 2>&1 || true
 	fi
 }

--- a/shared_files/aryaos/systemd/aryaos-serial-assign.service
+++ b/shared_files/aryaos/systemd/aryaos-serial-assign.service
@@ -5,12 +5,12 @@ Documentation=https://github.com/snstac/aryaos
 # /etc/default/{gpsd,ais-catcher} before those services read it. It also
 # try-restarts them afterward, so it is correct even if they started first.
 After=local-fs.target
-# Order before gpsd.socket too: gpsd is socket-activated, so a client (portal
-# CGI, Cockpit, gpstak) connecting to the socket triggers gpsd to open the GPS
-# tty WHILE this service is still probing it for NMEA — which logs a spurious
-# "Device or resource busy" error. Holding the socket until assignment is done
-# eliminates that race.
-Before=ais-catcher.service gpsd.service gpsd.socket
+# NOTE: do NOT order gpsd.socket after this unit. gpsd.socket belongs to
+# sockets.target, which basic.target requires, while this unit is
+# WantedBy=multi-user.target — ordering the socket after us forms a cycle that
+# systemd breaks by deleting jobs, leaving gpsd.socket failed. The open-while-
+# probing race is handled inside the script instead (it pauses gpsd).
+Before=ais-catcher.service gpsd.service
 
 [Service]
 Type=oneshot

--- a/shared_files/aryaos/systemd/gpsd.socket.d/after-serial-assign.conf
+++ b/shared_files/aryaos/systemd/gpsd.socket.d/after-serial-assign.conf
@@ -1,9 +1,0 @@
-# Don't accept gpsd clients until aryaos-serial-assign has finished probing the
-# GPS tty — otherwise an early client (Cockpit / portal CGI / gpstak) activates
-# gpsd mid-probe and it logs a spurious "/dev/ttyACM0: Device or resource busy".
-#
-# SPDX-License-Identifier: Apache-2.0
-# Copyright Sensors & Signals LLC https://www.snstac.com/
-[Unit]
-Wants=aryaos-serial-assign.service
-After=aryaos-serial-assign.service

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -376,10 +376,6 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/lighttpd.service.d/aryaos-net
 install -d -m 0755 "${ROOTFS_DIR}/etc/systemd/system/gpsd.socket.d"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/gpsd.socket.d/socket-group.conf" \
 	"${ROOTFS_DIR}/etc/systemd/system/gpsd.socket.d/socket-group.conf"
-# Order gpsd.socket after aryaos-serial-assign so socket-activation can't open the
-# GPS tty while it's still being probed ("Device or resource busy" boot warning).
-install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/gpsd.socket.d/after-serial-assign.conf" \
-	"${ROOTFS_DIR}/etc/systemd/system/gpsd.socket.d/after-serial-assign.conf"
 
 
 # WiFi


### PR DESCRIPTION
**Self-inflicted regression, caught by HIL validation of cf483f8.**

Ordering `gpsd.socket After=aryaos-serial-assign` formed a cycle (socket ∈ sockets.target ← basic.target; serial-assign is WantedBy=multi-user.target). systemd broke it by deleting the socket's start job → `gpsd.service` started without inherited fds → gpsd self-bound :2947 → `gpsd.socket` ended **failed (resources)** on every box with a GPS.

Unit ordering can't fix this race anyway (gpsd is socket-activated *and* udev-hotplug started via gpsdctl). `aryaos-serial-assign` now pauses gpsd around its probe and always restores it via a trap.

Verified on aryaos-88d8: no failed units, gpsd socket-activated on the assigned u-blox, gpspipe responding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)