### PR TITLE
Stop the PPS refclock killing chrony at boot

### DIFF
--- a/shared_files/aryaos/aryaos-time-pps
+++ b/shared_files/aryaos/aryaos-time-pps
@@ -27,7 +27,24 @@
 
 set -uo pipefail
 
-CONF="/etc/chrony/conf.d/20-aryaos-pps.conf"
+# The refclock config MUST be ephemeral. chronyd treats a refclock naming a
+# missing device as a FATAL error and refuses to start:
+#
+#   Fatal error : Could not open /dev/pps1 : No such file or directory
+#
+# A USB GPS enumerates after chrony starts, so a config persisted in
+# /etc/chrony/conf.d/ is present at boot while the device is not -- which killed
+# chrony outright on a lab box and left it with NO time sync for 7 hours. That is
+# strictly worse than having no PPS at all.
+#
+# Writing to /run instead means the file cannot survive a reboot: chrony starts
+# clean, then this helper (udev-triggered when the PPS device appears) writes the
+# refclock and reloads it. Verified: chronyd tolerates a confdir that does not
+# exist, and tolerates an empty one.
+RUN_DIR="/run/chrony-aryaos"
+CONF="${RUN_DIR}/20-aryaos-pps.conf"
+# Older builds wrote here and would break chrony on the next boot; remove it.
+LEGACY_CONF="/etc/chrony/conf.d/20-aryaos-pps.conf"
 
 log() { logger -t aryaos-time-pps "$*" 2>/dev/null || true; echo "aryaos-time-pps: $*"; }
 
@@ -53,14 +70,21 @@ find_gnss_pps() {
 main() {
 	[[ "$(id -u)" == 0 ]] || { echo "aryaos-time-pps: must run as root" >&2; exit 2; }
 
+	# Migration: a persisted config from an older build is a boot-time landmine.
+	if [[ -f "${LEGACY_CONF}" ]]; then
+		rm -f "${LEGACY_CONF}"
+		log "removed legacy ${LEGACY_CONF} (persisted refclock breaks chrony at boot)"
+	fi
+
 	local found dev name previous=""
+	install -d -m 0755 "${RUN_DIR}"
 	[[ -f "${CONF}" ]] && previous="$(cat "${CONF}")"
 
 	if ! found="$(find_gnss_pps)"; then
 		if [[ -f "${CONF}" ]]; then
 			rm -f "${CONF}"
 			log "no GNSS PPS present; removed ${CONF}"
-			systemctl try-restart chrony.service >/dev/null 2>&1 || true
+			systemctl reload-or-restart chrony.service >/dev/null 2>&1 || true
 		else
 			log "no GNSS PPS present (only non-GNSS sources such as ptp0, if any)"
 		fi
@@ -86,11 +110,10 @@ EOF
 		return 0
 	fi
 
-	install -d -m 0755 /etc/chrony/conf.d
 	printf '%s\n' "${desired}" > "${CONF}"
 	chmod 0644 "${CONF}"
 	log "GNSS PPS on ${dev} (${name}) -> ${CONF}"
-	systemctl try-restart chrony.service >/dev/null 2>&1 || true
+	systemctl reload-or-restart chrony.service >/dev/null 2>&1 || true
 }
 
 main "$@"

--- a/shared_files/aryaos/chrony/aryaos.conf
+++ b/shared_files/aryaos/chrony/aryaos.conf
@@ -14,3 +14,9 @@ allow
 # Fall back to the local clock (stratum 10) so the box still serves time when it
 # has neither upstream NTP nor a GPS fix (offline field use).
 local stratum 10
+
+# Ephemeral refclock directory, written by aryaos-time-pps when a GNSS PPS
+# actually exists. It deliberately lives in /run: a refclock naming a device
+# that is not present yet is a FATAL chronyd error, and a USB GPS enumerates
+# after chrony starts. chronyd tolerates this directory being absent or empty.
+confdir /run/chrony-aryaos


### PR DESCRIPTION
**My own regression, found by burn-in testing.** The GNSS PPS work (#207/#211) wrote a refclock into `/etc/chrony/conf.d/`, which persists across reboots. chronyd treats a refclock naming a missing device as **fatal**:

```
Fatal error : Could not open /dev/pps1 : No such file or directory
chrony.service: Failed with result 'exit-code'.
```

A USB GPS enumerates **after** chrony starts, so on every reboot the config was present while the device was not. Lab box `.60` had **no time sync at all for 7 hours** — strictly worse than having no PPS, because it lost NTP too.

It only surfaced because the burn-in enumerated failed units and `chrony.service` was among them. Nothing else was looking.

**#211 made this more dangerous, not less.** It fixed the helper being skipped at boot, so the config now gets written on more boxes — each of which then loses chrony on its next reboot.

## Fix

The refclock config becomes **ephemeral**, in `/run/chrony-aryaos/`, so it cannot survive a reboot. chrony starts clean; the udev-triggered helper then writes the refclock and reloads chrony.

Verified on hardware which cases chronyd tolerates:

| Scenario | chronyd |
|---|---|
| `confdir` points at a missing directory | **starts fine** |
| directory present but empty | **starts fine** |
| refclock naming a missing device | **FATAL** |

That asymmetry is the entire reason this has to live in `/run` rather than being written more carefully in `/etc`.

## Migration

The helper removes any `/etc/chrony/conf.d/20-aryaos-pps.conf` left by an earlier build. Boxes already carrying that file have a boot-time landmine; without this they'd lose chrony on their next reboot even after upgrading.

## Verified end to end on `.60`

```
removed legacy /etc/chrony/conf.d/20-aryaos-pps.conf
GNSS PPS on /dev/pps1 (acm0) -> /run/chrony-aryaos/20-aryaos-pps.conf
chrony: active     #? GPS   #? PPS      <- both refclocks loaded
chronyd -Q with /run/chrony-aryaos cleared: starts successfully
```

`#? PPS` is the first time chrony has actually loaded the PPS refclock. `?` means present but unselected, which is correct without a GPS fix — and the live box's time sync has been restored in the meantime.

## Lesson worth recording

I shipped a "safety" mechanism twice without testing the failure path. #211 removed a `ConditionPathExistsGlob` that was preventing the helper running; this fixes what that condition was accidentally protecting against. The condition was wrong, but deleting it exposed a worse bug underneath that I should have looked for at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM