### PR TITLE
Publish image-info.json + document AryaOS Imager

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -328,6 +328,38 @@ jobs:
           git tag -a "$TAG" -m "Automated image build ${{ github.sha }}"
           git push origin "refs/tags/${TAG}"
 
+      - name: Generate image-info.json (hashes + sizes)
+        # AryaOS Imager's OS list needs the hash of the UNCOMPRESSED image so it
+        # can verify a card after writing, but the GitHub asset digest only
+        # covers the .img.xz. Publishing it here costs ~30s and no disk: the
+        # image is decompressed to a PIPE, never to a file (the raw .img is long
+        # gone by now — ARYAOS_CI_TRIM_WORK reaps the pi-gen work dir). The
+        # uncompressed size differs per build, so it is recorded, not assumed.
+        if: success() && steps.build_aryaos.outputs.image-path != ''
+        run: |
+          set -euo pipefail
+          IMG_XZ="${{ steps.build_aryaos.outputs.image-path }}"
+          mkdir -p deploy/imager
+          XZ_SHA="$(sha256sum "${IMG_XZ}" | awk '{print $1}')"
+          XZ_SIZE="$(stat -c%s "${IMG_XZ}")"
+          IMG_SIZE="$(xz -l --robot "${IMG_XZ}" | awk -F'\t' '/^totals/{print $5}')"
+          IMG_SHA="$(xz -dc "${IMG_XZ}" | sha256sum | awk '{print $1}')"
+          IS_DEV=false
+          [ "${ARYAOS_LAB_ACCESS}" = "1" ] && IS_DEV=true
+          cat > deploy/imager/image-info.json <<EOF
+          {
+            "schema": 1,
+            "tag": "${{ steps.reltag.outputs.tag }}",
+            "is_dev": ${IS_DEV},
+            "image_name": "$(basename "${IMG_XZ}")",
+            "xz_sha256": "${XZ_SHA}",
+            "xz_size": ${XZ_SIZE},
+            "img_sha256": "${IMG_SHA}",
+            "img_size": ${IMG_SIZE}
+          }
+          EOF
+          python3 -m json.tool deploy/imager/image-info.json
+
       - name: Build overlay deb for release asset
         if: success() && steps.build_aryaos.outputs.image-path != ''
         run: |
@@ -350,6 +382,8 @@ jobs:
           for sbom in deploy/sbom/aryaos-*.json; do
             [ -f "$sbom" ] && args+=("$sbom")
           done
+          # Tiny (<1 KB) manifest the AryaOS Imager OS list is generated from.
+          [ -f deploy/imager/image-info.json ] && args+=(deploy/imager/image-info.json)
           if [ "${ARYAOS_LAB_ACCESS}" = "1" ]; then
             args+=(--prerelease)
           fi

--- a/docs/get-started/flash-the-image.md
+++ b/docs/get-started/flash-the-image.md
@@ -1,6 +1,6 @@
 # Flash the image
 
-Write the AryaOS image to a microSD card, then boot your Raspberry Pi from it. This takes a few minutes with either Raspberry Pi Imager or balenaEtcher, and both verify the write before you unplug.
+Write the AryaOS image to a microSD card, then boot your Raspberry Pi from it. The quickest route is **AryaOS Imager**, which downloads the image for you; Raspberry Pi Imager and balenaEtcher also work if you already have them.
 
 !!! danger "Flashing erases the card"
     Writing an image overwrites everything on the target microSD card. Double-check the drive you select before you start.
@@ -13,17 +13,35 @@ Write the AryaOS image to a microSD card, then boot your Raspberry Pi from it. T
 
 ## Get the image
 
+**If you use AryaOS Imager you can skip this section** — it fetches the current image itself.
+
 | Source | Where | When to use |
 |---|---|---|
-| GitHub Releases | [github.com/snstac/aryaos/releases](https://github.com/snstac/aryaos/releases) | The stable, recommended download |
+| AryaOS Imager | [github.com/snstac/aryaos-imager](https://github.com/snstac/aryaos-imager/releases) | Easiest: picks up the latest image automatically |
+| GitHub Releases | [github.com/snstac/aryaos/releases](https://github.com/snstac/aryaos/releases) | Downloading the `.img.xz` by hand |
 | CI artifacts | GitHub Actions build artifacts on the repo | Testing an unreleased build your team pointed you to |
 
-Download the AryaOS image (published as a compressed `.img.xz`). Both flashing tools below read `.img.xz` directly — you do not need to decompress it first.
+Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads `.img.xz` directly — you do not need to decompress it first.
 
 !!! info "Every release is signed and bill-of-materials'd"
     Each image build attaches an SPDX and CycloneDX software bill of materials (SBOM) to its GitHub Release, and all AryaOS packages install from the [signed apt repository](https://snstac.github.io/packages). See [SBOM & supply chain](../operations/sbom.md).
 
 ## Flash the card
+
+=== "AryaOS Imager"
+
+    [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases) is a single-purpose build of Raspberry Pi Imager that offers **only AryaOS**. It downloads the image for you, so there is no file to find and no way to pick the wrong operating system. Available for Windows and Linux.
+
+    1. Download and install AryaOS Imager.
+    2. Insert the microSD card into your workstation.
+    3. Open AryaOS Imager and choose **AryaOS (latest release)**. A **latest dev** build is also offered — that one bakes in lab access and is not for field use.
+    4. Under storage, select the microSD card. **Confirm the device — this erases the card.**
+    5. Write, and wait for the verify step to finish.
+
+    !!! note "Windows shows a SmartScreen warning"
+        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info → Run anyway**. Each release publishes a `SHA256SUMS.txt` if you would rather verify the download first.
+
+    There is no OS-customization step to skip: AryaOS configures itself on [first boot](first-boot.md), so the imager deliberately leaves those settings alone.
 
 === "Raspberry Pi Imager"
 


### PR DESCRIPTION
Supports the new [AryaOS Imager](https://github.com/snstac/aryaos-imager).

**image-info.json** — the imager's OS list needs the SHA-256 of the *uncompressed* image (to verify a card after writing), but GitHub's asset digest only covers the .img.xz. Computing it downstream would mean fetching 1.5 GB and expanding to 6.4 GB per manifest refresh, so the build emits it instead: ~30s, **no disk** (decompressed to a pipe — the raw .img is already reaped by ARYAOS_CI_TRIM_WORK). Uncompressed size is read from the xz index rather than assumed; it varies build to build.

**docs** — flash-the-image now leads with AryaOS Imager (auto-downloads the image), documents the unsigned-installer SmartScreen step, and notes there's no customization prompt to skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)