### PR TITLE
Fix the APRS receive path: it could never have worked

### DIFF
--- a/manifests/aryaos-sensor-packages.yml
+++ b/manifests/aryaos-sensor-packages.yml
@@ -16,6 +16,10 @@ sensor_apt_packages:
   - dronecot
   - sikw00fcot
   - lincot
+  # aprscot imports aprslib.parsing; the deb did not declare it, so aprscot
+  # could not start at all (snstac/aprscot#19). Belt and braces until that
+  # release lands in the apt repo.
+  - python3-aprslib
   # gdltak — CoT to GDL90: ForeFlight/EFB display of the TAK air picture.
   # NOTE: requires gdltak indexed in the apt repo (snstac/packages PR #1) —
   # merge/publish that before building an image from this manifest.

--- a/shared_files/aryaos/direwolf.conf
+++ b/shared_files/aryaos/direwolf.conf
@@ -8,12 +8,19 @@
 # no digipeat, no IGate (offline/EMCON-friendly — nothing is transmitted).
 
 # One 1200-baud AFSK channel (VHF APRS, 144.39 MHz in North America).
+# Audio: stdin in, null out. direwolf ALWAYS opens an output device even when
+# receiving from stdin, and on a headless Pi there is no sound card -- it failed
+# with "Could not open audio device default for output / Unknown error 524" and
+# exited before serving KISS. 'null' gives it somewhere to not-transmit to.
+#
+# There is deliberately NO "PTT OFF" line: that is not direwolf syntax. It parses
+# OFF as a PTT *device name* and rejects the config with "Missing RTS or DTR
+# after PTT device name". Omitting PTT entirely is how you disable it.
+ADEVICE stdin null
 ACHANNELS 1
 CHANNEL 0
 MODEM 1200
 
-# No transmit hardware — receive/decode only.
-PTT OFF
 
 # KISS TCP server for the CoT gateway (aprscot). AGW server left off.
 KISSPORT 8001

--- a/shared_files/aryaos/systemd/aryaos-direwolf@.service
+++ b/shared_files/aryaos/systemd/aryaos-direwolf@.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=AryaOS APRS receiver — rtl_fm + Dire Wolf on RTL-SDR %i (KISS :8001)
+# NOTE: rtl_fm is RTL-SDR ONLY. A SoapySDR-only box (LimeSDR, Airspy, HackRF)
+# cannot use this unit -- there is no Soapy FM demodulator in the image and
+# neither rx-tools nor csdr is in the configured apt repos. See aryaos task #81.
 Documentation=https://github.com/wb2osz/direwolf
 # Started on demand by `aryaos-sdr task %i aprs`. Tunes RTL-SDR %i to 144.39 MHz
 # (North America VHF APRS), FM-demodulates with rtl_fm, and hands 24 kHz audio to
@@ -14,7 +17,12 @@ Type=simple
 # %i = RTL device index (matches `aryaos-sdr list`). rtl_fm emits 24 kHz s16 mono on
 # stdout; direwolf reads it from stdin (`-`) and matches with -r 24000. -t 0 disables
 # color codes so journald stays clean. APRS RX frequency is 144.390 MHz (US/NA).
-ExecStart=/bin/sh -c 'exec /usr/bin/rtl_fm -d %i -f 144.39M -s 24000 -o 4 - | /usr/bin/direwolf -c /etc/aryaos/direwolf.conf -r 24000 -D 1 -t 0 -'
+# Frequency is REGIONAL and must not be hardcoded: 144.39 MHz is North America,
+# 144.800 MHz is most of Europe/UK, 145.175 in AU/NZ, 144.64 in JA. A box shipped
+# to the wrong default decodes nothing and looks like broken hardware. Override
+# APRS_FREQ in /etc/default/aprscot.
+EnvironmentFile=-/etc/default/aprscot
+ExecStart=/bin/sh -c 'exec /usr/bin/rtl_fm -d %i -f "${APRS_FREQ:-144.39M}" -s 24000 -o 4 - | /usr/bin/direwolf -c /etc/aryaos/direwolf.conf -r 24000 -D 1 -t 0 -'
 Restart=on-failure
 RestartSec=5
 

--- a/shared_files/aryaos/systemd/aryaos-direwolf@.service
+++ b/shared_files/aryaos/systemd/aryaos-direwolf@.service
@@ -17,10 +17,11 @@ Type=simple
 # %i = RTL device index (matches `aryaos-sdr list`). rtl_fm emits 24 kHz s16 mono on
 # stdout; direwolf reads it from stdin (`-`) and matches with -r 24000. -t 0 disables
 # color codes so journald stays clean. APRS RX frequency is 144.390 MHz (US/NA).
-# Frequency is REGIONAL and must not be hardcoded: 144.39 MHz is North America,
-# 144.800 MHz is most of Europe/UK, 145.175 in AU/NZ, 144.64 in JA. A box shipped
-# to the wrong default decodes nothing and looks like broken hardware. Override
-# APRS_FREQ in /etc/default/aprscot.
+# APRS is on a different channel per region: 144.39 MHz North America (the
+# default, and correct for our fleet), 144.800 most of Europe/UK, 145.175 AU/NZ,
+# 144.64 JA. The default is right; this only makes it overridable via APRS_FREQ
+# in /etc/default/aprscot so a unit shipped abroad does not need a code change.
+# A box on the wrong channel decodes nothing and looks like broken hardware.
 EnvironmentFile=-/etc/default/aprscot
 ExecStart=/bin/sh -c 'exec /usr/bin/rtl_fm -d %i -f "${APRS_FREQ:-144.39M}" -s 24000 -o 4 - | /usr/bin/direwolf -c /etc/aryaos/direwolf.conf -r 24000 -D 1 -t 0 -'
 Restart=on-failure


### PR DESCRIPTION
Testing APRS on a live box showed the whole chain was broken — **on any SDR**, not just the LimeSDR.

## 1. direwolf could not start

Two faults in the shipped `/etc/aryaos/direwolf.conf`:

**`PTT OFF` is not direwolf syntax.** It parses `OFF` as a PTT *device name* and rejects the config:
```
Config file line 16: Missing RTS or DTR after PTT device name.
```
Omitting PTT entirely is how you disable it.

**No audio output device.** direwolf always opens one even when receiving from stdin, and a headless Pi has no sound card:
```
Could not open audio device default for output
Unknown error 524
```
It exited before ever serving KISS. `ADEVICE stdin null` fixes it.

With both corrected, verified on hardware:
```
Audio input device for receive: stdin  (channel 0)
Audio out device for transmit: null  (channel 0)
Channel 0: 1200 baud, AFSK 1200 & 2200 Hz, A+, 24000 sample rate.
Ready to accept KISS TCP client application 0 on port 8001 ...
```

## 2. Frequency was hardcoded to North America

`144.39M` is the US APRS channel. **The UK and most of Europe use 144.800** (AU/NZ 145.175, JA 144.64). A box shipped anywhere else decodes nothing and looks like broken hardware — our own fleet is on Europe/London.

Now read from `APRS_FREQ` in `/etc/default/aprscot`, defaulting to the previous value so US units are unaffected.

## 3. aprscot could not start either

It imports `aprslib.parsing`, but the deb never declared `python3-aprslib`, and an over-broad `try/except` in its `__init__` masked the `ImportError` into a confusing `AttributeError`. Fixed upstream in **snstac/aprscot#19**; adding the package here as belt and braces until that release reaches apt.

## Not fixed here

`rtl_fm` is **RTL-SDR only**, so a SoapySDR-only box (LimeSDR, Airspy, HackRF) still can't run this unit — there is no Soapy FM demodulator in the image, and neither `rx-tools` nor `csdr` is in the configured apt repos. Documented in the unit, tracked as task #81.

I wrote and validated a ~60-line SoapySDR FM demodulator against the LimeSDR during this test — Lime → demod → direwolf → KISS worked end to end. Left out of this PR because it's new DSP that deserves its own review rather than riding along with config fixes.

## Scope of verification

The **path** is proven; **reception is not**. 0 frames decoded — expected indoors on a wideband antenna, with sporadic APRS traffic on 144.800. Needs an outdoor test with a proper 2 m antenna to confirm real decodes.

Also worth flagging: `MYCALL N0CALL` is still the unset placeholder, so aprscot would attribute CoT to `N0CALL`. Harmless receive-only, but worth prompting for at first boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM