### PR TITLE
Add ble-rid capability: Bluetooth Remote ID on the onboard radio

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -321,7 +321,7 @@ forbid_enabled() {
 }
 for _u in readsb.service dump978-fa.service adsbcot.service aiscot.service \
 	dronecot.service sikw00fcot.service ais-catcher.service sapientcot.service \
-	dronecot-wifi.service dronecot-dronescout.service; do
+	dronecot-wifi.service dronecot-ble.service dronecot-dronescout.service; do
 	forbid_enabled "${_u}"
 done
 require_grep '^ARYAOS_CAPABILITIES=""$' /etc/aryaos/aryaos-config.txt "no sensor capabilities enabled out of the box"

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -44,6 +44,21 @@ ONBOARD_WIFI_DRIVERS = {"brcmfmac"}  # the Pi's own radio: never a RID sniffer
 # default. The loser stays "available" and can be enabled by hand.
 CONTENTION_PRIORITY = ("adsb", "ais")
 
+# Capability -> the systemd unit that owns its receiver. Mirrors aryaos-role.
+CAP_UNITS = {
+    "adsb": "adsbcot",
+    "ais": "aiscot",
+    "dji": "dronecot",
+    "wifi-rid": "dronecot-wifi",
+    "ds101": "dronecot-dronescout",
+    "sik": "sikw00fcot",
+    "sapient": "sapientcot",
+}
+
+
+def unit_active(unit):
+    return _run(["/usr/bin/systemctl", "is-active", f"{unit}.service"], timeout=5) == "active"
+
 
 def _run(args, timeout=6.0):
     try:
@@ -292,6 +307,22 @@ def scan():
                     f"shares a radio with '{key}'; enable manually with "
                     f"`aryaos-role caps {loser}` (or add a second receiver)"
                 )
+
+    # A capability whose gateway is ALREADY RUNNING is available by definition —
+    # it is demonstrably working. Without this the probes lie about their own
+    # success: a live dronecot-dronescout holds the DS101 serial port, so the
+    # MAVLink probe (which deliberately refuses to disturb a busy port) reports
+    # nothing, and `discover --apply` would then switch off a capability that is
+    # working right now. Observed on a real box: firstboot found "dji ds101",
+    # a rescan minutes later found only "dji".
+    for key, cap in caps.items():
+        unit = CAP_UNITS.get(key)
+        if unit and unit_active(unit):
+            cap["available"] = True
+            cap["auto_apply"] = True
+            cap["in_use"] = True
+            cap["evidence"] = f"{unit}.service is running ({cap.get('evidence', '')})".strip()
+            cap.pop("deferred_reason", None)
 
     return {
         "ok": True,

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -50,6 +50,7 @@ CAP_UNITS = {
     "ais": "aiscot",
     "dji": "dronecot",
     "wifi-rid": "dronecot-wifi",
+    "ble-rid": "dronecot-ble",
     "ds101": "dronecot-dronescout",
     "sik": "sikw00fcot",
     "sapient": "sapientcot",
@@ -118,6 +119,28 @@ def probe_wifi_monitor():
             continue
         found.append({"interface": iface, "driver": driver})
     return found
+
+
+def probe_onboard_bt():
+    """Find a Bluetooth adapter capable of receiving Remote ID advertisements.
+
+    Unlike every other probe there is no add-on hardware to look for: the board's
+    own radio is always there. That is exactly why 'ble-rid' must NOT auto-apply
+    (see scan()) — detecting it on every box in the fleet is not a reason to
+    switch a sensor on across the fleet.
+    """
+    adapters = []
+    for path in sorted(glob.glob("/sys/class/bluetooth/hci*")):
+        # sysfs exposes no 'address' attribute for hci devices, so identify the
+        # adapter by its driver instead: hci_uart/btbcm is the Pi's own radio,
+        # btusb an add-on dongle.
+        driver = ""
+        try:
+            driver = os.path.basename(os.path.realpath(f"{path}/device/driver"))
+        except OSError:
+            pass
+        adapters.append({"adapter": os.path.basename(path), "driver": driver})
+    return adapters
 
 
 def probe_esp32_serial():
@@ -288,13 +311,39 @@ def scan():
         "manual_only": True,
     }
 
+    # Bluetooth Remote ID: the ONLY capability needing no add-on hardware, which
+    # makes it the only one where "available" must not imply "switch it on".
+    # Every box has a Bluetooth radio, so auto-applying would turn a sensor on
+    # across the whole fleet — the opposite of shipping everything off by
+    # default. It is reported as available so an operator can find it, and waits
+    # for `aryaos-role caps ... ble-rid`.
+    bt = probe_onboard_bt()
+    caps["ble-rid"] = {
+        "available": bool(bt),
+        "evidence": (
+            "Bluetooth adapter "
+            + ", ".join(a["adapter"] + (f" ({a['driver']})" if a["driver"] else "") for a in bt)
+            + " — legacy advertising only, no BT5 Coded PHY"
+            if bt
+            else "no Bluetooth adapter detected"
+        ),
+        "manual_only": True,
+        "deferred_reason": (
+            "present on every box, so it is never auto-enabled; turn it on with "
+            "`aryaos-role caps ... ble-rid`"
+        ),
+    }
+
     # Auto-apply must be conflict-free. Two capabilities that share one radio
     # would otherwise both be switched on and fight over it — on a single-SDR
     # box that means adsbcot and aiscot each grabbing the same dongle. Keep the
     # higher-priority one and say plainly why the other was held back; the JSON
     # still reports both as available so an operator can choose differently.
+    # 'manual_only' capabilities are never auto-applied even when available —
+    # ble-rid's radio is present on every board, and SAPIENT is a deliberate
+    # network configuration, not a discovery.
     for key, cap in caps.items():
-        cap["auto_apply"] = bool(cap.get("available"))
+        cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")
     for key in CONTENTION_PRIORITY:
         cap = caps.get(key)
         if not cap or not cap.get("auto_apply"):

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -17,6 +17,7 @@ SERVICES = (
     "aiscot",
     "dronecot",
     "dronecot-wifi",
+    "dronecot-ble",
     "dronecot-dronescout",
     "sapientcot",
 )
@@ -32,6 +33,7 @@ CAPABILITIES = {
     "ais": ("AIS", "aiscot", "AIS receiver"),
     "dji": ("DJI DroneID", "dronecot", "AntSDR (DJI OcuSync)"),
     "wifi-rid": ("Wi-Fi Remote ID", "dronecot-wifi", "Wi-Fi monitor-mode adapter"),
+    "ble-rid": ("Bluetooth Remote ID", "dronecot-ble", "onboard Bluetooth adapter"),
     "ds101": ("DroneScout DS101", "dronecot-dronescout", "BlueMark DS101 (OpenDroneID)"),
     "sik": ("SiK Telemetry", "sikw00fcot", "SiK radio"),
     "sapient": ("SAPIENT C-UAS", "sapientcot", "SAPIENT sensor (BSI Flex 335)"),

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -33,7 +33,7 @@ set -euo pipefail
 
 SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
 PRODUCTS="AryaAir AryaSea DragonEgg"
-CAPS="adsb ais dji wifi-rid ds101 sik sapient"
+CAPS="adsb ais dji wifi-rid ble-rid ds101 sik sapient"
 LEGACY_ROLES="multi air maritime cuas relay"
 DEFAULT_PRODUCT="DragonEgg"
 
@@ -84,6 +84,7 @@ cap_units() {
 		ais)      echo "ais-catcher aiscot" ;;
 		dji)      echo "dronecot" ;;
 		wifi-rid) echo "dronecot-wifi" ;;
+		ble-rid)  echo "dronecot-ble" ;;
 		ds101)    echo "dronecot-dronescout" ;;
 		sik)      echo "sikw00fcot" ;;
 		sapient)  echo "sapientcot" ;;
@@ -98,6 +99,7 @@ cap_label() {
 		ais)      echo "AIS" ;;
 		dji)      echo "DJI DroneID" ;;
 		wifi-rid) echo "Wi-Fi Remote ID" ;;
+		ble-rid)  echo "Bluetooth Remote ID" ;;
 		ds101)    echo "DroneScout DS101" ;;
 		sik)      echo "SiK Telemetry" ;;
 		sapient)  echo "SAPIENT C-UAS" ;;
@@ -129,7 +131,7 @@ role_caps() {
 
 all_managed_units() {
 	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot \
-		dronecot dronecot-wifi dronecot-dronescout sikw00fcot sapientcot"
+		dronecot dronecot-wifi dronecot-ble dronecot-dronescout sikw00fcot sapientcot"
 }
 
 # Expand a capability list to the (deduplicated) union of its units.

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -62,6 +62,11 @@ resume_gpsd() {
 	# was already using gpsd pick the new device up.
 	systemctl start gpsd.socket >/dev/null 2>&1 || true
 	systemctl try-restart gpsd.service >/dev/null 2>&1 || true
+	# Stopping gpsd also SIGTERMs the udev-launched gpsdctl@<tty> units that
+	# were registering devices with it, leaving them "failed" on every GPS box
+	# even though gpsd itself is healthy. Their work is redone by the restart
+	# above, so clear the collateral damage rather than leave a scary unit state.
+	systemctl reset-failed 'gpsdctl@*' >/dev/null 2>&1 || true
 }
 
 # True for an ESP32-based Remote ID receiver (BlueMark DroneScout DS101 /

--- a/shared_files/aryaos/dronecot-ble.default
+++ b/shared_files/aryaos/dronecot-ble.default
@@ -1,0 +1,34 @@
+# AryaOS dronecot (Bluetooth Remote ID) config — /etc/default/dronecot-ble
+#
+# Captures Open Drone ID broadcast over Bluetooth LE (ASTM F3411 service data,
+# UUID 0xFFFA, app code 0x0D) using the board's OWN Bluetooth radio and forwards
+# it to charontak as CoT. COT_URL is inherited from aryaos-config.txt via the
+# service EnvironmentFile.
+#
+# No add-on hardware is required, so this is deliberately OPT-IN — the radio is
+# present on every box and auto-enabling would switch a sensor on fleet-wide:
+#   sudo aryaos-role caps <existing caps...> ble-rid
+#
+# LEGACY ADVERTISING ONLY: the ASTM long-range profile uses BT5 extended
+# advertising on the Coded PHY, which the Pi's CYW43455 is not known to receive.
+# Treat this as complementary to a Sniffle dongle or a DroneScout DS101.
+
+FEED_URL=ble+hci://hci0
+BLE_ADAPTER=hci0
+SENSOR_ID=ble-rid
+
+# Reader selection:
+#   monitor — HCI_CHANNEL_MONITOR socket (needs CAP_NET_RAW, granted by the
+#             unit). Every advertising report, nothing coalesced. Preferred.
+#   dbus    — BlueZ ServiceData property. No capability needed, but BlueZ may
+#             coalesce repeated advertisements, and because a transmitter
+#             rotates message types a coalesced repeat is a LOST MESSAGE TYPE.
+#   auto    — try monitor, fall back to dbus.
+BLE_READER=auto
+
+# Optional: ignore advertisements weaker than this (dBm). Unset = no filter.
+#BLE_RSSI_THRESHOLD=-95
+
+# SIGINT / receiver detail carried in the CoT payload (dronecot >= 2.2.5).
+SENSOR_TYPE=Bluetooth Open Drone ID
+SENSOR_MODEL=Onboard Bluetooth (BlueZ)

--- a/shared_files/aryaos/systemd/dronecot-ble.service
+++ b/shared_files/aryaos/systemd/dronecot-ble.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=DroneCOT (Bluetooth Remote ID) — Open Drone ID over BLE to TAK
+Documentation=https://github.com/snstac/dronecot
+# A dronecot instance that captures Open Drone ID from Bluetooth LE
+# advertisements (ASTM F3411 service data, UUID 0xFFFA, app code 0x0D) using the
+# board's OWN Bluetooth radio — no Sniffle dongle, no add-on hardware. Decodes
+# with dronecot's BlueZWorker and feeds the same charontak hub as the Wi-Fi,
+# AntSDR/DJI and DS101 sources.
+#
+# This is the only sensor with no external hardware to plug in, which is exactly
+# why it stays OPT-IN: the radio is present on every box, so auto-enabling it
+# would switch a sensor on across the whole fleet. Turn it on deliberately:
+#   sudo aryaos-role caps <existing caps...> ble-rid
+#
+# Coexists with aryaos-bt-pan: dronecot drives an LE scan over BlueZ D-Bus as an
+# ordinary client rather than seizing the adapter, so Classic PAN keeps working.
+#
+# CAPTURES LEGACY ADVERTISING ONLY. The ASTM long-range profile uses BT5
+# extended advertising on the Coded PHY, which the Pi's CYW43455 is not known to
+# receive — this complements a Sniffle dongle or DS101, it does not replace one.
+Wants=network.target
+After=network.target bluetooth.service aryaos-bt-ready.service
+ConditionPathExistsGlob=/sys/class/bluetooth/hci*
+
+[Service]
+User=root
+# The default reader is an HCI_CHANNEL_MONITOR socket (the passive tap btmon
+# uses), which delivers every advertising report un-coalesced but needs
+# CAP_NET_RAW. Without it dronecot falls back to the BlueZ D-Bus reader, where
+# BlueZ may coalesce repeats — and for Remote ID a coalesced repeat is a lost
+# message TYPE, not a duplicate, because a transmitter rotates message types.
+AmbientCapabilities=CAP_NET_RAW
+ExecStart=/usr/bin/dronecot
+RuntimeDirectory=dronecot-ble
+SyslogIdentifier=dronecot-ble
+EnvironmentFile=-/etc/aryaos/aryaos-config.txt
+EnvironmentFile=/etc/default/dronecot-ble
+Type=simple
+Restart=always
+RestartSec=20
+Nice=-1
+
+[Install]
+WantedBy=multi-user.target

--- a/shared_files/bt-pan/aryaos-bt-ready.sh
+++ b/shared_files/bt-pan/aryaos-bt-ready.sh
@@ -35,10 +35,22 @@ if [[ -x "${HCICONFIG}" ]]; then
 fi
 
 if [[ -x "${BLUETOOTHCTL}" ]]; then
-	timeout 8 "${BLUETOOTHCTL}" power on
-	timeout 8 "${BLUETOOTHCTL}" discoverable-timeout 0
-	timeout 8 "${BLUETOOTHCTL}" discoverable on
-	timeout 8 "${BLUETOOTHCTL}" pairable on
+	# The adapter directory appearing in sysfs does not mean bluetoothd has
+	# registered a controller yet; issuing commands too early returns "No
+	# default controller available" and, under set -e, failed the whole unit on
+	# a box whose Bluetooth was otherwise fine. Wait for the controller, then
+	# treat these as best-effort: Bluetooth PAN is an optional transport and
+	# must not leave a failed unit behind.
+	for _ in $(seq 1 20); do
+		if timeout 5 "${BLUETOOTHCTL}" show >/dev/null 2>&1; then
+			break
+		fi
+		sleep 0.5
+	done
+	timeout 8 "${BLUETOOTHCTL}" power on || log "power on failed (controller not ready)"
+	timeout 8 "${BLUETOOTHCTL}" discoverable-timeout 0 || true
+	timeout 8 "${BLUETOOTHCTL}" discoverable on || true
+	timeout 8 "${BLUETOOTHCTL}" pairable on || true
 fi
 
 if [[ -r "/sys/class/bluetooth/${ADAPTER}/address" ]]; then

--- a/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
+++ b/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
@@ -28,6 +28,7 @@ ais-catcher
 aiscot
 dronecot
 dronecot-wifi
+dronecot-ble
 dronecot-dronescout
 sikw00fcot
 sapientcot

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -79,6 +79,15 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-wifi.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/dronecot-wifi.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-wifi.default" \
 	"${ROOTFS_DIR}/etc/default/dronecot-wifi"
+# Bluetooth Remote ID: an opt-in dronecot instance that decodes Open Drone ID
+# from BLE advertisements using the board's OWN Bluetooth radio — the only
+# sensor needing no add-on hardware, which is precisely why it must stay opt-in
+# (auto-enabling would switch a sensor on across the entire fleet).
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-ble.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/dronecot-ble.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-ble.default" \
+	"${ROOTFS_DIR}/etc/default/dronecot-ble"
+
 # Monitor-mode prep helper (dronecot's own set_monitor_mode doesn't down the
 # iface first nor release it from NetworkManager) — used as ExecStartPre.
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-wifi-monitor" \


### PR DESCRIPTION
> Needs `dronecot` with the BlueZ backend (snstac/dronecot#8) before it can actually run.

## Why

Wi-Fi Remote ID needs a monitor-mode adapter, which the Pi's onboard radio cannot provide — `iw list` on brcmfmac reports `IBSS, managed, AP, P2P-client, P2P-GO, P2P-device` and **no monitor mode**. BLE is the one Remote ID path the board can serve unaided, and it demonstrably works: `btmon` on `.13` captured real ASTM F3411 advertisements from a DroneBeacon DB120 with no add-on hardware at all.

This makes `ble-rid` the **first capability requiring no external hardware**.

## What changed

Mirrors the `wifi-rid` pattern throughout:

| File | Change |
|---|---|
| `shared_files/aryaos/aryaos-role` | `CAPS`, `cap_units` → `dronecot-ble`, `cap_label`, `all_managed_units` |
| `shared_files/aryaos/aryaos-capability-scan` | new `probe_onboard_bt()`, `CAP_UNITS` entry |
| `shared_files/aryaos/aryaos-cot-detail` | `SERVICES` + `CAPABILITIES` so the v2 beacon reports it |
| `shared_files/aryaos/systemd/dronecot-ble.service` | **new** |
| `shared_files/aryaos/dronecot-ble.default` | **new** |
| `stages/stage-dronecot/00-install/00-run.sh` | install both |
| `stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh` | ships disabled |
| `scripts/verify-image.sh` | asserts it ships disabled |

## The important design point: opt-in by construction

Every other capability implies hardware you had to plug in, so "available" can safely imply "switch it on". **This radio is present on every board**, so auto-applying would enable a sensor across the entire fleet — the opposite of shipping everything off by default.

`ble-rid` is therefore reported as available and appears in `--detected`, but is **excluded from `--caps`** (the auto-apply set) until an operator runs `aryaos-role caps ... ble-rid`. The beacon carries `available=true enabled=false`.

That required making `manual_only` **actually suppress** `auto_apply` rather than being informational — SAPIENT got away with the flag only because it is also `available: false`, whereas `ble-rid` is genuinely available.

## Gotcha found while building

`probe_onboard_bt()` identifies the adapter by its **driver**, not an address: sysfs exposes no `address` attribute for hci devices (verified — only `device`, `power`, `rfkill0`, `subsystem`, `uevent`), so the obvious lookup silently yields `""`.

## Coexistence

The unit orders after `bluetooth.service` and `aryaos-bt-ready.service`, and grants `AmbientCapabilities=CAP_NET_RAW` for dronecot's `HCI_CHANNEL_MONITOR` reader. It coexists with `aryaos-bt-pan` (enabled by default on every box): dronecot drives the LE scan as an ordinary BlueZ D-Bus client rather than seizing the adapter, so Classic PAN keeps working.

## Limitation

Captures **legacy** advertising only. The ASTM long-range profile uses BT5 extended advertising on the Coded PHY, which the CYW43455 is not known to receive. Documented as complementary to a Sniffle dongle or DS101, not a replacement.

## Verification done

- All modified shell/Python scripts syntax-check.
- `probe_onboard_bt()` run for real: finds `hci0 (btusb)` on the dev workstation.
- `scan()` confirms `ble-rid` is `available=true`, `auto_apply=false`, present in `--detected`, absent from `--caps`.
- Cross-checked all three capability registries (`aryaos-role` CAPS, `aryaos-capability-scan` CAP_UNITS, `aryaos-cot-detail` CAPABILITIES) for drift — they agree exactly.
- `aryaos-role` functions exercised: `cap_units ble-rid` → `dronecot-ble`, `units_for_caps` dedups correctly.

## Not yet verified

**No hardware run.** Needs an image build plus a box with a transmitting drone to confirm CoT reaches charontak and to measure the real catch rate, and to measure the BT PAN coexistence cost both ways. No catch-rate figure is claimed anywhere until measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM