### PR TITLE
Fix PPS discipline losing a boot race and never running

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -135,6 +135,7 @@ require_path /usr/local/sbin/aryaos-cot-detail
 require_grep 'capabilities' /usr/local/sbin/aryaos-cot-detail "beacon advertises product + capabilities (v2)"
 require_path /usr/local/sbin/aryaos-time-pps
 require_path /etc/systemd/system/aryaos-time-pps.service
+require_path /etc/udev/rules.d/99-aryaos-pps.rules
 require_path /etc/systemd/system/multi-user.target.wants/aryaos-time-pps.service
 # Crash-loop guard: a sensor unit that restarts forever never enters `failed`,
 # so a start limit is what makes the failure visible at all.

--- a/shared_files/aryaos/systemd/aryaos-time-pps.service
+++ b/shared_files/aryaos/systemd/aryaos-time-pps.service
@@ -6,11 +6,23 @@ Documentation=https://www.aryaos.org/
 # because the PPS device number is not stable across reboots or replugs.
 After=gpsd.service chrony.service
 Wants=gpsd.service
-ConditionPathExistsGlob=/sys/class/pps/pps*
+# NO ConditionPathExistsGlob here. A USB GPS enumerates asynchronously, so at
+# boot the condition was evaluated before /sys/class/pps/pps* existed and the
+# unit was skipped entirely -- on a box that had a perfectly good GNSS pulse.
+# Observed: "skipped, unmet condition check", while running the helper by hand
+# a minute later selected /dev/pps1 (acm0) and wrote the config.
+#
+# The helper is idempotent and already handles "no PPS present" by removing any
+# stale config and exiting 0, so it is safe to run unconditionally. A udev rule
+# (99-aryaos-pps.rules) re-triggers it whenever a PPS device appears, which
+# covers both the boot race and replugging the GPS.
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
+# Deliberately NOT RemainAfterExit: the unit would stay "active" after its first
+# run, and the udev re-trigger (a Wants= on an already-active oneshot) would do
+# nothing. Each PPS device event must be able to re-run the helper, which is
+# idempotent and rewrites the config only when the selected device changes.
 ExecStart=/usr/local/sbin/aryaos-time-pps
 # Best effort: a box with no GNSS pulse is a normal, supported configuration.
 SuccessExitStatus=0 2

--- a/shared_files/aryaos/udev/99-aryaos-pps.rules
+++ b/shared_files/aryaos/udev/99-aryaos-pps.rules
@@ -1,0 +1,9 @@
+# Re-run the chrony PPS helper whenever a pulse-per-second source appears.
+#
+# A USB GPS enumerates asynchronously, so at boot the service can run (or be
+# skipped) before /sys/class/pps/* exists. Triggering on the device itself
+# removes the race and also covers replugging the receiver mid-flight.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+ACTION=="add", SUBSYSTEM=="pps", TAG+="systemd", ENV{SYSTEMD_WANTS}="aryaos-time-pps.service"

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -133,6 +133,10 @@ install -v -D -m 0755 "${SHARED_FILES}/aryaos/aryaos-time-pps" \
 	"${ROOTFS_DIR}/usr/local/sbin/aryaos-time-pps"
 install -v -D -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-time-pps.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-time-pps.service"
+# Re-trigger the helper when a PPS device appears: a USB GPS enumerates
+# asynchronously, so a boot-time-only run loses the race.
+install -v -D -m 0644 "${SHARED_FILES}/aryaos/udev/99-aryaos-pps.rules" \
+	"${ROOTFS_DIR}/etc/udev/rules.d/99-aryaos-pps.rules"
 
 # Stop hopeless sensor units from crash-looping forever (and from hiding the
 # fact, since a unit that restarts endlessly never enters `failed`).


### PR DESCRIPTION
The GNSS PPS discipline shipped in #207 **never ran**. Caught on the first image that carried it: both freshly flashed boxes had `aryaos-time-pps` inactive with no chrony config written — on a box with a perfectly good GNSS pulse.

```
ConditionResult=no
skipped, unmet condition check ConditionPathExistsGlob=/sys/class/pps/pps*
```

A USB GPS enumerates asynchronously, so systemd evaluated the condition before `/sys/class/pps/pps*` existed. `After=gpsd.service` doesn't help — gpsd starts whether or not the receiver is present.

Running the helper by hand a minute later worked first time:

```
aryaos-time-pps: GNSS PPS on /dev/pps1 (acm0) -> /etc/chrony/conf.d/20-aryaos-pps.conf
```

That's what proved the *logic* was right and the *trigger* was wrong — the selection even picked `pps1` over the Ethernet PHY on `pps0`, exactly as designed.

## Fix

- **Drop `ConditionPathExistsGlob`.** The helper is idempotent and already treats "no PPS" as a normal, supported outcome — it removes any stale config and exits 0 — so running it unconditionally is safe.
- **Add a udev rule** (`99-aryaos-pps.rules`) so any PPS device appearing re-triggers the unit. That closes the race properly rather than papering over it with a sleep, and also covers replugging the GPS mid-flight.

**`RemainAfterExit` is dropped deliberately.** It would leave the unit "active" after the first run, and a udev `Wants=` on an already-active oneshot does nothing — the re-trigger would have been silently inert. That would have looked fixed and not been.

`verify-image.sh` asserts the udev rule ships.

## Note on what this doesn't prove

This makes the helper *run*. Whether `tdoa_ready` then flips true is still unmeasured — u-blox PPS over USB CDC is markedly jitterier than a GPIO-wired pulse, so the RMS may not reach the 10 µs the beacon requires. That's the next thing to measure, and a negative result would be useful evidence for GPIO PPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM