### PR TITLE
Pin flightaware-apt-repository in the script that actually runs

### DIFF
--- a/stages/stage-adsbcot/02-install-repos/00-run-chroot.sh
+++ b/stages/stage-adsbcot/02-install-repos/00-run-chroot.sh
@@ -16,6 +16,41 @@
 
 dpkg -i /usr/src/flightaware-apt-repository_1.2_all.deb
 
+# Never let apt pull flightaware-apt-repository from FlightAware's own repo.
+#
+# Their pool and their index disagree about 1.3 — same 4664-byte size, different
+# content — so any apt run that tries to upgrade it aborts the whole
+# transaction and fails the build:
+#
+#   E: Failed to fetch .../flightaware-apt-repository_1.3_all.deb Hash Sum mismatch
+#      expected SHA256: b0a60c0d...fc9df1   (their index)
+#      received SHA256: 20bdb735...1046cc   (their pool)
+#
+# Verified by hand 2026-07-27: fetching that URL really does yield the "received"
+# hash. Upstream inconsistency, not a corrupt download — three builds failed
+# identically. It bites in pi-gen's OWN export-image/02-set-sources step, which
+# runs a blanket `apt-get dist-upgrade` long after this stage.
+#
+# We install this package solely for the sources.list it drops, and 1.2 is
+# vendored in shared_files precisely so the repo definition is reproducible, so
+# a remote copy is never wanted. Two independent guards, because a dpkg hold
+# alone did not survive to export-image:
+#   1. a negative pin, so no remote version is ever a candidate (any version —
+#      1.4 would presumably be just as broken)
+#   2. a dpkg hold, so upgrade passes skip it
+# Nothing in FlightAware's index Depends on this package, so neither can block
+# dump978-fa/skyaware978.
+install -d /etc/apt/preferences.d
+cat >/etc/apt/preferences.d/02-aryaos-pin-flightaware-apt-repository.pref <<'EOF'
+# flightaware-apt-repository is installed from a vendored .deb; FlightAware's
+# hosted copy has a pool/index SHA256 mismatch that breaks any apt transaction
+# that tries to fetch it. Refuse every remote version.
+Package: flightaware-apt-repository
+Pin: release *
+Pin-Priority: -1
+EOF
+apt-mark hold flightaware-apt-repository
+
 # FlightAware does not publish a trixie dist; use the bookworm suite on Debian 13+ / Pi OS trixie images.
 # See build log: "404  Not Found" on .../packages trixie Release.
 if [[ -f /etc/apt/sources.list.d/flightaware-apt-repository.list ]]; then

--- a/stages/stage-adsbcot/tasks/fa.yml
+++ b/stages/stage-adsbcot/tasks/fa.yml
@@ -26,6 +26,28 @@
   ansible.builtin.apt:
     deb: /usr/src/flightaware-apt-repository_1.2_all.deb
 
+# FlightAware's package pool and their own index disagree about this package, so
+# ANY apt run that tries to upgrade it aborts the whole transaction and fails the
+# build:
+#
+#   E: Failed to fetch .../flightaware-apt-repository_1.3_all.deb Hash Sum mismatch
+#      expected SHA256: b0a60c0dfd9620a95e7331d382ae7a8b81634650209ce088df489e8804fc9df1
+#      received SHA256: 20bdb73536845d9d95bc4659973e7ed07bc0fbdda7491045b82a66d5361046cc
+#
+# Verified by hand 2026-07-27: fetching that URL yields the "received" hash, so
+# the file they serve genuinely is not the file their index describes (same
+# 4664-byte size, different content). Upstream's inconsistency — retrying never
+# clears it; two identical build failures confirmed that.
+#
+# We only want this package for the sources.list it drops, and 1.2 is vendored
+# above precisely so the repo definition is reproducible. Hold it so upgrade
+# passes skip it and never attempt the broken fetch. Nothing depends on it, so
+# the hold cannot block another package.
+- name: Hold flightaware-apt-repository (upstream pool/index SHA256 disagree for 1.3)
+  ansible.builtin.dpkg_selections:
+    name: flightaware-apt-repository
+    selection: hold
+
 - name: Use bookworm FlightAware apt suite on trixie (no trixie Release upstream)
   ansible.builtin.replace:
     path: /etc/apt/sources.list.d/flightaware-apt-repository.list

--- a/stages/stage-adsbcot/tasks/fa.yml
+++ b/stages/stage-adsbcot/tasks/fa.yml
@@ -1,6 +1,12 @@
 # code: language=ansible
 # fa.yml
 #
+# !! NOT EXECUTED BY THE IMAGE BUILD !!
+# The live code path is stages/stage-adsbcot/02-install-repos/00-run-chroot.sh,
+# which duplicates this logic in shell. A 2026-07-27 build log contained no
+# PLAY/TASK lines at all — ansible does not run — so a fix applied only here has
+# no effect on the image. Keep the two in sync, but change the shell script.
+#
 # Copyright Sensors & Signals LLC https://www.snstac.com
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Follow-up to #202, which **did not work**. Build failed a third time, identically.

## Why #202 missed

I put the fix in `stages/stage-adsbcot/tasks/fa.yml`. **That file never executes.** The build log for run 30290539826 contains **no `PLAY` or `TASK` lines anywhere in 11,803 lines** — ansible does not run, so the entire `stages/*/tasks/*.yml` tree is dead code in the current build path.

The live path is `stages/stage-adsbcot/02-install-repos/00-run-chroot.sh`, which duplicates the same logic in shell:

```
##[group]stages/stage-adsbcot/02-install-repos/00-run-chroot.sh
 Selecting previously unselected package flightaware-apt-repository.
```

Two parallel implementations of the same logic, one of them dead, is what made this easy to get wrong — so this PR also marks `fa.yml` with a warning header.

## Root cause (unchanged, upstream)

FlightAware's pool and their own index disagree about `flightaware-apt-repository` 1.3 — same 4664-byte size, different content:

```
expected SHA256: b0a60c0dfd9620a95e7331d382ae7a8b81634650209ce088df489e8804fc9df1  (index)
received SHA256: 20bdb73536845d9d95bc4659973e7ed07bc0fbdda7491045b82a66d5361046cc  (pool)
```

Reproduced by hand with `curl | sha256sum`. Not a corrupt download — three builds failed identically.

It bites in **pi-gen's own `export-image/02-set-sources`**, which runs a blanket `dist-upgrade` long after our stage:

```
Calculating upgrade...
The following packages will be upgraded:
  cockpit-aiscot flightaware-apt-repository
```

Note it says *"will be upgraded"*, not *"kept back"* — so the dpkg hold from #202 was not in effect there even had it run.

## The fix

Two independent guards in the shell script, because a hold alone is evidently not enough:

1. **`/etc/apt/preferences.d/02-aryaos-pin-flightaware-apt-repository.pref`** — pins *every* remote version to `-1`, so none is ever a candidate. Deliberately not version-specific; 1.4 would presumably be just as broken.
2. **`apt-mark hold`** — upgrade passes skip it.

We install this package solely for the `sources.list` it drops, and 1.2 is vendored in `shared_files/adsbcot/` so the repo definition is reproducible — a remote copy is never wanted. Verified against FlightAware's index that **nothing Depends on it**, so neither guard can block `dump978-fa`/`skyaware978`.

## Still outstanding

The `trusted=yes` workaround for their SHA1 signing key means `dump978-fa`/`skyaware978` install with **no signature verification**. Worth a deliberate decision separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM