### PR TITLE
config-backup: stop silently dropping newer gateways

### DIFF
--- a/manifests/aryaos-sensor-packages.yml
+++ b/manifests/aryaos-sensor-packages.yml
@@ -16,9 +16,10 @@ sensor_apt_packages:
   - dronecot
   - sikw00fcot
   - lincot
-  # aprscot imports aprslib.parsing; the deb did not declare it, so aprscot
-  # could not start at all (snstac/aprscot#19). Belt and braces until that
-  # release lands in the apt repo.
+  # aprscot imports aprslib.parsing. The deb used to not declare it, so aprscot
+  # could not start at all (snstac/aprscot#19). Fixed and released: aprscot
+  # 8.2.1 declares python3-aprslib, and it is in the apt repo. Kept explicit
+  # anyway so an older pinned aprscot cannot silently install unusable.
   - python3-aprslib
   # gdltak — CoT to GDL90: ForeFlight/EFB display of the TAK air picture.
   # NOTE: requires gdltak indexed in the apt repo (snstac/packages PR #1) —

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -597,7 +597,8 @@ backup_covers_gateway_configs() {
 
 		covered=0
 		for pat in "${pats[@]}"; do
-			# shellcheck disable=SC2053 -- pattern match is the point
+			# Unquoted RHS is deliberate: glob matching is the point here.
+			# shellcheck disable=SC2053
 			[[ "${rel}" == ${pat} ]] && { covered=1; break; }
 		done
 		[[ "${covered}" -eq 1 ]] || missing+=("${base}")

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -540,5 +540,76 @@ else
 	fi
 fi
 
+# Regression guard for a data-loss bug found on a live box: aryaos-config-backup
+# captured a literal, hand-maintained list of config paths, and it had gone stale.
+# aprscot, sapientcot, ais-catcher, dronecot-ble, dronecot-wifi,
+# dronecot-dronescout and readsb all existed in /etc/default and NONE were backed
+# up, so a factory reset + restore came back with those capabilities silently
+# reverted to defaults.
+#
+# "Is this file AryaOS configuration?" is decided from dpkg ownership, NOT from a
+# second hardcoded list here -- a second list would rot exactly the same way. A
+# /etc/default entry is ours if no package in the image claims it (our stage
+# scripts wrote it), or if the claiming package is one we install from the snstac
+# apt repo.
+backup_covers_gateway_configs() {
+	local script="${MNT}/usr/local/sbin/aryaos-config-backup"
+	if [[ ! -r "${script}" ]]; then
+		fail "aryaos-config-backup not readable; cannot check backup coverage"
+		return
+	fi
+
+	local -a pats=()
+	# Take the path lines straight out of the config_paths() block. Matching the
+	# heredoc markers instead needs nested quoting that is easy to get wrong --
+	# a first attempt at it silently extracted nothing and the check "passed" by
+	# doing nothing at all.
+	mapfile -t pats < <(sed -n "/^config_paths() {/,/^}/p" "${script}" \
+		| grep -E '^(etc|home|usr|var)/')
+	if [[ "${#pats[@]}" -eq 0 ]]; then
+		fail "could not read config_paths() out of aryaos-config-backup"
+		return
+	fi
+
+	# Packages we install from the snstac repo, per the build manifest.
+	local -a ours=()
+	mapfile -t ours < <(grep -oE '^\s*-\s+[A-Za-z0-9._+-]+' manifests/aryaos-sensor-packages.yml 2>/dev/null \
+		| sed -E 's/^\s*-\s+//')
+
+	local -a missing=()
+	local f base rel owner is_ours covered pat pkg
+	for f in "${MNT}"/etc/default/*; do
+		[[ -f "${f}" ]] || continue
+		base="$(basename "${f}")"
+		rel="etc/default/${base}"
+
+		# Which package claims it, if any?
+		owner=""
+		owner="$(grep -lFx "/${rel}" "${MNT}"/var/lib/dpkg/info/*.list 2>/dev/null | head -1)"
+		is_ours=0
+		if [[ -z "${owner}" ]]; then
+			is_ours=1
+		else
+			pkg="$(basename "${owner}" .list)"; pkg="${pkg%%:*}"
+			for p in "${ours[@]}"; do [[ "${pkg}" == "${p}" ]] && { is_ours=1; break; }; done
+		fi
+		[[ "${is_ours}" -eq 1 ]] || continue
+
+		covered=0
+		for pat in "${pats[@]}"; do
+			# shellcheck disable=SC2053 -- pattern match is the point
+			[[ "${rel}" == ${pat} ]] && { covered=1; break; }
+		done
+		[[ "${covered}" -eq 1 ]] || missing+=("${base}")
+	done
+
+	if [[ "${#missing[@]}" -gt 0 ]]; then
+		fail "aryaos-config-backup would not back up: ${missing[*]}"
+	else
+		ok "aryaos-config-backup covers every AryaOS config in /etc/default"
+	fi
+}
+backup_covers_gateway_configs
+
 echo "== ${PASS} ok, ${FAIL} failed =="
 [[ "${FAIL}" -eq 0 ]]

--- a/shared_files/aryaos/aryaos-config-backup
+++ b/shared_files/aryaos/aryaos-config-backup
@@ -35,6 +35,20 @@ require_root() {
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 # Config paths to capture. Missing paths are skipped, not errors.
+#
+# Entries may be GLOBS. They used to be a literal, hand-maintained list, and it
+# went stale: every gateway added after the list was written was silently left
+# out of the backup. Measured on a live box, these existed in /etc/default but
+# were NOT captured -- aprscot, sapientcot, ais-catcher, dronecot-ble,
+# dronecot-wifi, dronecot-dronescout, readsb, dump1090-fa, dump978-fa.
+#
+# That is a data-loss bug in the one tool whose entire job is not losing data:
+# a factory reset and restore would come back with APRS, SAPIENT, Bluetooth
+# Remote ID, Wi-Fi Remote ID, DroneScout and the AIS/ADS-B receiver settings all
+# reverted to defaults, and nothing would say so.
+#
+# Globbing by family means a new gateway is captured the day it lands, with no
+# edit here. That is the point: the failure mode was "someone must remember".
 config_paths() {
 	cat <<'EOF'
 etc/aryaos
@@ -42,15 +56,13 @@ etc/charontak.ini
 etc/charontak
 etc/comitup.conf
 etc/comitup.json
-etc/default/adsbcot
-etc/default/aiscot
-etc/default/dronecot
-etc/default/lincot
-etc/default/gpstak
-etc/default/gdltak
-etc/default/sikw00fcot
-etc/default/charontak
+etc/default/*cot*
+etc/default/*tak
+etc/default/ais-catcher
 etc/default/gpsd
+etc/default/readsb
+etc/default/dump1090-fa
+etc/default/dump978-fa
 etc/adsbcot
 etc/aiscot
 etc/dronecot
@@ -85,7 +97,9 @@ do_backup() {
 	[[ "${1:-}" == "--no-secrets" ]] && include_secrets=0
 
 	local host stamp name root
-	host="$(hostname | tr -c 'A-Za-z0-9.-' '-')"
+	# tr -d '\n' first: tr -c would otherwise translate hostname's trailing
+	# newline into a '-', producing names like aryaos-config_aryaos-4f11-_2026...
+	host="$(hostname | tr -d '\n' | tr -c 'A-Za-z0-9.-' '-')"
 	# Second-granularity stamp plus the PID, so two backups in the same second
 	# (e.g. a full then a --no-secrets from the UI) get distinct names instead
 	# of one silently overwriting the other.
@@ -101,9 +115,14 @@ do_backup() {
 
 	# Build the list of existing paths (relative to /).
 	local -a paths=()
-	local p
+	local p m
 	while IFS= read -r p; do
-		[[ -e "/${p}" ]] && paths+=("${p}")
+		# Entries may be globs, so expand rather than testing the pattern
+		# literally. A pattern that matches nothing stays unexpanded and fails
+		# the -e test, preserving "missing paths are skipped, not errors".
+		for m in /${p}; do
+			[[ -e "${m}" ]] && paths+=("${m#/}")
+		done
 	done < <(config_paths)
 	if [[ "${include_secrets}" == "1" ]]; then
 		while IFS= read -r p; do


### PR DESCRIPTION
Found on a live box (`aryaos-4f11`) while testing the new image.

`aryaos-config-backup` captured **8** of the `/etc/default` gateway configs and silently omitted **9** others sitting right next to them:

```
aprscot  sapientcot  ais-catcher  dronecot-ble  dronecot-wifi
dronecot-dronescout  readsb  dump1090-fa  dump978-fa
```

Every one of those is a capability we shipped in the last month. So a **factory reset + restore came back with APRS, SAPIENT C-UAS, Bluetooth Remote ID, Wi-Fi Remote ID, DroneScout and the AIS/ADS-B receiver settings all reverted to defaults — and nothing said so.**

That's a data-loss bug in the one tool whose whole job is not losing data, and it's worst exactly when it matters: recovering a box in the field.

## Root cause is structural

`config_paths()` was a literal, hand-maintained list. Every gateway added after it was written had to be remembered separately, and for five capabilities running, it wasn't. This wasn't going to be fixed by adding nine lines.

## Fix

- Glob by family (`etc/default/*cot*`, `*tak`, …) and expand globs when collecting, so a new gateway is captured the day it lands.
- Verified against a tree mirroring the live box: **all 18 gateway configs captured, zero Debian-owned files** (`keyboard`, `locale`, `cron`, `grub`, `useradd`, `hwclock`) dragged in.
- Also fixes the archive name — `hostname | tr -c` translated the trailing **newline** into a dash, producing `aryaos-config_aryaos-4f11-_2026…`.

## CI guard

"Someone must remember" is what failed here, so the guard decides whether a `/etc/default` entry is ours from **dpkg ownership + the build manifest** — deliberately *not* a second hardcoded list, which would rot identically.

Tested offline against a synthetic image:

| Case | Expected | Result |
|---|---|---|
| Fixed script | ok | ok |
| Reverted to the old literal list | FAIL, naming gaps | FAIL — named all 9 |
| New gateway `foocot` appears | ok (glob covers it) | ok |
| New config the globs don't match | FAIL (loud) | FAIL |
| Debian ships a new `/etc/default` | ok (ignored) | ok |

Case 2 is the one that matters: the check reproduces the bug it exists to prevent.

**Worth knowing:** my first version of this check extracted nothing at all and "passed" vacuously — nested quoting around `<<'EOF'`. That's why the negative cases are in here rather than just the happy path.

## Residual, not fixed here

The globs cover `/etc/default`. A gateway that puts config somewhere new (say `/etc/sapientcot/`) is still missed — Case 4 shows CI will at least shout when the name doesn't match, but a whole new directory wouldn't be noticed. Flagging rather than fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM