### PR TITLE
Never assign a GNSS receiver as the AIS serial port

### DIFF
--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -213,12 +213,30 @@ def probe_antsdr():
     return None
 
 
+def _is_gnss(port):
+    """Does udev identify this serial port as a GNSS receiver?"""
+    props = _run(["/usr/bin/udevadm", "info", "-q", "property", "-n", port], timeout=5)
+    if re.search(r"^ID_VENDOR_ID=1546$", props, re.M):
+        return True
+    return bool(re.search(r"^ID_(MODEL|SERIAL|VENDOR)=.*(gps|gnss|u-blox|garmin)", props, re.M | re.I))
+
+
 def probe_ais_serial():
-    """A dAISy (or similar) NMEA AIS receiver wired up by aryaos-serial-assign."""
+    """A dAISy (or similar) NMEA AIS receiver wired up by aryaos-serial-assign.
+
+    This reads back the config aryaos-serial-assign WROTE, so on its own it can
+    only confirm that assignment -- including a wrong one. Observed on a real box:
+    a silent u-blox GPS was assigned to ais-catcher by elimination, and this probe
+    then dutifully reported "AIS receiver present", enabling the ais capability on
+    a box that had no AIS hardware at all. So reject a port that udev says is a
+    GNSS receiver rather than treating the config as ground truth.
+    """
     for line in _read("/etc/default/ais-catcher").splitlines():
         if line.startswith("SERIAL_PORT="):
             port = line.split("=", 1)[1].strip().strip("\"'")
             if port and os.path.exists(port):
+                if _is_gnss(port):
+                    return None
                 return port
     return None
 

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -79,6 +79,26 @@ is_rid_device() {
 	[[ "$vid" == "303a" ]]  # Espressif
 }
 
+# True for a GNSS receiver, identified by udev rather than by what it is saying.
+#
+# This matters because a GPS is NOT always talking: gpsd is deliberately stopped
+# while we probe (see pause_gpsd), and a receiver that is cold-starting, indoors,
+# or between fixes can be silent for the whole probe window. A silent GPS used to
+# fall through to the "leftover" pile and get claimed as a dAISy BY ELIMINATION.
+#
+# Observed on a real box: /etc/default/gpsd DEVICES and /etc/default/ais-catcher
+# SERIAL_PORT both pointed at the SAME u-blox 7, so ais-catcher crash-looped
+# fighting gpsd for the port AND the GPS lost its fix. Worse, the capability scan
+# then read that config back and reported "AIS receiver present" -- confirming its
+# own mistake.
+is_gps_device() {
+	local dev="$1" props
+	props="$(udevadm info -q property -n "$dev" 2>/dev/null)"
+	# u-blox vendor id, or any device whose model/serial announces GPS/GNSS.
+	grep -qE '^ID_VENDOR_ID=1546$' <<<"$props" && return 0
+	grep -qiE '^ID_(MODEL|SERIAL|VENDOR)=.*(gps|gnss|u-blox|garmin)' <<<"$props"
+}
+
 # True if this port is the AntSDR's serial console (pinned to /dev/antsdr-console
 # by udev when the operator opts in). The AntSDR console echoes but never emits
 # NMEA, so it must not be swept up as a silent "leftover" and mis-assigned as a
@@ -143,7 +163,17 @@ main() {
 			busy)  log "skip $dev (held by a running service)";;
 			gps:*) [[ -z "$gps_dev" ]] && { gps_dev="$dev"; log "GPS on $dev (${cls#gps:} baud)"; };;
 			ais:*) [[ -z "$ais_dev" ]] && { ais_dev="$dev"; ais_baud="${cls#ais:}"; log "AIS/dAISy on $dev (${cls#ais:} baud)"; };;
-			"")    leftover+=("$dev"); log "silent/unknown serial: $dev";;
+			"")
+				# A silent port that udev says is a GNSS receiver is a GPS, not a
+				# candidate dAISy. Never let it reach "leftover" -- assignment by
+				# elimination would hand the GPS to ais-catcher.
+				if is_gps_device "$dev"; then
+					[[ -z "$gps_dev" ]] && { gps_dev="$dev"; log "GPS on $dev (silent during probe; identified by udev)"; } \
+						|| log "skip $dev (additional GNSS receiver)"
+				else
+					leftover+=("$dev"); log "silent/unknown serial: $dev"
+				fi
+				;;
 		esac
 	done
 	shopt -u nullglob
@@ -154,6 +184,13 @@ main() {
 		&& systemctl is-enabled ais-catcher.service >/dev/null 2>&1; then
 		ais_dev="${leftover[0]}"; ais_baud="$AIS_BAUD_DEFAULT"
 		log "AIS/dAISy assumed on $ais_dev by elimination (silent; ${ais_baud} baud)"
+	fi
+
+	# Final guard: gpsd and ais-catcher must never be pointed at one device.
+	if [[ -n "$gps_dev" && -n "$ais_dev" ]] \
+		&& [[ "$(readlink -f "$gps_dev")" == "$(readlink -f "$ais_dev")" ]]; then
+		log "refusing to assign $ais_dev to BOTH gpsd and ais-catcher; keeping it as GPS"
+		ais_dev=""
 	fi
 
 	local changed=0


### PR DESCRIPTION
Fixes a bug found on live box `.224`, where **`/etc/default/gpsd` `DEVICES` and `/etc/default/ais-catcher` `SERIAL_PORT` both pointed at the same u-blox 7**:

```
gps_serial = usb-u-blox_AG_..._u-blox_7_-_GPS_GNSS_Receiver-if00
ais_serial = usb-u-blox_AG_..._u-blox_7_-_GPS_GNSS_Receiver-if00   <- same device
```

`ais-catcher` crash-looped fighting gpsd for the port, and **the GPS lost its fix** (mode 1, 0 sats). That box has **no AIS hardware at all** — the u-blox was its only serial device.

## Two independent faults

**1. Assignment by elimination claimed the GPS.** `aryaos-serial-assign` assigns a silent leftover port as the dAISy. But a GPS is not always talking: `pause_gpsd()` deliberately stops gpsd while probing, and a receiver that is cold-starting or indoors stays silent for the whole window. So the GPS looked like a silent unknown.

**2. The capability scan then confirmed its own mistake.** `probe_ais_serial()` reads back the config `aryaos-serial-assign` just wrote, so it reported "AIS receiver present" — enabling the `ais` capability on hardware that does not exist. Circular evidence: the check and the thing being checked were the same file.

## The fix

- **`is_gps_device()`** identifies a GNSS receiver from **udev** (u-blox vendor id `1546`, or any `ID_MODEL`/`ID_SERIAL`/`ID_VENDOR` announcing `gps`/`gnss`/`u-blox`/`garmin`) rather than from what the port happens to be saying. A silent port that udev calls a GNSS receiver is assigned as the **GPS** and never reaches the leftover pile.
- **A final guard** refuses to write the same resolved device to both gpsd and ais-catcher under any circumstances — cheap insurance against any other path reaching the same state.
- **`probe_ais_serial()`** rejects a configured port that udev says is GNSS, breaking the circular confirmation.

## Verified against the real fault

Both halves tested against the live misconfiguration on `.224`, not just unit-reasoned:

```
is_gps_device()      -> GPS  -> usb-u-blox_AG_..._GPS_GNSS_Receiver-if00
probe_ais_serial()   -> None    (correctly refuses the GPS)
```

The bug was **deterministic, not a boot race** — it reproduced identically across a reboot before this change, so a fresh image should show `.224` keeping its GPS and simply not claiming an AIS capability it has no hardware for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM