### PR TITLE
Fix three issues found burning four boxes

### DIFF
--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -44,6 +44,21 @@ ONBOARD_WIFI_DRIVERS = {"brcmfmac"}  # the Pi's own radio: never a RID sniffer
 # default. The loser stays "available" and can be enabled by hand.
 CONTENTION_PRIORITY = ("adsb", "ais")
 
+# Capability -> the systemd unit that owns its receiver. Mirrors aryaos-role.
+CAP_UNITS = {
+    "adsb": "adsbcot",
+    "ais": "aiscot",
+    "dji": "dronecot",
+    "wifi-rid": "dronecot-wifi",
+    "ds101": "dronecot-dronescout",
+    "sik": "sikw00fcot",
+    "sapient": "sapientcot",
+}
+
+
+def unit_active(unit):
+    return _run(["/usr/bin/systemctl", "is-active", f"{unit}.service"], timeout=5) == "active"
+
 
 def _run(args, timeout=6.0):
     try:
@@ -292,6 +307,22 @@ def scan():
                     f"shares a radio with '{key}'; enable manually with "
                     f"`aryaos-role caps {loser}` (or add a second receiver)"
                 )
+
+    # A capability whose gateway is ALREADY RUNNING is available by definition —
+    # it is demonstrably working. Without this the probes lie about their own
+    # success: a live dronecot-dronescout holds the DS101 serial port, so the
+    # MAVLink probe (which deliberately refuses to disturb a busy port) reports
+    # nothing, and `discover --apply` would then switch off a capability that is
+    # working right now. Observed on a real box: firstboot found "dji ds101",
+    # a rescan minutes later found only "dji".
+    for key, cap in caps.items():
+        unit = CAP_UNITS.get(key)
+        if unit and unit_active(unit):
+            cap["available"] = True
+            cap["auto_apply"] = True
+            cap["in_use"] = True
+            cap["evidence"] = f"{unit}.service is running ({cap.get('evidence', '')})".strip()
+            cap.pop("deferred_reason", None)
 
     return {
         "ok": True,

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -62,6 +62,11 @@ resume_gpsd() {
 	# was already using gpsd pick the new device up.
 	systemctl start gpsd.socket >/dev/null 2>&1 || true
 	systemctl try-restart gpsd.service >/dev/null 2>&1 || true
+	# Stopping gpsd also SIGTERMs the udev-launched gpsdctl@<tty> units that
+	# were registering devices with it, leaving them "failed" on every GPS box
+	# even though gpsd itself is healthy. Their work is redone by the restart
+	# above, so clear the collateral damage rather than leave a scary unit state.
+	systemctl reset-failed 'gpsdctl@*' >/dev/null 2>&1 || true
 }
 
 # True for an ESP32-based Remote ID receiver (BlueMark DroneScout DS101 /

--- a/shared_files/bt-pan/aryaos-bt-ready.sh
+++ b/shared_files/bt-pan/aryaos-bt-ready.sh
@@ -35,10 +35,22 @@ if [[ -x "${HCICONFIG}" ]]; then
 fi
 
 if [[ -x "${BLUETOOTHCTL}" ]]; then
-	timeout 8 "${BLUETOOTHCTL}" power on
-	timeout 8 "${BLUETOOTHCTL}" discoverable-timeout 0
-	timeout 8 "${BLUETOOTHCTL}" discoverable on
-	timeout 8 "${BLUETOOTHCTL}" pairable on
+	# The adapter directory appearing in sysfs does not mean bluetoothd has
+	# registered a controller yet; issuing commands too early returns "No
+	# default controller available" and, under set -e, failed the whole unit on
+	# a box whose Bluetooth was otherwise fine. Wait for the controller, then
+	# treat these as best-effort: Bluetooth PAN is an optional transport and
+	# must not leave a failed unit behind.
+	for _ in $(seq 1 20); do
+		if timeout 5 "${BLUETOOTHCTL}" show >/dev/null 2>&1; then
+			break
+		fi
+		sleep 0.5
+	done
+	timeout 8 "${BLUETOOTHCTL}" power on || log "power on failed (controller not ready)"
+	timeout 8 "${BLUETOOTHCTL}" discoverable-timeout 0 || true
+	timeout 8 "${BLUETOOTHCTL}" discoverable on || true
+	timeout 8 "${BLUETOOTHCTL}" pairable on || true
 fi
 
 if [[ -r "/sys/class/bluetooth/${ADAPTER}/address" ]]; then


### PR DESCRIPTION
**1. A rescan could switch off a working capability.** The MAVLink probe skips ports held by another process (so it never disturbs a live gateway) — but a *running* `dronecot-dronescout` therefore hides its own DS101. Real box: firstboot found `dji ds101`, a rescan minutes later found only `dji` → `discover --apply` would have disabled a working capability. A capability whose gateway is active is now available by definition.

**2. `gpsdctl@<tty>` failed on every GPS box** — pausing gpsd around the NMEA probe SIGTERMs the udev-launched gpsdctl units mid-registration. gpsd was healthy; the failed state was collateral. Now cleared after resume.

**3. `aryaos-bt-ready` failed** with *No default controller available* — sysfs adapter ≠ bluetoothd controller registered, and `set -e` failed the unit. Now waits for the controller; power-on is best-effort since BT PAN is optional.

Verified on the boxes that showed each symptom — both now report zero failed units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)