### PR TITLE
Product lines (AryaUAS), ds101→rid, GNSS PPS discipline, crash-loop limits

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -133,6 +133,13 @@ require_path /usr/local/sbin/aryaos-firstboot.sh
 require_path /usr/local/sbin/aryaos-lincot-remarks
 require_path /usr/local/sbin/aryaos-cot-detail
 require_grep 'capabilities' /usr/local/sbin/aryaos-cot-detail "beacon advertises product + capabilities (v2)"
+require_path /usr/local/sbin/aryaos-time-pps
+require_path /etc/systemd/system/aryaos-time-pps.service
+require_path /etc/systemd/system/multi-user.target.wants/aryaos-time-pps.service
+# Crash-loop guard: a sensor unit that restarts forever never enters `failed`,
+# so a start limit is what makes the failure visible at all.
+require_path /etc/systemd/system/readsb.service.d/aryaos-startlimit.conf
+require_path /etc/systemd/system/adsbcot.service.d/aryaos-startlimit.conf
 require_path /usr/local/sbin/aryaos-neighbord
 require_path /etc/systemd/system/aryaos-firstboot.service
 require_path /etc/systemd/system/aryaos-neighbord.service

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -51,7 +51,7 @@ CAP_UNITS = {
     "dji": "dronecot",
     "wifi-rid": "dronecot-wifi",
     "ble-rid": "dronecot-ble",
-    "ds101": "dronecot-dronescout",
+    "rid": "dronecot-dronescout",
     "sik": "sikw00fcot",
     "sapient": "sapientcot",
 }
@@ -279,7 +279,7 @@ def scan():
     }
 
     # DroneScout DS101 vs SiKW00F: same USB id, so probe for MAVLink.
-    ds101 = {"available": False, "evidence": "no ESP32-S3 serial device"}
+    rid = {"available": False, "evidence": "no ESP32-S3 serial device"}
     sik = {"available": False, "evidence": "no ESP32-S3 serial device"}
     if esp32:
         mav = None
@@ -288,10 +288,10 @@ def scan():
             if mav:
                 break
         if mav:
-            ds101 = {"available": True, "evidence": f"MAVLink on {esp32[0]}"}
+            rid = {"available": True, "evidence": f"MAVLink on {esp32[0]}"}
             sik = {
                 "available": False,
-                "evidence": "ESP32-S3 present but speaking MAVLink (DS101)",
+                "evidence": "ESP32 present but speaking MAVLink (DroneScout receiver)",
             }
         else:
             note = (
@@ -299,9 +299,9 @@ def scan():
                 "SiKW00F share the same USB id and the port was silent or busy — "
                 "cannot tell them apart"
             )
-            ds101 = {"available": False, "ambiguous": True, "evidence": note}
+            rid = {"available": False, "ambiguous": True, "evidence": note}
             sik = {"available": False, "ambiguous": True, "evidence": note}
-    caps["ds101"] = ds101
+    caps["rid"] = rid
     caps["sik"] = sik
 
     # SAPIENT: network sensor, no local signature.
@@ -362,7 +362,7 @@ def scan():
     # success: a live dronecot-dronescout holds the DS101 serial port, so the
     # MAVLink probe (which deliberately refuses to disturb a busy port) reports
     # nothing, and `discover --apply` would then switch off a capability that is
-    # working right now. Observed on a real box: firstboot found "dji ds101",
+    # working right now. Observed on a real box: firstboot found "dji rid",
     # a rescan minutes later found only "dji".
     for key, cap in caps.items():
         unit = CAP_UNITS.get(key)

--- a/shared_files/aryaos/aryaos-config.txt
+++ b/shared_files/aryaos/aryaos-config.txt
@@ -34,7 +34,7 @@ WIFI_AP_IP=10.41.0.1
 # Product line: AryaAir (airspace SA) | AryaSea (maritime SA) | DragonEgg (general SIGINT).
 ARYAOS_PRODUCT="DragonEgg"
 
-# Active sensor capabilities: adsb ais dji wifi-rid ds101 sik sapient
+# Active sensor capabilities: adsb ais dji wifi-rid ble-rid rid sik sapient
 #
 # EMPTY BY DEFAULT — the image ships with every sensor gateway disabled. A box
 # with no radios attached should be quiet, not crash-looping decoders it has no

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -36,7 +36,7 @@ CAPABILITIES = {
     "dji": ("DJI DroneID", "dronecot", "AntSDR (DJI OcuSync)"),
     "wifi-rid": ("Wi-Fi Remote ID", "dronecot-wifi", "Wi-Fi monitor-mode adapter"),
     "ble-rid": ("Bluetooth Remote ID", "dronecot-ble", "onboard Bluetooth adapter"),
-    "ds101": ("DroneScout DS101", "dronecot-dronescout", "BlueMark DS101 (OpenDroneID)"),
+    "rid": ("Remote ID receiver", "dronecot-dronescout", "BlueMark DroneScout (OpenDroneID)"),
     "sik": ("SiK Telemetry", "sikw00fcot", "SiK radio"),
     "sapient": ("SAPIENT C-UAS", "sapientcot", "SAPIENT sensor (BSI Flex 335)"),
 }

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -20,7 +20,7 @@
 #                        it supports; --apply enables them.
 #   set ROLE             Back-compat: apply a legacy role as a capability preset.
 #
-# Capability keys: adsb ais dji wifi-rid ds101 sik sapient
+# Capability keys: adsb ais dji wifi-rid ble-rid rid sik sapient
 # The ADS-B decoder unit follows ARYAOS_ADSB_DECODER (readsb | dump1090_fa).
 # Units missing from the image are skipped, not errors.
 #
@@ -32,8 +32,8 @@
 set -euo pipefail
 
 SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
-PRODUCTS="AryaAir AryaSea DragonEgg"
-CAPS="adsb ais dji wifi-rid ble-rid ds101 sik sapient"
+PRODUCTS="AryaAir AryaSea AryaUAS DragonEgg"
+CAPS="adsb ais dji wifi-rid ble-rid rid sik sapient"
 LEGACY_ROLES="multi air maritime cuas relay"
 DEFAULT_PRODUCT="DragonEgg"
 
@@ -85,7 +85,7 @@ cap_units() {
 		dji)      echo "dronecot" ;;
 		wifi-rid) echo "dronecot-wifi" ;;
 		ble-rid)  echo "dronecot-ble" ;;
-		ds101)    echo "dronecot-dronescout" ;;
+		rid)      echo "dronecot-dronescout" ;;
 		sik)      echo "sikw00fcot" ;;
 		sapient)  echo "sapientcot" ;;
 		*)        return 1 ;;
@@ -100,7 +100,7 @@ cap_label() {
 		dji)      echo "DJI DroneID" ;;
 		wifi-rid) echo "Wi-Fi Remote ID" ;;
 		ble-rid)  echo "Bluetooth Remote ID" ;;
-		ds101)    echo "DroneScout DS101" ;;
+		rid)      echo "Remote ID receiver" ;;
 		sik)      echo "SiK Telemetry" ;;
 		sapient)  echo "SAPIENT C-UAS" ;;
 		*)        echo "$1" ;;
@@ -108,9 +108,19 @@ cap_label() {
 }
 
 # Product line -> default capability set applied by `product`.
+# Product line -> default capability set applied by `product`.
+#
+# The lines describe what the box is FOR, and the capability mix is what makes
+# that true:
+#   AryaAir  air picture: ADS-B/UAT *plus* Remote ID, so crewed and uncrewed
+#            traffic appear together.
+#   AryaUAS  uncrewed only: drone detection with NO ADS-B.
+#   AryaSea  maritime: AIS.
+#   DragonEgg general SIGINT: no assumption, operator chooses.
 product_default_caps() {
 	case "$1" in
-		AryaAir)   echo "adsb" ;;
+		AryaAir)   echo "adsb rid" ;;
+		AryaUAS)   echo "dji rid" ;;
 		AryaSea)   echo "ais" ;;
 		DragonEgg) echo "" ;;
 		*)         return 1 ;;
@@ -135,6 +145,20 @@ all_managed_units() {
 }
 
 # Expand a capability list to the (deduplicated) union of its units.
+# Accept the retired 'ds101' key and map it to 'rid'. The capability was named
+# after one BlueMark model, but the same code path serves a DroneScout Bridge
+# (DS110) and anything else speaking MAVLink Open Drone ID over serial, so the
+# key is now model-neutral. Deployed boxes may still have ds101 persisted in
+# aryaos-config.txt.
+normalize_caps() {
+	local cap out=""
+	for cap in $1; do
+		[[ "${cap}" == "ds101" ]] && cap="rid"
+		out="${out}${cap} "
+	done
+	echo "${out% }"
+}
+
 units_for_caps() {
 	local cap u seen=" "
 	for cap in $1; do
@@ -218,6 +242,9 @@ set_caps() {
 	case "${caps}" in
 		none | off) caps="" ;;
 	esac
+	# Map retired keys (ds101 -> rid) before validation, so deployed boxes and
+	# existing muscle memory keep working.
+	caps="$(normalize_caps "${caps}")"
 	local cap
 	for cap in ${caps}; do
 		cap_units "${cap}" >/dev/null 2>&1 || { echo "aryaos-role: unknown capability '${cap}' (caps: ${CAPS})" >&2; exit 2; }

--- a/shared_files/aryaos/aryaos-time-pps
+++ b/shared_files/aryaos/aryaos-time-pps
@@ -1,0 +1,96 @@
+#!/bin/bash
+# aryaos-time-pps — discipline chrony from a GNSS pulse-per-second, when one exists.
+#
+# Why this is not just a static config line:
+#
+#   * The PPS device NUMBER is not stable. On a Pi 5 with a USB GPS the kernel
+#     exposes /dev/pps0 = ptp0 (the Ethernet PHY clock) and /dev/pps1 = acm0
+#     (the GPS pulse over USB CDC). Hardcoding /dev/pps0 would discipline the
+#     clock from the NIC, which is not tied to GNSS at all.
+#   * Boxes without a GPS expose only ptp0, and must get no refclock rather than
+#     a wrong one.
+#
+# So pick the PPS source by NAME, and only accept one that is GNSS-backed.
+#
+# Why it matters: the packaged drop-in already has `refclock SHM 0 refid GPS`,
+# which is gpsd's NMEA time — good to roughly a millisecond. For time-difference
+# work between nodes that is useless: at ~300 m per microsecond, the 130-800 us
+# RMS measured across the fleet is tens to hundreds of kilometres of error. The
+# PPS edge is what turns a "synced" box into one that can contribute to TDOA.
+#
+# `lock GPS` ties the pulse to the SHM refclock so PPS takes its second number
+# from NMEA; without a fix chrony simply will not select it, which is the
+# correct failure mode.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+CONF="/etc/chrony/conf.d/20-aryaos-pps.conf"
+
+log() { logger -t aryaos-time-pps "$*" 2>/dev/null || true; echo "aryaos-time-pps: $*"; }
+
+# A GNSS receiver's pulse arrives via a serial/CDC driver (acm0, ttyACM0) or is
+# named for the receiver. An Ethernet PHY (ptp0) is NOT disciplined to GNSS.
+is_gnss_pps() {
+	[[ "$1" =~ ^(acm|ttyACM|gps|gnss|ublox|u-blox) ]]
+}
+
+find_gnss_pps() {
+	local path name
+	for path in /sys/class/pps/pps*; do
+		[[ -e "${path}/name" ]] || continue
+		name="$(cat "${path}/name" 2>/dev/null)"
+		if is_gnss_pps "${name}"; then
+			echo "/dev/$(basename "${path}")|${name}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+main() {
+	[[ "$(id -u)" == 0 ]] || { echo "aryaos-time-pps: must run as root" >&2; exit 2; }
+
+	local found dev name previous=""
+	[[ -f "${CONF}" ]] && previous="$(cat "${CONF}")"
+
+	if ! found="$(find_gnss_pps)"; then
+		if [[ -f "${CONF}" ]]; then
+			rm -f "${CONF}"
+			log "no GNSS PPS present; removed ${CONF}"
+			systemctl try-restart chrony.service >/dev/null 2>&1 || true
+		else
+			log "no GNSS PPS present (only non-GNSS sources such as ptp0, if any)"
+		fi
+		return 0
+	fi
+
+	dev="${found%%|*}"
+	name="${found##*|}"
+
+	local desired
+	desired="$(cat <<EOF
+# Written by aryaos-time-pps. Do not edit; re-run the service to regenerate.
+#
+# GNSS pulse-per-second on ${dev} (kernel name: ${name}).
+# 'lock GPS' pairs the pulse with the SHM refclock in aryaos.conf, so PPS takes
+# its second number from NMEA. With no GPS fix chrony will not select it.
+refclock PPS ${dev} refid PPS lock GPS
+EOF
+)"
+
+	if [[ "${previous}" == "${desired}" ]]; then
+		log "GNSS PPS already configured on ${dev} (${name})"
+		return 0
+	fi
+
+	install -d -m 0755 /etc/chrony/conf.d
+	printf '%s\n' "${desired}" > "${CONF}"
+	chmod 0644 "${CONF}"
+	log "GNSS PPS on ${dev} (${name}) -> ${CONF}"
+	systemctl try-restart chrony.service >/dev/null 2>&1 || true
+}
+
+main "$@"

--- a/shared_files/aryaos/systemd/aryaos-startlimit.conf
+++ b/shared_files/aryaos/systemd/aryaos-startlimit.conf
@@ -1,0 +1,21 @@
+# AryaOS: let a hopeless sensor unit actually FAIL instead of churning forever.
+#
+# The sensor units ship Restart=always, which is right for a flapping receiver
+# but wrong for one that can never work — a box with `adsb` enabled and no SDR
+# ran readsb and adsbcot 669 times in 97 minutes and filled the journal with
+# 2066 warnings.
+#
+# Worse, it hid itself: a unit that restarts forever NEVER enters the failed
+# state, so `systemctl --failed` reported "none" and `is-system-running` said
+# "running" throughout. Any health check, Cockpit indicator or beacon field
+# based on those was blind to it.
+#
+# With a start limit the unit gives up after repeated rapid failures and enters
+# failed, which is both quieter and honest. A genuinely transient fault still
+# gets ten quick retries, and anything that stays up longer than the interval
+# resets the counter.
+#
+# StartLimit* MUST live in [Unit]; systemd silently ignores it in [Service].
+[Unit]
+StartLimitIntervalSec=300
+StartLimitBurst=10

--- a/shared_files/aryaos/systemd/aryaos-time-pps.service
+++ b/shared_files/aryaos/systemd/aryaos-time-pps.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AryaOS: discipline chrony from a GNSS PPS when one is present
+Documentation=https://www.aryaos.org/
+# Runs after gpsd so the GPS has been opened and its PPS device exists, and
+# after chrony so the restart lands on a running daemon. Re-runs on every boot
+# because the PPS device number is not stable across reboots or replugs.
+After=gpsd.service chrony.service
+Wants=gpsd.service
+ConditionPathExistsGlob=/sys/class/pps/pps*
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-time-pps
+# Best effort: a box with no GNSS pulse is a normal, supported configuration.
+SuccessExitStatus=0 2
+
+[Install]
+WantedBy=multi-user.target

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -123,6 +123,25 @@ done
 # chrony drop-in: GPS-disciplined NTP + serve time to the local networks.
 install -v -D -m 0644 "${SHARED_FILES}/aryaos/chrony/aryaos.conf" "${ROOTFS_DIR}/etc/chrony/conf.d/aryaos.conf"
 
+# GNSS pulse-per-second discipline. The packaged drop-in above gives chrony
+# gpsd's NMEA time (SHM), good to about a millisecond; the PPS edge is what
+# takes a node from "synced" to usable for time-difference work between boxes.
+# It cannot be a static config line because the PPS device number is not stable
+# — on a Pi 5 with a USB GPS, /dev/pps0 is the Ethernet PHY clock (ptp0) and the
+# GPS pulse is /dev/pps1 (acm0) — so a helper picks it by name at boot.
+install -v -D -m 0755 "${SHARED_FILES}/aryaos/aryaos-time-pps" \
+	"${ROOTFS_DIR}/usr/local/sbin/aryaos-time-pps"
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-time-pps.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-time-pps.service"
+
+# Stop hopeless sensor units from crash-looping forever (and from hiding the
+# fact, since a unit that restarts endlessly never enters `failed`).
+for _u in readsb dump1090-fa dump978-fa adsbcot gdltak ais-catcher aiscot \
+	dronecot dronecot-wifi dronecot-ble dronecot-dronescout sikw00fcot sapientcot; do
+	install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-startlimit.conf" \
+		"${ROOTFS_DIR}/etc/systemd/system/${_u}.service.d/aryaos-startlimit.conf"
+done
+
 ## One-click updates: helper + oneshot unit (driven by Cockpit -> AryaOS Site)
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-update" "${ROOTFS_DIR}/usr/local/sbin/aryaos-update"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-update.service" \

--- a/stages/stage-aryaos/00-install/01-run-chroot.sh
+++ b/stages/stage-aryaos/00-install/01-run-chroot.sh
@@ -41,6 +41,8 @@ systemctl enable aryaos-gps-time-sync.service
 # client-only systemd-timesyncd.
 systemctl disable systemd-timesyncd.service 2>/dev/null || true
 systemctl enable chrony.service
+# Picks a GNSS PPS (by name, not by device number) and hands it to chrony.
+systemctl enable aryaos-time-pps.service
 systemctl enable aryaos-tak-dp-importd.service
 systemctl enable aryaos-neighbord.service
 # EMCON: re-applies WiFi/Bluetooth rfkill at boot when /etc/aryaos/emcon is set.


### PR DESCRIPTION
Four related fixes to the product/capability model and to time + reliability. Three commits.

## 1. Product lines

The lines describe what a box is **for**, and the capability mix is what makes that true:

| Product | Default caps | Meaning |
|---|---|---|
| **AryaAir** | `adsb rid` | Air picture — ADS-B/UAT **plus** Remote ID, so crewed and uncrewed traffic appear together |
| **AryaUAS** | `dji rid` | **New.** Uncrewed only — drone detection with **no** ADS-B |
| **AryaSea** | `ais` | Maritime |
| **DragonEgg** | *(none)* | General SIGINT, operator chooses |

`AryaUAS` is the common counter-UAS laydown (AntSDR and/or a DroneScout receiver, no ADS-B), which previously had to masquerade as DragonEgg.

## 2. Capability rename `ds101` → `rid`

`ds101` was named after one BlueMark model, but the code path is model-agnostic — MAVLink Open Drone ID over serial — and it is currently serving a **DroneScout Bridge (DS110)**. Reading `caps=[dji ds101]` on a box with no DS101 attached is simply wrong.

Safe: `ds101` appears nowhere outside this repo (no Cockpit, no neighbord), and `normalize_caps()` maps the old key on input so deployed configs keep working.

## 3. GNSS PPS discipline for chrony (#77)

The shipped drop-in gives chrony gpsd's NMEA time via SHM — about a millisecond. For time-difference work between nodes that is useless: at **~300 m per microsecond**, the 130–800 µs RMS measured across the fleet is tens to hundreds of kilometres of error.

**This cannot be a static config line.** Measured on a Pi 5 with a USB GPS:

```
/dev/pps0 = ptp0   Ethernet PHY clock, NOT disciplined to GNSS
/dev/pps1 = acm0   the GPS pulse over USB CDC
```

Hardcoding `/dev/pps0` would have disciplined the system clock **from the NIC**. So `aryaos-time-pps` picks the source by *name*, accepts only a GNSS-backed one, and writes `conf.d/20-aryaos-pps.conf`. Verified on both lab boxes: `.60` rejects `pps0` and selects `pps1`; `.13` (no GPS) correctly selects nothing.

`lock GPS` pairs the pulse with the existing SHM refclock, so with no fix chrony simply won't select it — the right failure mode. The beacon's `tdoa_ready` should flip true on its own once a box has a fix.

## 4. Sensor crash-loops stop hiding (#75)

A box with `adsb` enabled and no usable SDR ran `readsb` and `adsbcot` **669 times in 97 minutes** for 2066 warnings. Worse, it **hid itself**: a unit that restarts forever never enters `failed`, so `systemctl --failed` reported "none" and `is-system-running` said "running" throughout — blinding every health check built on them.

A `StartLimitIntervalSec=300` / `StartLimitBurst=10` drop-in on each sensor unit lets a hopeless one give up and actually fail. Ten quick retries still cover a transient fault. `StartLimit*` is in `[Unit]` deliberately — systemd silently ignores it in `[Service]`.

## Verified

- All three capability registries agree (checked programmatically for drift)
- `normalize_caps "dji ds101"` → `dji rid`; product defaults resolve as tabled
- PPS selection tested against both live boxes (see above)
- `verify-image.sh` asserts the PPS helper, its unit, and the start-limit drop-ins ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM
