### PR TITLE
verify-image: assert the PPS refclock is wired and ephemeral

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -103,6 +103,14 @@ require_grep() {
 		fail "${label} missing from ${path}"
 	fi
 }
+forbid_grep() {
+	local pattern="$1" path="$2" label="$3"
+	if grep -qsE "${pattern}" "${MNT}${path}"; then
+		fail "${label} — unexpectedly found ${pattern} in ${path}"
+	else
+		ok "${label}"
+	fi
+}
 require_unit() {
 	local u="$1" d
 	for d in etc/systemd/system lib/systemd/system usr/lib/systemd/system; do
@@ -136,6 +144,20 @@ require_grep 'capabilities' /usr/local/sbin/aryaos-cot-detail "beacon advertises
 require_path /usr/local/sbin/aryaos-time-pps
 require_path /etc/systemd/system/aryaos-time-pps.service
 require_path /etc/udev/rules.d/99-aryaos-pps.rules
+# Without this line the helper writes a refclock into /run that chrony never
+# reads, and the PPS discipline silently does nothing -- which is exactly how
+# this feature failed twice already. The /run path is deliberate: a refclock
+# naming a not-yet-enumerated device is a FATAL chronyd error, so it must not
+# persist across a reboot.
+require_grep '^confdir /run/chrony-aryaos$' /etc/chrony/conf.d/aryaos.conf \
+	"chrony reads the ephemeral PPS refclock dir"
+# The helper must WRITE to /run. It still mentions the /etc path deliberately, to
+# migrate it away on boxes from an older build, so assert the write target rather
+# than the absence of the string.
+require_grep '^CONF="\$\{RUN_DIR\}/' /usr/local/sbin/aryaos-time-pps \
+	"PPS refclock is written under /run, not a path that survives reboot"
+forbid_grep '^CONF="/etc/' /usr/local/sbin/aryaos-time-pps \
+	"PPS refclock target is not in /etc"
 require_path /etc/systemd/system/multi-user.target.wants/aryaos-time-pps.service
 # Crash-loop guard: a sensor unit that restarts forever never enters `failed`,
 # so a start limit is what makes the failure visible at all.


### PR DESCRIPTION
The PPS discipline has now failed **silently twice, in two different ways**, and nothing in CI would have caught either:

- **#211** — the unit was skipped at boot by a condition that lost a race with USB enumeration, so the helper never ran.
- **#213** — the refclock was persisted in `/etc`, so chrony died at boot with a fatal `Could not open /dev/pps1` and the box lost **all** time sync for 7 hours.

Both shipped in images that `verify-image.sh` passed. It checked that the helper and unit *exist* — which was true, and useless.

## Three assertions

- **`confdir /run/chrony-aryaos` is present in the chrony drop-in.** Without it, the helper writes a refclock nothing ever reads: working plumbing, no effect. That's the hardest failure to notice and the most likely to recur.
- The helper's write target is **under `/run`**.
- The helper's write target is **not in `/etc`**, so the boot-fatal arrangement can't come back.

Adds a `forbid_grep` helper alongside the existing `require_grep`.

## One subtlety

The forbid deliberately matches the `CONF=` **assignment**, not any mention of the `/etc` path. The helper still references that path on purpose — to migrate it away on already-deployed boxes — and my first draft of this assertion would have **failed the build on correct code**. Caught it by dry-running the greps against the repo files before pushing.

## Verified

All three pass against the current tree:
```
ok:   confdir present
ok:   writes under /run
ok:   target not in /etc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM