### PR TITLE
Add ble-rid capability: Bluetooth Remote ID on the onboard radio

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -321,7 +321,7 @@ forbid_enabled() {
 }
 for _u in readsb.service dump978-fa.service adsbcot.service aiscot.service \
 	dronecot.service sikw00fcot.service ais-catcher.service sapientcot.service \
-	dronecot-wifi.service dronecot-dronescout.service; do
+	dronecot-wifi.service dronecot-ble.service dronecot-dronescout.service; do
 	forbid_enabled "${_u}"
 done
 require_grep '^ARYAOS_CAPABILITIES=""$' /etc/aryaos/aryaos-config.txt "no sensor capabilities enabled out of the box"

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -50,6 +50,7 @@ CAP_UNITS = {
     "ais": "aiscot",
     "dji": "dronecot",
     "wifi-rid": "dronecot-wifi",
+    "ble-rid": "dronecot-ble",
     "ds101": "dronecot-dronescout",
     "sik": "sikw00fcot",
     "sapient": "sapientcot",
@@ -118,6 +119,28 @@ def probe_wifi_monitor():
             continue
         found.append({"interface": iface, "driver": driver})
     return found
+
+
+def probe_onboard_bt():
+    """Find a Bluetooth adapter capable of receiving Remote ID advertisements.
+
+    Unlike every other probe there is no add-on hardware to look for: the board's
+    own radio is always there. That is exactly why 'ble-rid' must NOT auto-apply
+    (see scan()) — detecting it on every box in the fleet is not a reason to
+    switch a sensor on across the fleet.
+    """
+    adapters = []
+    for path in sorted(glob.glob("/sys/class/bluetooth/hci*")):
+        # sysfs exposes no 'address' attribute for hci devices, so identify the
+        # adapter by its driver instead: hci_uart/btbcm is the Pi's own radio,
+        # btusb an add-on dongle.
+        driver = ""
+        try:
+            driver = os.path.basename(os.path.realpath(f"{path}/device/driver"))
+        except OSError:
+            pass
+        adapters.append({"adapter": os.path.basename(path), "driver": driver})
+    return adapters
 
 
 def probe_esp32_serial():
@@ -288,13 +311,39 @@ def scan():
         "manual_only": True,
     }
 
+    # Bluetooth Remote ID: the ONLY capability needing no add-on hardware, which
+    # makes it the only one where "available" must not imply "switch it on".
+    # Every box has a Bluetooth radio, so auto-applying would turn a sensor on
+    # across the whole fleet — the opposite of shipping everything off by
+    # default. It is reported as available so an operator can find it, and waits
+    # for `aryaos-role caps ... ble-rid`.
+    bt = probe_onboard_bt()
+    caps["ble-rid"] = {
+        "available": bool(bt),
+        "evidence": (
+            "Bluetooth adapter "
+            + ", ".join(a["adapter"] + (f" ({a['driver']})" if a["driver"] else "") for a in bt)
+            + " — legacy advertising only, no BT5 Coded PHY"
+            if bt
+            else "no Bluetooth adapter detected"
+        ),
+        "manual_only": True,
+        "deferred_reason": (
+            "present on every box, so it is never auto-enabled; turn it on with "
+            "`aryaos-role caps ... ble-rid`"
+        ),
+    }
+
     # Auto-apply must be conflict-free. Two capabilities that share one radio
     # would otherwise both be switched on and fight over it — on a single-SDR
     # box that means adsbcot and aiscot each grabbing the same dongle. Keep the
     # higher-priority one and say plainly why the other was held back; the JSON
     # still reports both as available so an operator can choose differently.
+    # 'manual_only' capabilities are never auto-applied even when available —
+    # ble-rid's radio is present on every board, and SAPIENT is a deliberate
+    # network configuration, not a discovery.
     for key, cap in caps.items():
-        cap["auto_apply"] = bool(cap.get("available"))
+        cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")
     for key in CONTENTION_PRIORITY:
         cap = caps.get(key)
         if not cap or not cap.get("auto_apply"):

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -17,6 +17,7 @@ SERVICES = (
     "aiscot",
     "dronecot",
     "dronecot-wifi",
+    "dronecot-ble",
     "dronecot-dronescout",
     "sapientcot",
 )
@@ -32,6 +33,7 @@ CAPABILITIES = {
     "ais": ("AIS", "aiscot", "AIS receiver"),
     "dji": ("DJI DroneID", "dronecot", "AntSDR (DJI OcuSync)"),
     "wifi-rid": ("Wi-Fi Remote ID", "dronecot-wifi", "Wi-Fi monitor-mode adapter"),
+    "ble-rid": ("Bluetooth Remote ID", "dronecot-ble", "onboard Bluetooth adapter"),
     "ds101": ("DroneScout DS101", "dronecot-dronescout", "BlueMark DS101 (OpenDroneID)"),
     "sik": ("SiK Telemetry", "sikw00fcot", "SiK radio"),
     "sapient": ("SAPIENT C-UAS", "sapientcot", "SAPIENT sensor (BSI Flex 335)"),

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -33,7 +33,7 @@ set -euo pipefail
 
 SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
 PRODUCTS="AryaAir AryaSea DragonEgg"
-CAPS="adsb ais dji wifi-rid ds101 sik sapient"
+CAPS="adsb ais dji wifi-rid ble-rid ds101 sik sapient"
 LEGACY_ROLES="multi air maritime cuas relay"
 DEFAULT_PRODUCT="DragonEgg"
 
@@ -84,6 +84,7 @@ cap_units() {
 		ais)      echo "ais-catcher aiscot" ;;
 		dji)      echo "dronecot" ;;
 		wifi-rid) echo "dronecot-wifi" ;;
+		ble-rid)  echo "dronecot-ble" ;;
 		ds101)    echo "dronecot-dronescout" ;;
 		sik)      echo "sikw00fcot" ;;
 		sapient)  echo "sapientcot" ;;
@@ -98,6 +99,7 @@ cap_label() {
 		ais)      echo "AIS" ;;
 		dji)      echo "DJI DroneID" ;;
 		wifi-rid) echo "Wi-Fi Remote ID" ;;
+		ble-rid)  echo "Bluetooth Remote ID" ;;
 		ds101)    echo "DroneScout DS101" ;;
 		sik)      echo "SiK Telemetry" ;;
 		sapient)  echo "SAPIENT C-UAS" ;;
@@ -129,7 +131,7 @@ role_caps() {
 
 all_managed_units() {
 	echo "readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot \
-		dronecot dronecot-wifi dronecot-dronescout sikw00fcot sapientcot"
+		dronecot dronecot-wifi dronecot-ble dronecot-dronescout sikw00fcot sapientcot"
 }
 
 # Expand a capability list to the (deduplicated) union of its units.

--- a/shared_files/aryaos/dronecot-ble.default
+++ b/shared_files/aryaos/dronecot-ble.default
@@ -1,0 +1,34 @@
+# AryaOS dronecot (Bluetooth Remote ID) config — /etc/default/dronecot-ble
+#
+# Captures Open Drone ID broadcast over Bluetooth LE (ASTM F3411 service data,
+# UUID 0xFFFA, app code 0x0D) using the board's OWN Bluetooth radio and forwards
+# it to charontak as CoT. COT_URL is inherited from aryaos-config.txt via the
+# service EnvironmentFile.
+#
+# No add-on hardware is required, so this is deliberately OPT-IN — the radio is
+# present on every box and auto-enabling would switch a sensor on fleet-wide:
+#   sudo aryaos-role caps <existing caps...> ble-rid
+#
+# LEGACY ADVERTISING ONLY: the ASTM long-range profile uses BT5 extended
+# advertising on the Coded PHY, which the Pi's CYW43455 is not known to receive.
+# Treat this as complementary to a Sniffle dongle or a DroneScout DS101.
+
+FEED_URL=ble+hci://hci0
+BLE_ADAPTER=hci0
+SENSOR_ID=ble-rid
+
+# Reader selection:
+#   monitor — HCI_CHANNEL_MONITOR socket (needs CAP_NET_RAW, granted by the
+#             unit). Every advertising report, nothing coalesced. Preferred.
+#   dbus    — BlueZ ServiceData property. No capability needed, but BlueZ may
+#             coalesce repeated advertisements, and because a transmitter
+#             rotates message types a coalesced repeat is a LOST MESSAGE TYPE.
+#   auto    — try monitor, fall back to dbus.
+BLE_READER=auto
+
+# Optional: ignore advertisements weaker than this (dBm). Unset = no filter.
+#BLE_RSSI_THRESHOLD=-95
+
+# SIGINT / receiver detail carried in the CoT payload (dronecot >= 2.2.5).
+SENSOR_TYPE=Bluetooth Open Drone ID
+SENSOR_MODEL=Onboard Bluetooth (BlueZ)

--- a/shared_files/aryaos/systemd/dronecot-ble.service
+++ b/shared_files/aryaos/systemd/dronecot-ble.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=DroneCOT (Bluetooth Remote ID) — Open Drone ID over BLE to TAK
+Documentation=https://github.com/snstac/dronecot
+# A dronecot instance that captures Open Drone ID from Bluetooth LE
+# advertisements (ASTM F3411 service data, UUID 0xFFFA, app code 0x0D) using the
+# board's OWN Bluetooth radio — no Sniffle dongle, no add-on hardware. Decodes
+# with dronecot's BlueZWorker and feeds the same charontak hub as the Wi-Fi,
+# AntSDR/DJI and DS101 sources.
+#
+# This is the only sensor with no external hardware to plug in, which is exactly
+# why it stays OPT-IN: the radio is present on every box, so auto-enabling it
+# would switch a sensor on across the whole fleet. Turn it on deliberately:
+#   sudo aryaos-role caps <existing caps...> ble-rid
+#
+# Coexists with aryaos-bt-pan: dronecot drives an LE scan over BlueZ D-Bus as an
+# ordinary client rather than seizing the adapter, so Classic PAN keeps working.
+#
+# CAPTURES LEGACY ADVERTISING ONLY. The ASTM long-range profile uses BT5
+# extended advertising on the Coded PHY, which the Pi's CYW43455 is not known to
+# receive — this complements a Sniffle dongle or DS101, it does not replace one.
+Wants=network.target
+After=network.target bluetooth.service aryaos-bt-ready.service
+ConditionPathExistsGlob=/sys/class/bluetooth/hci*
+
+[Service]
+User=root
+# The default reader is an HCI_CHANNEL_MONITOR socket (the passive tap btmon
+# uses), which delivers every advertising report un-coalesced but needs
+# CAP_NET_RAW. Without it dronecot falls back to the BlueZ D-Bus reader, where
+# BlueZ may coalesce repeats — and for Remote ID a coalesced repeat is a lost
+# message TYPE, not a duplicate, because a transmitter rotates message types.
+AmbientCapabilities=CAP_NET_RAW
+ExecStart=/usr/bin/dronecot
+RuntimeDirectory=dronecot-ble
+SyslogIdentifier=dronecot-ble
+EnvironmentFile=-/etc/aryaos/aryaos-config.txt
+EnvironmentFile=/etc/default/dronecot-ble
+Type=simple
+Restart=always
+RestartSec=20
+Nice=-1
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
+++ b/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
@@ -28,6 +28,7 @@ ais-catcher
 aiscot
 dronecot
 dronecot-wifi
+dronecot-ble
 dronecot-dronescout
 sikw00fcot
 sapientcot

--- a/stages/stage-dronecot/00-install/00-run.sh
+++ b/stages/stage-dronecot/00-install/00-run.sh
@@ -79,6 +79,15 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-wifi.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/dronecot-wifi.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-wifi.default" \
 	"${ROOTFS_DIR}/etc/default/dronecot-wifi"
+# Bluetooth Remote ID: an opt-in dronecot instance that decodes Open Drone ID
+# from BLE advertisements using the board's OWN Bluetooth radio — the only
+# sensor needing no add-on hardware, which is precisely why it must stay opt-in
+# (auto-enabling would switch a sensor on across the entire fleet).
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/dronecot-ble.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/dronecot-ble.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/dronecot-ble.default" \
+	"${ROOTFS_DIR}/etc/default/dronecot-ble"
+
 # Monitor-mode prep helper (dronecot's own set_monitor_mode doesn't down the
 # iface first nor release it from NetworkManager) — used as ExecStartPre.
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-wifi-monitor" \


### PR DESCRIPTION
> Supersedes #200, which was based on an orphaned pre-squash commit of local `main` and showed CONFLICTING (GitHub then runs no CI at all). Same change, cherry-picked cleanly onto current `main` (1743771).

> Requires **snstac/dronecot#8** (the `ble+hci://` BlueZ backend) in the apt repo. Without it `dronecot-ble` would fall through to the Sniffle worker and fail — which is why the unit ships **disabled**.

## Why

Wi-Fi Remote ID needs a monitor-mode adapter, which the Pi's onboard radio cannot provide — `iw list` on brcmfmac reports `IBSS, managed, AP, P2P-client, P2P-GO, P2P-device` and **no monitor mode**. BLE is the one Remote ID path the board can serve unaided, and it demonstrably works: `btmon` captured real ASTM F3411 advertisements from a DroneBeacon DB120 with no add-on hardware.

This is the **first capability requiring no external hardware**, which drives the one interesting design decision below.

## Opt-in by construction

Every other capability implies hardware you had to plug in, so "available" can safely imply "switch it on". **This radio is present on every board**, so auto-applying would enable a sensor across the entire fleet — the opposite of shipping everything off by default.

`ble-rid` is reported available and appears in `--detected`, but is **excluded from `--caps`** until an operator runs `aryaos-role caps ... ble-rid`. The beacon carries `available=true enabled=false`.

That required making `manual_only` **actually suppress** `auto_apply` rather than being informational — SAPIENT got away with the flag only because it is also `available: false`, whereas `ble-rid` is genuinely available.

## Changes

| File | Change |
|---|---|
| `aryaos-role` | `CAPS`, `cap_units` → `dronecot-ble`, `cap_label`, `all_managed_units` |
| `aryaos-capability-scan` | `probe_onboard_bt()`, `CAP_UNITS`, `manual_only` now gates auto-apply |
| `aryaos-cot-detail` | `SERVICES` + `CAPABILITIES` for the v2 beacon |
| `systemd/dronecot-ble.service`, `dronecot-ble.default` | **new** |
| `stage-dronecot/00-install/00-run.sh` | install both |
| `stage-bt-pan/01-sensors-off/00-run-chroot.sh` | ships disabled |
| `scripts/verify-image.sh` | asserts it ships disabled |

## Gotcha

`probe_onboard_bt()` identifies the adapter by its **driver**, not an address: sysfs exposes no `address` attribute for hci devices (verified — only `device`, `power`, `rfkill0`, `subsystem`, `uevent`), so the obvious lookup silently yields `""`.

## Coexistence

Orders after `bluetooth.service` and `aryaos-bt-ready.service`, and grants `AmbientCapabilities=CAP_NET_RAW` for dronecot's `HCI_CHANNEL_MONITOR` reader. Coexists with `aryaos-bt-pan` (enabled on every box): dronecot drives the LE scan as an ordinary BlueZ D-Bus client rather than seizing the adapter.

## Verified

- All modified shell/Python scripts syntax-check.
- `probe_onboard_bt()` run for real — finds the adapter and its driver.
- `scan()` confirms `available=true`, `auto_apply=false`, in `--detected`, absent from `--caps`.
- All three capability registries (`aryaos-role` CAPS, `aryaos-capability-scan` CAP_UNITS, `aryaos-cot-detail` CAPABILITIES) cross-checked for drift — they agree exactly.

## Not verified

**No hardware run.** Needs this image burned onto a box with a transmitting drone to confirm CoT reaches charontak, and to measure catch rate and BT PAN coexistence cost. Captures **legacy** advertising only — BT5 Coded PHY on the CYW43455 is unmeasured and expected absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM