### PR TITLE
Ship every sensor gateway disabled; capability turns them on

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -296,6 +296,35 @@ require_path /etc/systemd/system/multi-user.target.wants/fail2ban.service
 require_grep 'zone=trusted' /etc/NetworkManager/system-connections/aryaos-antsdr.nmconnection "AntSDR link in trusted firewall zone"
 require_grep 'web-tls-regenerated' /usr/local/sbin/aryaos-firstboot.sh "firstboot mints per-device web TLS cert"
 
+# Sensors OFF by default: capability drives what runs. The sensor debs enable
+# themselves in postinst, so this regresses the moment a package is added or
+# reordered — assert the enablement symlinks are genuinely absent.
+forbid_enabled() {
+	local unit="$1" found=""
+	local d
+	for d in etc/systemd/system/multi-user.target.wants \
+		etc/systemd/system/default.target.wants \
+		usr/lib/systemd/system/multi-user.target.wants; do
+		if [[ -e "${MNT}/${d}/${unit}" || -L "${MNT}/${d}/${unit}" ]]; then
+			found="${d}"
+			break
+		fi
+	done
+	if [[ -z "${found}" ]]; then
+		ok "${unit} not enabled by default"
+	else
+		fail "${unit} is enabled by default (${found}) — sensors must be capability-gated"
+	fi
+}
+for _u in readsb.service dump978-fa.service adsbcot.service aiscot.service \
+	dronecot.service sikw00fcot.service ais-catcher.service sapientcot.service \
+	dronecot-wifi.service dronecot-dronescout.service; do
+	forbid_enabled "${_u}"
+done
+require_grep '^ARYAOS_CAPABILITIES=""$' /etc/aryaos/aryaos-config.txt "no sensor capabilities enabled out of the box"
+# ...while the CoT core still runs unconditionally.
+require_path /etc/systemd/system/multi-user.target.wants/charontak.service
+
 # One-click updates (Cockpit -> AryaOS Site drives aryaos-update)
 require_path /usr/local/sbin/aryaos-update
 require_path /etc/systemd/system/aryaos-update.service

--- a/shared_files/aryaos/aryaos-config.txt
+++ b/shared_files/aryaos/aryaos-config.txt
@@ -31,6 +31,21 @@ PYTAK_MULTICAST_LOCAL_ADDR=10.41.0.1
 # DEPRECATED: Legacy setting.
 WIFI_AP_IP=10.41.0.1
 
+# Product line: AryaAir (airspace SA) | AryaSea (maritime SA) | DragonEgg (general SIGINT).
+ARYAOS_PRODUCT="DragonEgg"
+
+# Active sensor capabilities: adsb ais dji wifi-rid ds101 sik sapient
+#
+# EMPTY BY DEFAULT — the image ships with every sensor gateway disabled. A box
+# with no radios attached should be quiet, not crash-looping decoders it has no
+# hardware for. The CoT core (charontak, lincot, gpsd) always runs regardless,
+# so an out-of-box unit is still a working TAK node.
+#
+# Turn capabilities on with:
+#   sudo aryaos-role product AryaAir     # applies that line's defaults
+#   sudo aryaos-role caps adsb wifi-rid  # or pick them explicitly
+ARYAOS_CAPABILITIES=""
+
 # 1090 MHz ADS-B decoder: readsb or dump1090_fa (only one may be enabled). Must match image build
 # (vars.yml aryaos_adsb_decoder). Changing this alone does not reconfigure systemd — see docs/config.md.
 ARYAOS_ADSB_DECODER=readsb

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -15,6 +15,7 @@
 #   list                 JSON: product, capabilities, available caps/units, roles.
 #   product LINE         Set the product line and apply its default capabilities.
 #   caps CAP...          Set the active capability set (space/comma separated).
+#                        Use "none" to disable every sensor (bare CoT node).
 #   set ROLE             Back-compat: apply a legacy role as a capability preset.
 #
 # Capability keys: adsb ais dji wifi-rid ds101 sik sapient
@@ -37,7 +38,7 @@ DEFAULT_PRODUCT="DragonEgg"
 usage() {
 	echo "usage: aryaos-role {list | product LINE | caps CAP... | set ROLE}" >&2
 	echo "  products: ${PRODUCTS}" >&2
-	echo "  caps:     ${CAPS}" >&2
+	echo "  caps:     ${CAPS}  (or 'none' for a bare CoT node)" >&2
 	echo "  roles:    ${LEGACY_ROLES}  (legacy presets)" >&2
 	exit 2
 }
@@ -208,6 +209,11 @@ persist_and_settle() {
 set_caps() {
 	local caps
 	caps="$(echo "$1" | tr ',' ' ' | xargs || true)"
+	# "none"/"off" is the explicit way to run a bare CoT node — clearer than
+	# passing a quoted empty string, and it is what the image ships as.
+	case "${caps}" in
+		none | off) caps="" ;;
+	esac
 	local cap
 	for cap in ${caps}; do
 		cap_units "${cap}" >/dev/null 2>&1 || { echo "aryaos-role: unknown capability '${cap}' (caps: ${CAPS})" >&2; exit 2; }

--- a/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
+++ b/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+# Ship every sensor gateway DISABLED.
+#
+# The sensor debs enable themselves in their postinst, so a stock image booted
+# with no radios attached spends its life crash-looping: readsb/dump978-fa/
+# adsbcot restart dozens of times before systemd gives up, aiscot and
+# sikw00fcot sit "active" against hardware that isn't there, and the journal
+# fills with failures that look like a broken appliance.
+#
+# Instead, capability drives everything: nothing sensor-related runs until
+# `aryaos-role product <line>` / `aryaos-role caps <cap...>` turns it on. The
+# CoT core (charontak, lincot, gpsd) is untouched and always runs, so a box with
+# no capabilities is still a working TAK node that beacons its own position.
+#
+# This runs in the LAST stage on purpose — stage-bt-pan carries EXPORT_IMAGE —
+# so it lands after every sensor package (and its postinst) is installed.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+SENSOR_UNITS="
+readsb
+dump1090-fa
+dump978-fa
+adsbcot
+gdltak
+ais-catcher
+aiscot
+dronecot
+dronecot-wifi
+dronecot-dronescout
+sikw00fcot
+sapientcot
+"
+
+for unit in ${SENSOR_UNITS}; do
+	if systemctl list-unit-files --no-legend "${unit}.service" 2>/dev/null | grep -q .; then
+		systemctl disable "${unit}.service" >/dev/null 2>&1 || true
+		echo "sensors-off: disabled ${unit}.service"
+	fi
+done
+
+# Make the default explicit rather than implied by an empty variable, so
+# `aryaos-role list` and the capability beacon report something meaningful on a
+# fresh image.
+CONFIG="/etc/aryaos/aryaos-config.txt"
+if [[ -f "${CONFIG}" ]]; then
+	grep -qE '^#?\s*ARYAOS_PRODUCT=' "${CONFIG}" || printf 'ARYAOS_PRODUCT="DragonEgg"\n' >>"${CONFIG}"
+	grep -qE '^#?\s*ARYAOS_CAPABILITIES=' "${CONFIG}" || printf 'ARYAOS_CAPABILITIES=""\n' >>"${CONFIG}"
+fi
+
+echo "sensors-off: image ships with no sensor capabilities enabled"


### PR DESCRIPTION
Sensor debs self-enable in postinst, so a stock image with no radios crash-loops: on cf483f8 boxes readsb restarted 19x (66 on one), adsbcot 14x, dump978-fa 10x, while aiscot/sikw00fcot ran against absent hardware.

- Final-stage step (stage-bt-pan = EXPORT_IMAGE, so after all sensor packages) disables all 12 sensor units.
- `ARYAOS_PRODUCT`/`ARYAOS_CAPABILITIES` written explicitly into aryaos-config.txt.
- `aryaos-role caps none|off` = explicit bare-CoT-node.
- verify-image asserts the enablement symlinks are ABSENT (regresses the moment a package is added), and that charontak stays enabled.

CoT core (charontak/lincot/gpsd) untouched — a capability-less box is still a working TAK node. Verified live on aryaos-fd66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)