### PR TITLE
Front-facing copy: mission types and sensor capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,70 @@
 <img src="https://aryaos.readthedocs.io/en/latest/media/aryaos_logo-25p.png" width="160" height="160" alt="AryaOS logo">
 
-# AryaOS - The Operating System for Modern Situational Awareness
+# AryaOS — the situational awareness operating system for TAK
 
-AryaOS is a Linux-based operating system with a suite of situational awareness tools pre-installed.
+AryaOS turns an inexpensive single-board computer into a turn-key sensor gateway. It listens to
+the radio traffic around it — aircraft, vessels, drones, radios — and puts what it hears onto any
+[TAK](https://www.aryaos.org/reference/glossary/#tak) device as
+[Cursor on Target](https://www.aryaos.org/reference/glossary/#cot): ATAK, WinTAK, iTAK, TAKX, or a
+TAK Server.
 
-Features of AryaOS:
+No cloud. No subscription. No command line. Flash a card, boot the box, connect a phone —
+everything else is configured from a touch-friendly web console.
 
-* Includes decoders and gateways for [AIS](https://github.com/snstac/aiscot), [ADS-B](https://github.com/snstac/adsbcot) & [Drone Remote ID](https://github.com/snstac/dronecot).
-* Works with all TAK Products, including ATAK, WinTAK, iTAK, TAKX & TAK Server.
-* Facilitates rapid test & evaluation of edge node sensors.
-* Browser based low-code development tool for visual programming & open API.
-* Runs on inexpensive COTS & low SWaP-C small board computers, including the Raspberry Pi.
-* Built for Arm (arm64) single-board computers today; Intel/amd64 support is planned ([#129](https://github.com/snstac/aryaos/issues/129)) — the full gateway suite already installs on any Debian host from the [signed apt repository](https://snstac.github.io/packages).
+[**Get started in 15 minutes →**](https://www.aryaos.org/get-started/quickstart/)
+
+## What you can build with it
+
+| Mission | What AryaOS does |
+|---------|------------------|
+| **Aerial firefighting & wildland fire** | Puts the local ADS-B and UAT air picture in front of crews on the ground, with no dependence on connectivity. The original AirTAK use case, funded by the Colorado Center of Excellence and the USDA Forest Service. |
+| **Search & rescue** | A backpack-sized node that broadcasts its own Wi-Fi and shares aircraft, vessel, and team position with every phone in range. |
+| **Maritime domain awareness** | Live vessel traffic from an over-the-air AIS receiver or an online feed. |
+| **Counter-UAS & airspace security** | Detects drones by Remote ID (Wi-Fi and Bluetooth), DJI DroneID, and purpose-built receivers — reporting the aircraft *and* the operator's location. |
+| **Range & site security** | A fixed multi-sensor node fusing air, maritime, and drone feeds into a single common operating picture. |
+| **CoT relay & bridging** | Moves Cursor on Target between isolated networks, radios, and a TAK Server. |
+| **Electronic flight bag** | Feeds ADS-B traffic to ForeFlight and other GDL 90 apps. |
+
+## Sensor capabilities
+
+Each capability is a receiver AryaOS knows how to turn into TAK tracks. The image ships with every
+sensor **switched off**; on first boot the box detects what is actually plugged in and enables what
+it finds, then reports anything it could do but did not turn on — so you always know what the
+hardware is capable of.
+
+| Capability | What appears on the map | Typical receiver |
+|------------|-------------------------|------------------|
+| **ADS-B / UAT** | Crewed aircraft on 1090 MHz and 978 MHz | RTL-SDR or any SoapySDR device |
+| **AIS** | Ships and vessels | dAISy NMEA receiver, or a spare SDR |
+| **Wi-Fi Remote ID** | ASTM F3411 Remote ID broadcast over 802.11, plus operator location | Monitor-mode adapter (e.g. Atheros AR9271) |
+| **Bluetooth Remote ID** | ASTM F3411 Remote ID broadcast over Bluetooth LE | **None — the board's own Bluetooth radio** |
+| **DJI DroneID** | DJI aircraft and the pilot's position | AntSDR E200 |
+| **DroneScout DS101** | Remote ID via a dedicated BlueMark receiver | BlueMark DS101 |
+| **SiK telemetry** | MAVLink drone telemetry | SiK radio |
+| **SAPIENT** | Counter-UAS sensors speaking BSI Flex 335 | Network sensor |
+| **APRS** | Amateur radio stations and trackers | RTL-SDR |
+| **GPS** | The node's own position, shared with every connected device | USB GPS receiver |
+
+Mix them freely: one box can run an air picture and a drone picture at once, and tells you when two
+capabilities want the same radio.
+
+## Why teams choose it
+
+* **Works with every TAK product** — ATAK, WinTAK, iTAK, TAKX, and TAK Server, over the open
+  Cursor on Target standard.
+* **Runs offline.** Boots on a Raspberry Pi, broadcasts its own Wi-Fi, and needs no internet to put
+  a picture on a phone in a backpack.
+* **Quiet by default.** A stock image ships with every sensor disabled and only starts what the
+  attached hardware supports, so a box with no radios is a working TAK node rather than a wall of
+  errors.
+* **No terminal required.** Network, radios, TAK certificates, VPN, updates, and diagnostics all
+  live in the browser.
+* **Open source, end to end.** Every gateway is built on [PyTAK](https://github.com/snstac/pytak)
+  and licensed Apache 2.0.
+* **Inexpensive, low SWaP-C hardware.** Built for Arm (arm64) single-board computers such as the
+  Raspberry Pi 4 and 5. Intel/amd64 support is planned
+  ([#129](https://github.com/snstac/aryaos/issues/129)) — the full gateway suite already installs on
+  any Debian host from the [signed apt repository](https://snstac.github.io/packages).
 
 ## AryaOS Software Suite
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ device — ATAK, WinTAK, iTAK, or a TAK Server — with no cloud, no subscriptio
 and no command line required. Sensors in, [Cursor on Target](reference/glossary.md#cot)
 out, managed entirely from a touch-friendly web console.
 
+ADS-B and UAT aircraft, AIS vessels, drone Remote ID over Wi-Fi and Bluetooth,
+DJI DroneID, APRS, and your own GPS position — on one box, in one picture.
+
 [Get started in 15 minutes](get-started/quickstart.md){ .md-button .md-button--primary }
 [What is AryaOS?](get-started/overview.md){ .md-button }
 
@@ -44,7 +47,8 @@ out, managed entirely from a touch-friendly web console.
 
     ---
 
-    Detect and track drones via Remote ID and DJI DroneID for airspace awareness.
+    Detect and track drones by Remote ID — over Wi-Fi *and* over Bluetooth — plus
+    DJI DroneID. Reports the aircraft and the operator's location.
 
     [:octicons-arrow-right-24: Counter-UAS](deploy/counter-uas.md)
 
@@ -58,6 +62,30 @@ out, managed entirely from a touch-friendly web console.
     [:octicons-arrow-right-24: Multi-sensor](deploy/multi-sensor.md)
 
 </div>
+
+## What it can hear
+
+Each capability is a receiver AryaOS knows how to turn into TAK tracks. The image
+ships with every sensor **switched off**; on first boot the box detects what is
+actually plugged in and enables what it finds, then reports anything it could do
+but did not turn on. Mix them freely — it will tell you when two capabilities
+want the same radio.
+
+| Capability | What appears on the map | Typical receiver |
+|------------|-------------------------|------------------|
+| **ADS-B / UAT** | Crewed aircraft on 1090 MHz and 978 MHz | RTL-SDR or any SoapySDR device |
+| **AIS** | Ships and vessels | dAISy NMEA receiver, or a spare SDR |
+| **Wi-Fi Remote ID** | ASTM F3411 Remote ID over 802.11, plus operator location | Monitor-mode adapter (e.g. Atheros AR9271) |
+| **Bluetooth Remote ID** | ASTM F3411 Remote ID over Bluetooth LE | **None — the board's own radio** |
+| **DJI DroneID** | DJI aircraft and the pilot's position | AntSDR E200 |
+| **DroneScout DS101** | Remote ID via a dedicated receiver | BlueMark DS101 |
+| **SiK telemetry** | MAVLink drone telemetry | SiK radio |
+| **SAPIENT** | Counter-UAS sensors speaking BSI Flex 335 | Network sensor |
+| **APRS** | Amateur radio stations and trackers | RTL-SDR |
+| **GPS** | The node's own position, shared with every connected device | USB GPS receiver |
+
+[:octicons-arrow-right-24: Choosing hardware](get-started/hardware.md) &nbsp;·&nbsp;
+[:octicons-arrow-right-24: Capabilities and device roles](config/device-roles.md)
 
 ## Start here
 
@@ -103,6 +131,9 @@ out, managed entirely from a touch-friendly web console.
   and needs no internet to put a picture on a phone in a backpack.
 - **Never touch a terminal.** Network, radios, TAK certificates, VPN, updates,
   device role, and diagnostics all live in the web console.
+- **Quiet by default.** A stock image ships with every sensor disabled and only starts
+  what the attached hardware supports, so a box with no radios is a working TAK node —
+  not a wall of errors.
 - **Built on open standards.** Every gateway is powered by
   [PyTAK](reference/glossary.md#pytak) and speaks Cursor on Target to the whole
   TAK ecosystem. See the [software suite](reference/software-suite.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ repo_url: https://github.com/snstac/aryaos
 repo_name: snstac/aryaos
 edit_uri: edit/main/docs/
 site_description: >-
-  AryaOS — the all-in-one operating system for building a Common Operating
-  Picture from aircraft, vessels, and drones with TAK.
+  Turn a Raspberry Pi into a TAK sensor gateway: ADS-B aircraft, AIS vessels and
+  drone Remote ID as Cursor on Target. Open source and offline-capable.
 site_author: Greg Albrecht <gba@snstac.com>
 copyright: Copyright Sensors &amp; Signals LLC https://www.snstac.com/
 


### PR DESCRIPTION
Copy only — no behaviour changes. Touches `README.md`, `docs/index.md`, and the `site_description` in `mkdocs.yml`.

## Why

Both front doors had drifted behind the product. Neither the README lede nor the site landing page mentioned **Wi-Fi Remote ID, Bluetooth Remote ID, DJI DroneID, DroneScout DS101, SiK telemetry, SAPIENT, APRS or GDL 90** — and neither said what AryaOS is *for* beyond a generic feature list. A reader could not tell whether it fit their mission.

## What changed

**Mission framing.** A "What you can build with it" table in the README and refreshed mission cards on the site, covering the jobs people actually run: aerial firefighting and wildland fire, search & rescue, maritime domain awareness, counter-UAS, site security, CoT relay, and electronic flight bag.

**Sensor capability table** on both surfaces — capability, what appears on the map, and the receiver required. Bluetooth Remote ID is called out as needing **no add-on hardware**, since it is the only capability that runs on the board's own radio.

**Meta description** rewritten to lead with the concrete outcome and fit a search snippet.

## On the SEO

Deliberately restrained. The terms people genuinely search — *ADS-B to TAK*, *AIS*, *drone Remote ID*, *counter-UAS*, *Cursor on Target*, *Raspberry Pi* — now appear in headings and prose where they were simply absent before. No keyword stuffing, no superlatives, no invented benefits. The existing plain register is unchanged; this extends it rather than replacing it.

## One accuracy fix worth flagging

My first draft said sensors "wait to be asked". **That is wrong** — `aryaos-firstboot.sh` *auto-applies* detected capabilities; only `ble-rid` and SAPIENT are `manual_only`. Reworded to describe what actually happens:

> The image ships with every sensor switched off; on first boot the box detects what is actually plugged in and enables what it finds, then reports anything it could do but did not turn on.

Everything else is checked against the shipped code: the capability list matches `CAPS` in `aryaos-role`, the contention note matches `CONTENTION_PRIORITY` in `aryaos-capability-scan`, and "ships with every sensor disabled" is the property `verify-image.sh` asserts on every build.

## Not claimed

No range, catch-rate, or performance numbers anywhere — Bluetooth Remote ID in particular is described by what it decodes, not how well, since it has not yet been measured on Pi hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM