### PR TITLE
CI: don't rebuild the image for docs-only changes

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -10,6 +10,17 @@ on:
   push:
     branches:
       - main
+    # A docs or branding change cannot alter the image, but it used to trigger a
+    # full ~20 minute arm64 build AND cut a release — which the AryaOS Imager
+    # then offers as "latest dev", superseding a verified image with one that is
+    # functionally identical. paths-ignore only skips when EVERY changed file
+    # matches, so any real change still builds.
+    paths-ignore:
+      - 'docs/**'
+      - 'overrides/**'
+      - 'README.md'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
     inputs:
       release:


### PR DESCRIPTION
A docs or branding change cannot alter the image, but pushing one to `main` triggers a full **~20 minute arm64 build** *and* cuts a release. The AryaOS Imager then offers that release as **"latest dev"**, superseding a verified image with one that is functionally identical — so someone flashing mid-test picks up a different tag than the one that was validated.

Hit twice today: merging the front-facing copy (#204) and merging the design kit (#208). Both builds were cancelled by hand.

## The fix

`paths-ignore` on the `push` trigger for `docs/**`, `overrides/**`, `README.md`, `mkdocs.yml` and the docs workflow.

**`paths-ignore` only skips when EVERY changed file matches**, so a commit touching docs *and* a stage script still builds — which is the failure mode worth being careful about. `pull_request` is left unfiltered so PR validation is unchanged, and `workflow_dispatch` still forces a build on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM