### PR TITLE
Hold flightaware-apt-repository: upstream pool/index hashes disagree

### DIFF
--- a/stages/stage-adsbcot/tasks/fa.yml
+++ b/stages/stage-adsbcot/tasks/fa.yml
@@ -26,6 +26,28 @@
   ansible.builtin.apt:
     deb: /usr/src/flightaware-apt-repository_1.2_all.deb
 
+# FlightAware's package pool and their own index disagree about this package, so
+# ANY apt run that tries to upgrade it aborts the whole transaction and fails the
+# build:
+#
+#   E: Failed to fetch .../flightaware-apt-repository_1.3_all.deb Hash Sum mismatch
+#      expected SHA256: b0a60c0dfd9620a95e7331d382ae7a8b81634650209ce088df489e8804fc9df1
+#      received SHA256: 20bdb73536845d9d95bc4659973e7ed07bc0fbdda7491045b82a66d5361046cc
+#
+# Verified by hand 2026-07-27: fetching that URL yields the "received" hash, so
+# the file they serve genuinely is not the file their index describes (same
+# 4664-byte size, different content). Upstream's inconsistency — retrying never
+# clears it; two identical build failures confirmed that.
+#
+# We only want this package for the sources.list it drops, and 1.2 is vendored
+# above precisely so the repo definition is reproducible. Hold it so upgrade
+# passes skip it and never attempt the broken fetch. Nothing depends on it, so
+# the hold cannot block another package.
+- name: Hold flightaware-apt-repository (upstream pool/index SHA256 disagree for 1.3)
+  ansible.builtin.dpkg_selections:
+    name: flightaware-apt-repository
+    selection: hold
+
 - name: Use bookworm FlightAware apt suite on trixie (no trixie Release upstream)
   ansible.builtin.replace:
     path: /etc/apt/sources.list.d/flightaware-apt-repository.list


### PR DESCRIPTION
Unblocks the image build, which has failed twice on `main` (run 30288165046, and again on rerun).

## The failure

```
E: Failed to fetch .../flightaware-apt-repository_1.3_all.deb  Hash Sum mismatch
   expected SHA256: b0a60c0dfd9620a95e7331d382ae7a8b81634650209ce088df489e8804fc9df1
   received SHA256: 20bdb73536845d9d95bc4659973e7ed07bc0fbdda7491045b82a66d5361046cc
E: Unable to fetch some archives
pi-gen build failed with exit code 100
```

Verified by hand — fetching that URL really does yield the `received` hash:

```
$ curl -sL -o fa13.deb http://flightaware.com/adsb/piaware/files/packages/pool/piaware/f/flightaware-apt-repository/flightaware-apt-repository_1.3_all.deb
$ sha256sum fa13.deb
20bdb73536845d9d95bc4659973e7ed07bc0fbdda7491045b82a66d5361046cc
```

So the file FlightAware serves is **not** the file their own index describes — same 4664-byte size, different content. That is upstream's inconsistency, not a corrupt download, which is why the rerun failed identically.

**This is not the pre-existing SHA1/`sqv` signing-key problem.** That one is already handled by the `trusted=yes` workaround further down `fa.yml` and only logs a warning; it appears in the same log and is easy to mistake for the cause. The fatal error is the content hash.

## The fix

We install `flightaware-apt-repository` solely for the `sources.list` it drops, and **1.2 is vendored** in `shared_files/adsbcot/` precisely so the repo definition is reproducible. Holding the package makes upgrade passes skip it, so the broken fetch is never attempted. Nothing depends on it, so the hold cannot block another package.

One task added to `stages/stage-adsbcot/tasks/fa.yml`, immediately after the local `.deb` install.

## Follow-up worth tracking separately

The SHA1 warning is a real time-bomb for the `adsb` capability: FlightAware signs that repo with a SHA1-bound key and **Debian trixie's `sqv` rejects SHA1 as of 2026-02-01**. Today `trusted=yes` papers over it, at the cost of no signature verification on `dump978-fa`/`skyaware978`. Worth deciding deliberately whether to keep trusting it unverified or move UAT to a snstac-built package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM