### PR TITLE
Capability discovery: a box works out what hardware it has

### DIFF
--- a/docs/config/device-roles.md
+++ b/docs/config/device-roles.md
@@ -67,6 +67,55 @@ Because the units are *disabled*, the role sticks across reboots.
 !!! warning "Applying a role disables other sensors"
     Switching to `air` stops and disables the AIS and drone units; switching to `relay` stops **all** sensor units. This is intentional — pick the role that matches the mission. The CoT core keeps running regardless.
 
+## Capability discovery
+
+A box can work out what it is. `aryaos-capability-scan` probes the attached
+hardware and maps it to capabilities:
+
+```sh
+sudo aryaos-role discover           # report what's present, change nothing
+sudo aryaos-role discover --apply   # enable what the hardware supports
+```
+
+Example on a single-SDR node:
+
+```
+Detected hardware capabilities: adsb
+  adsb      yes        1 SDR(s): LimeSDR Mini [USB 3.0] 1DBB4189078E3F
+  ais       yes*       1 SDR(s) could run AIS
+                       * shares a radio with 'adsb'; enable manually with
+                         `aryaos-role caps ais` (or add a second receiver)
+  wifi-rid  no         no external Wi-Fi adapter
+  sapient   manual     network sensor — configure deliberately, never auto-detected
+```
+
+**This runs automatically once, at first boot.** The image ships every sensor
+disabled, so a bare unit stays quiet while a kitted one comes up configured. The
+marker `/etc/aryaos/.capabilities-autodetected` makes it a one-shot: a later
+deliberate `aryaos-role caps ...` is never overwritten.
+
+### What it will not guess
+
+Auto-apply is deliberately conservative, because enabling the wrong thing is
+worse than enabling nothing:
+
+- **Contended radios.** One SDR cannot serve ADS-B *and* AIS at once, so only
+  the higher-priority capability (`adsb`) is auto-enabled; the other is reported
+  as available with the reason it was held back.
+- **DS101 vs SiKW00F.** Both are ESP32-S3 (`303a:1001`) — the USB id cannot tell
+  them apart. The scanner probes the port for MAVLink framing (a DS101 speaks
+  it); if the port is silent or in use it reports `AMBIGUOUS` rather than
+  guessing.
+- **SAPIENT.** A network sensor with no local hardware signature; never
+  auto-detected.
+
+### Beacons advertise availability
+
+Each capability in the AryaOS beacon carries `active` (running now),
+`enabled` (in the capability set) and `available` (hardware detected). A fleet
+view can therefore spot a node with a Wi-Fi Remote ID adapter that is switched
+off, or a service running that nobody declared.
+
 ## Persistence and precedence
 
 - The current role lives in `ARYAOS_ROLE` in the site config. When unset, the effective role is `multi`.

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -247,6 +247,9 @@ require_grep 'aryaos-wifi-monitor' /etc/systemd/system/dronecot-wifi.service "dr
 require_grep 'SENSOR_TYPE' /etc/default/dronecot-wifi "dronecot-wifi carries SIGINT sensor detail"
 # Capability model.
 require_grep 'ARYAOS_CAPABILITIES' /usr/local/sbin/aryaos-role "aryaos-role has the capability model"
+require_path /usr/local/sbin/aryaos-capability-scan
+require_grep 'discover' /usr/local/sbin/aryaos-role "aryaos-role can discover hardware capabilities"
+require_grep 'capability-scan' /usr/local/sbin/aryaos-firstboot.sh "firstboot auto-detects capabilities"
 require_unit gdltak.service
 require_unit lincot.service
 require_unit charontak.service

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Detect which AryaOS sensor capabilities this box's hardware can support.
+
+Reports what is PRESENT, not what is running. `aryaos-role discover` maps this
+onto the capability set; the beacon advertises it so the fleet can see "that box
+has a Wi-Fi Remote ID adapter but it's switched off".
+
+Honesty rules, because guessing wrong is worse than saying "I don't know":
+  * An RTL-SDR can serve ADS-B *or* AIS *or* APRS — one dongle cannot do all
+    three at once. Capabilities that share a scarce radio are reported with the
+    number of radios available so the caller can decide.
+  * A DroneScout DS101 and a SiKW00F are BOTH ESP32-S3 (303a:1001) — the USB id
+    alone cannot tell them apart. We probe the port for MAVLink framing (the
+    DS101 speaks it, and that is what dronecot consumes) and mark the capability
+    ambiguous when the port is silent.
+  * SAPIENT is a network sensor with no local hardware signature; it is never
+    auto-detected and must be configured deliberately.
+
+Usage:
+  aryaos-capability-scan            # full JSON report
+  aryaos-capability-scan --caps     # conflict-free set safe to auto-enable
+  aryaos-capability-scan --detected # everything the hardware supports
+  aryaos-capability-scan --report   # human-readable table
+
+Copyright Sensors & Signals LLC https://www.snstac.com/
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import glob
+
+CONFIG = "/etc/aryaos/aryaos-config.txt"
+ESP32_VID_PID = ("303a", "1001")  # Espressif native USB (DS101 *and* SiKW00F)
+ONBOARD_WIFI_DRIVERS = {"brcmfmac"}  # the Pi's own radio: never a RID sniffer
+
+# When capabilities contend for one scarce radio, this is the order auto-apply
+# prefers. ADS-B first: it is the common air-picture case and the AryaAir
+# default. The loser stays "available" and can be enabled by hand.
+CONTENTION_PRIORITY = ("adsb", "ais")
+
+
+def _run(args, timeout=6.0):
+    try:
+        proc = subprocess.run(
+            args, check=False, capture_output=True, text=True, timeout=timeout
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return (proc.stdout or "").strip()
+
+
+def _read(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fp:
+            return fp.read()
+    except OSError:
+        return ""
+
+
+def _config(key):
+    for line in _read(CONFIG).splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line.split("=", 1)[1].strip().strip("\"'")
+    return ""
+
+
+# --- individual probes ------------------------------------------------------
+
+
+def probe_sdrs():
+    """Enumerate SDRs via aryaos-sdr (SoapySDR/rtl_test under the hood)."""
+    out = _run(["/usr/local/sbin/aryaos-sdr", "list"], timeout=15)
+    try:
+        return json.loads(out).get("devices", []) if out else []
+    except ValueError:
+        return []
+
+
+def probe_wifi_monitor():
+    """Find an external Wi-Fi adapter that could run monitor mode."""
+    found = []
+    for path in sorted(glob.glob("/sys/class/net/wlan*")):
+        iface = os.path.basename(path)
+        driver = ""
+        try:
+            driver = os.path.basename(os.path.realpath(f"{path}/device/driver"))
+        except OSError:
+            pass
+        if not driver or driver in ONBOARD_WIFI_DRIVERS:
+            continue
+        found.append({"interface": iface, "driver": driver})
+    return found
+
+
+def probe_esp32_serial():
+    """Locate ESP32-S3 USB-serial ports (DS101 and/or SiKW00F)."""
+    ports = []
+    for path in sorted(glob.glob("/dev/serial/by-id/*")):
+        props = _run(["/usr/bin/udevadm", "info", "-q", "property", "-n", path])
+        vid = re.search(r"^ID_VENDOR_ID=(\S+)$", props, re.M)
+        pid = re.search(r"^ID_MODEL_ID=(\S+)$", props, re.M)
+        if vid and pid and (vid.group(1), pid.group(1)) == ESP32_VID_PID:
+            ports.append(path)
+    return ports
+
+
+def probe_mavlink(port, seconds=3):
+    """Does this port emit MAVLink? Distinguishes a DS101 from a bare ESP32.
+
+    Read-only and non-destructive: if something else holds the port we simply
+    report unknown rather than fighting for it.
+    """
+    if not port or not os.path.exists(port):
+        return None
+    if _run(["/usr/bin/fuser", port], timeout=3):
+        return None  # in use — don't disturb a running dronecot
+    try:
+        import selectors
+
+        fd = os.open(port, os.O_RDONLY | os.O_NONBLOCK)
+    except OSError:
+        return None
+    try:
+        sel = selectors.DefaultSelector()
+        sel.register(fd, selectors.EVENT_READ)
+        import time
+
+        end = time.time() + seconds
+        buf = b""
+        while time.time() < end and len(buf) < 4096:
+            if sel.select(timeout=0.5):
+                try:
+                    chunk = os.read(fd, 1024)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                buf += chunk
+        # MAVLink v1 starts 0xFE, v2 starts 0xFD.
+        return bool(buf) and (b"\xfd" in buf or b"\xfe" in buf)
+    finally:
+        os.close(fd)
+
+
+def probe_antsdr():
+    """Is an AntSDR present on the point-to-point link?"""
+    bind = ""
+    for line in _read("/etc/default/dronecot").splitlines():
+        if line.startswith("DJI_BIND_ADDRESS="):
+            bind = line.split("=", 1)[1].strip().strip("\"'")
+    bind = bind or "172.31.100.1"
+    peer = bind.rsplit(".", 1)[0] + ".2"
+    neigh = _run(["/usr/sbin/ip", "neigh", "show", peer], timeout=3)
+    if re.search(r"REACHABLE|STALE|DELAY|PROBE", neigh):
+        return peer
+    if subprocess.call(
+        ["/usr/bin/ping", "-c1", "-W1", peer],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ) == 0:
+        return peer
+    return None
+
+
+def probe_ais_serial():
+    """A dAISy (or similar) NMEA AIS receiver wired up by aryaos-serial-assign."""
+    for line in _read("/etc/default/ais-catcher").splitlines():
+        if line.startswith("SERIAL_PORT="):
+            port = line.split("=", 1)[1].strip().strip("\"'")
+            if port and os.path.exists(port):
+                return port
+    return None
+
+
+# --- capability mapping -----------------------------------------------------
+
+
+def scan():
+    sdrs = probe_sdrs()
+    wifi = probe_wifi_monitor()
+    esp32 = probe_esp32_serial()
+    antsdr = probe_antsdr()
+    ais_serial = probe_ais_serial()
+
+    caps = {}
+
+    # ADS-B/UAT: needs at least one SDR.
+    caps["adsb"] = {
+        "available": bool(sdrs),
+        "evidence": (
+            f"{len(sdrs)} SDR(s): "
+            + ", ".join(d.get("label") or d.get("driver", "?") for d in sdrs)
+            if sdrs
+            else "no SDR detected"
+        ),
+    }
+
+    # AIS: a dedicated NMEA receiver, or a spare SDR. Flag the contention: with
+    # a single SDR, enabling both adsb and ais fights over one radio.
+    ais_available = bool(ais_serial) or bool(sdrs)
+    ais_ev = []
+    if ais_serial:
+        ais_ev.append(f"NMEA AIS receiver at {ais_serial}")
+    if sdrs and not ais_serial:
+        ais_ev.append(f"{len(sdrs)} SDR(s) could run AIS")
+    caps["ais"] = {
+        "available": ais_available,
+        "evidence": "; ".join(ais_ev) or "no AIS receiver detected",
+    }
+    if sdrs and not ais_serial and len(sdrs) < 2:
+        caps["ais"]["contended_with"] = ["adsb"]
+        caps["adsb"]["contended_with"] = ["ais"]
+
+    # DJI DroneID: AntSDR on the point-to-point Ethernet link.
+    caps["dji"] = {
+        "available": bool(antsdr),
+        "evidence": f"AntSDR reachable at {antsdr}" if antsdr else "no AntSDR on link",
+    }
+
+    # Wi-Fi Remote ID: an external (non-onboard) Wi-Fi adapter.
+    caps["wifi-rid"] = {
+        "available": bool(wifi),
+        "evidence": (
+            "; ".join(f"{w['interface']} ({w['driver']})" for w in wifi)
+            if wifi
+            else "no external Wi-Fi adapter"
+        ),
+    }
+
+    # DroneScout DS101 vs SiKW00F: same USB id, so probe for MAVLink.
+    ds101 = {"available": False, "evidence": "no ESP32-S3 serial device"}
+    sik = {"available": False, "evidence": "no ESP32-S3 serial device"}
+    if esp32:
+        mav = None
+        for port in esp32:
+            mav = probe_mavlink(port)
+            if mav:
+                break
+        if mav:
+            ds101 = {"available": True, "evidence": f"MAVLink on {esp32[0]}"}
+            sik = {
+                "available": False,
+                "evidence": "ESP32-S3 present but speaking MAVLink (DS101)",
+            }
+        else:
+            note = (
+                f"{len(esp32)} ESP32-S3 serial device(s) found, but a DS101 and a "
+                "SiKW00F share the same USB id and the port was silent or busy — "
+                "cannot tell them apart"
+            )
+            ds101 = {"available": False, "ambiguous": True, "evidence": note}
+            sik = {"available": False, "ambiguous": True, "evidence": note}
+    caps["ds101"] = ds101
+    caps["sik"] = sik
+
+    # SAPIENT: network sensor, no local signature.
+    caps["sapient"] = {
+        "available": False,
+        "evidence": "network sensor — configure deliberately, never auto-detected",
+        "manual_only": True,
+    }
+
+    # Auto-apply must be conflict-free. Two capabilities that share one radio
+    # would otherwise both be switched on and fight over it — on a single-SDR
+    # box that means adsbcot and aiscot each grabbing the same dongle. Keep the
+    # higher-priority one and say plainly why the other was held back; the JSON
+    # still reports both as available so an operator can choose differently.
+    for key, cap in caps.items():
+        cap["auto_apply"] = bool(cap.get("available"))
+    for key in CONTENTION_PRIORITY:
+        cap = caps.get(key)
+        if not cap or not cap.get("auto_apply"):
+            continue
+        for loser in cap.get("contended_with") or []:
+            other = caps.get(loser)
+            if other and other.get("auto_apply"):
+                other["auto_apply"] = False
+                other["deferred_reason"] = (
+                    f"shares a radio with '{key}'; enable manually with "
+                    f"`aryaos-role caps {loser}` (or add a second receiver)"
+                )
+
+    return {
+        "ok": True,
+        "hardware": {
+            "sdrs": sdrs,
+            "wifi_monitor": wifi,
+            "esp32_serial": esp32,
+            "antsdr": antsdr,
+            "ais_serial": ais_serial,
+        },
+        "capabilities": caps,
+        "detected": sorted(k for k, v in caps.items() if v.get("available")),
+        "auto_apply": sorted(k for k, v in caps.items() if v.get("auto_apply")),
+    }
+
+
+def report_text(report):
+    """Human-readable table for `aryaos-role discover`."""
+    lines = []
+    auto = report.get("auto_apply") or []
+    for key, cap in sorted(report.get("capabilities", {}).items()):
+        if cap.get("manual_only"):
+            mark = "manual"
+        elif cap.get("ambiguous"):
+            mark = "AMBIGUOUS"
+        elif cap.get("available"):
+            mark = "yes" if key in auto else "yes*"
+        else:
+            mark = "no"
+        lines.append("  {:<9} {:<10} {}".format(key, mark, cap.get("evidence", "")))
+        reason = cap.get("deferred_reason")
+        if reason:
+            lines.append("  {:<9} {:<10} {}".format("", "", "* " + reason))
+    return "\n".join(lines)
+
+
+def main():
+    report = scan()
+    if "--caps" in sys.argv:
+        # The auto-apply set, NOT everything detected: firstboot consumes this.
+        print(" ".join(report["auto_apply"]))
+        return 0
+    if "--detected" in sys.argv:
+        print(" ".join(report["detected"]))
+        return 0
+    if "--report" in sys.argv:
+        print(report_text(report))
+        return 0
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -22,6 +22,7 @@ SERVICES = (
 )
 
 SITE_CONFIG = "/etc/aryaos/aryaos-config.txt"
+CAP_SCAN = "/usr/local/sbin/aryaos-capability-scan"
 DEFAULT_PRODUCT = "DragonEgg"
 
 # Capability key -> (human label, capability unit, default sensor description).
@@ -160,11 +161,41 @@ def _wifi_adapter() -> str:
     return ""
 
 
+def _detected_caps() -> set:
+    """Capabilities this box's HARDWARE supports, per the capability scanner.
+
+    Cached in /run so the beacon (every 60s) doesn't re-probe USB and the AntSDR
+    link constantly; hardware changes are picked up on reboot or when the cache
+    is removed.
+    """
+    cache = "/run/aryaos/capabilities-detected"
+    cached = _read(cache)
+    if cached:
+        return set(cached.split())
+    if not os.path.exists(CAP_SCAN):
+        return set()
+    out = _run([CAP_SCAN, "--detected"], timeout=20)
+    try:
+        os.makedirs("/run/aryaos", exist_ok=True)
+        with open(cache, "w", encoding="utf-8") as fp:
+            fp.write(out)
+    except OSError:
+        pass
+    return set(out.split())
+
+
 def _capabilities() -> list[dict[str, str]]:
-    """Active capabilities from site config, with label + live state + sensor."""
-    caps = _config("ARYAOS_CAPABILITIES").replace(",", " ").split()
+    """Every capability this box has hardware for OR has switched on.
+
+    Reporting `available` as well as `active` lets a fleet view spot a
+    misconfigured node — "that box has a Wi-Fi Remote ID adapter but it's off" —
+    which is invisible if the beacon only carries what is running.
+    """
+    active_caps = _config("ARYAOS_CAPABILITIES").replace(",", " ").split()
+    detected = _detected_caps()
+
     out: list[dict[str, str]] = []
-    for key in caps:
+    for key in sorted(set(active_caps) | detected):
         label, unit, sensor = CAPABILITIES.get(key, (key, "", ""))
         if key == "wifi-rid":
             sensor = _wifi_adapter() or sensor
@@ -173,6 +204,8 @@ def _capabilities() -> list[dict[str, str]]:
                 "key": key,
                 "label": label,
                 "active": str(bool(unit) and _service_state(unit) == "active").lower(),
+                "available": str(key in detected).lower(),
+                "enabled": str(key in active_caps).lower(),
                 "sensor": sensor,
             }
         )

--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -154,6 +154,29 @@ if [[ ! -f /etc/sudoers.d/aryaos-lab && ! -f "$NR_PASS_MARKER" ]] \
 	fi
 fi
 
+# Auto-configure sensor capabilities from attached hardware.
+#
+# The image ships every sensor gateway disabled, because a box with no radios
+# should be quiet rather than crash-looping decoders. On first boot we look at
+# what is actually plugged in and turn on what it supports, so a kitted unit is
+# plug-and-play while a bare one stays silent. Runs ONCE (marker file) so a
+# later deliberate `aryaos-role caps ...` is never overwritten.
+CAP_MARKER="/etc/aryaos/.capabilities-autodetected"
+if [[ ! -f "$CAP_MARKER" ]] \
+	&& [[ -x /usr/local/sbin/aryaos-role ]] \
+	&& [[ -x /usr/local/sbin/aryaos-capability-scan ]]; then
+	DETECTED="$(/usr/local/sbin/aryaos-capability-scan --caps 2>/dev/null | xargs || true)"
+	if [[ -n "$DETECTED" ]]; then
+		if /usr/local/sbin/aryaos-role caps $DETECTED >/dev/null 2>&1; then
+			echo "AryaOS firstboot: detected hardware -> capabilities: $DETECTED"
+			CHANGED=1
+		fi
+	else
+		echo "AryaOS firstboot: no sensor hardware detected; staying a bare CoT node."
+	fi
+	touch "$CAP_MARKER"
+fi
+
 if [[ "$CHANGED" -eq 0 ]]; then
 	echo "AryaOS firstboot: no changes needed."
 	exit 0

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -16,6 +16,8 @@
 #   product LINE         Set the product line and apply its default capabilities.
 #   caps CAP...          Set the active capability set (space/comma separated).
 #                        Use "none" to disable every sensor (bare CoT node).
+#   discover [--apply]   Detect attached hardware and report which capabilities
+#                        it supports; --apply enables them.
 #   set ROLE             Back-compat: apply a legacy role as a capability preset.
 #
 # Capability keys: adsb ais dji wifi-rid ds101 sik sapient
@@ -36,7 +38,7 @@ LEGACY_ROLES="multi air maritime cuas relay"
 DEFAULT_PRODUCT="DragonEgg"
 
 usage() {
-	echo "usage: aryaos-role {list | product LINE | caps CAP... | set ROLE}" >&2
+	echo "usage: aryaos-role {list | discover [--apply] | product LINE | caps CAP... | set ROLE}" >&2
 	echo "  products: ${PRODUCTS}" >&2
 	echo "  caps:     ${CAPS}  (or 'none' for a bare CoT node)" >&2
 	echo "  roles:    ${LEGACY_ROLES}  (legacy presets)" >&2
@@ -226,6 +228,38 @@ set_caps() {
 	echo "Capabilities set to: ${caps:-<none>}"
 }
 
+CAP_SCAN="/usr/local/sbin/aryaos-capability-scan"
+
+# Detect attached hardware and (optionally) enable the capabilities it supports.
+# Report-only by default: seeing what a box COULD do should never change what it
+# IS doing without being asked.
+discover() {
+	local apply="${1:-0}"
+	if [[ ! -x "${CAP_SCAN}" ]]; then
+		echo "aryaos-role: ${CAP_SCAN} not installed" >&2
+		exit 2
+	fi
+
+	local detected
+	detected="$("${CAP_SCAN}" --caps 2>/dev/null | xargs || true)"
+
+	echo "Detected hardware capabilities: ${detected:-<none>}"
+	"${CAP_SCAN}" --report 2>/dev/null || true
+
+	if [[ "${apply}" != 1 ]]; then
+		echo
+		echo "Nothing changed. Apply with: aryaos-role discover --apply"
+		return 0
+	fi
+
+	if [[ -z "${detected}" ]]; then
+		echo "No sensor hardware detected; leaving capabilities unchanged." >&2
+		return 0
+	fi
+	echo
+	set_caps "${detected}"
+}
+
 set_product() {
 	local product="$1" defaults
 	if ! defaults="$(product_default_caps "${product}")"; then
@@ -298,6 +332,10 @@ case "${cmd}" in
 		require_root
 		[[ $# -eq 2 ]] || usage
 		set_role "$2"
+		;;
+	discover)
+		[[ "${2:-}" == "--apply" ]] && require_root
+		discover "$([[ "${2:-}" == "--apply" ]] && echo 1 || echo 0)"
 		;;
 	*)
 		usage

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -133,6 +133,7 @@ install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-support-bundle" "${ROOTFS_DIR}
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-set-nodered-password" "${ROOTFS_DIR}/usr/local/sbin/aryaos-set-nodered-password"
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-sdr" "${ROOTFS_DIR}/usr/local/sbin/aryaos-sdr"
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-role" "${ROOTFS_DIR}/usr/local/sbin/aryaos-role"
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-capability-scan" "${ROOTFS_DIR}/usr/local/sbin/aryaos-capability-scan"
 
 ## Lifecycle helpers: backup/restore, factory reset, zeroize (Cockpit-driven)
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-config-backup" "${ROOTFS_DIR}/usr/local/sbin/aryaos-config-backup"


### PR DESCRIPTION
The image ships every sensor disabled — right for a bare unit, but a kitted one needed hand-configuring. Now it configures itself.

`aryaos-capability-scan` probes hardware → capabilities (SDRs, dAISy, AntSDR link, external Wi-Fi adapter, ESP32-S3 serial). `aryaos-role discover [--apply]` reports/applies; **firstboot applies it once** (marker file) so a deliberate `caps` is never overwritten.

**Guessing wrong is worse than not guessing:**
- **Contended radios** — one SDR can't serve ADS-B *and* AIS, so auto-apply takes only the higher-priority one and says why the other was held back. Verified on HW: 1-SDR box → `[adsb]`; 2-SDR box → `[adsb, ais]`.
- **DS101 vs SiKW00F** share USB id `303a:1001` → probes for MAVLink framing; silent/busy reports **AMBIGUOUS**. (Same ambiguity that bit us identifying the DS101 originally.) The probe skips ports held by another process, so it never disturbs a running dronecot.
- **SAPIENT** is never auto-detected (network sensor, no local signature).

Beacon now carries `active`/`enabled`/`available` per capability — a fleet view can spot hardware switched off, or a service running nobody declared (seen live: `ais active=true enabled=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)