### PR TITLE
Drop the product line: capabilities are the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Each line is what a box is **for**; the capability mix is what makes that true.
 Marks and accents come from the [AryaOS Product Suite design kit](docs/brand/)
 (`docs/brand/logo/`), vendored here as the source of truth.
 
-| | Line | Default capabilities | For |
+These are build configurations, not something the software labels itself with.
+AryaOS describes a box by the capabilities it actually has — the same image runs
+on all of them, and one box can carry any mix.
+
+| | Line | Typical capabilities | For |
 |---|------|----------------------|-----|
 | <img src="docs/brand/logo/mark-aryaair.svg" width="28" alt=""> | **AryaAir** | `adsb rid` | Air picture — ADS-B/UAT **and** Remote ID, so crewed and uncrewed traffic appear together |
 | <img src="docs/brand/logo/mark-aryauas.svg" width="28" alt=""> | **AryaUAS** | `dji rid` | Uncrewed only — drone detection with no ADS-B |

--- a/manifests/aryaos-sensor-packages.yml
+++ b/manifests/aryaos-sensor-packages.yml
@@ -16,9 +16,10 @@ sensor_apt_packages:
   - dronecot
   - sikw00fcot
   - lincot
-  # aprscot imports aprslib.parsing; the deb did not declare it, so aprscot
-  # could not start at all (snstac/aprscot#19). Belt and braces until that
-  # release lands in the apt repo.
+  # aprscot imports aprslib.parsing. The deb used to not declare it, so aprscot
+  # could not start at all (snstac/aprscot#19). Fixed and released: aprscot
+  # 8.2.1 declares python3-aprslib, and it is in the apt repo. Kept explicit
+  # anyway so an older pinned aprscot cannot silently install unusable.
   - python3-aprslib
   # gdltak — CoT to GDL90: ForeFlight/EFB display of the TAK air picture.
   # NOTE: requires gdltak indexed in the apt repo (snstac/packages PR #1) —

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -597,7 +597,8 @@ backup_covers_gateway_configs() {
 
 		covered=0
 		for pat in "${pats[@]}"; do
-			# shellcheck disable=SC2053 -- pattern match is the point
+			# Unquoted RHS is deliberate: glob matching is the point here.
+			# shellcheck disable=SC2053
 			[[ "${rel}" == ${pat} ]] && { covered=1; break; }
 		done
 		[[ "${covered}" -eq 1 ]] || missing+=("${base}")

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -140,7 +140,11 @@ require_path /etc/sudoers.d/aryaos
 require_path /usr/local/sbin/aryaos-firstboot.sh
 require_path /usr/local/sbin/aryaos-lincot-remarks
 require_path /usr/local/sbin/aryaos-cot-detail
-require_grep 'capabilities' /usr/local/sbin/aryaos-cot-detail "beacon advertises product + capabilities (v2)"
+require_grep 'capabilities' /usr/local/sbin/aryaos-cot-detail "beacon advertises capabilities"
+# v4 dropped <product line="...">: it was baked in at build time and identical on
+# every box, so it looked authoritative while carrying no information.
+forbid_grep '"product"' /usr/local/sbin/aryaos-cot-detail "beacon does not advertise a product line"
+forbid_grep '^ARYAOS_PRODUCT=' /etc/aryaos/aryaos-config.txt "no product line baked into the shipped config"
 require_path /usr/local/sbin/aryaos-time-pps
 require_path /etc/systemd/system/aryaos-time-pps.service
 require_path /etc/udev/rules.d/99-aryaos-pps.rules

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -540,5 +540,76 @@ else
 	fi
 fi
 
+# Regression guard for a data-loss bug found on a live box: aryaos-config-backup
+# captured a literal, hand-maintained list of config paths, and it had gone stale.
+# aprscot, sapientcot, ais-catcher, dronecot-ble, dronecot-wifi,
+# dronecot-dronescout and readsb all existed in /etc/default and NONE were backed
+# up, so a factory reset + restore came back with those capabilities silently
+# reverted to defaults.
+#
+# "Is this file AryaOS configuration?" is decided from dpkg ownership, NOT from a
+# second hardcoded list here -- a second list would rot exactly the same way. A
+# /etc/default entry is ours if no package in the image claims it (our stage
+# scripts wrote it), or if the claiming package is one we install from the snstac
+# apt repo.
+backup_covers_gateway_configs() {
+	local script="${MNT}/usr/local/sbin/aryaos-config-backup"
+	if [[ ! -r "${script}" ]]; then
+		fail "aryaos-config-backup not readable; cannot check backup coverage"
+		return
+	fi
+
+	local -a pats=()
+	# Take the path lines straight out of the config_paths() block. Matching the
+	# heredoc markers instead needs nested quoting that is easy to get wrong --
+	# a first attempt at it silently extracted nothing and the check "passed" by
+	# doing nothing at all.
+	mapfile -t pats < <(sed -n "/^config_paths() {/,/^}/p" "${script}" \
+		| grep -E '^(etc|home|usr|var)/')
+	if [[ "${#pats[@]}" -eq 0 ]]; then
+		fail "could not read config_paths() out of aryaos-config-backup"
+		return
+	fi
+
+	# Packages we install from the snstac repo, per the build manifest.
+	local -a ours=()
+	mapfile -t ours < <(grep -oE '^\s*-\s+[A-Za-z0-9._+-]+' manifests/aryaos-sensor-packages.yml 2>/dev/null \
+		| sed -E 's/^\s*-\s+//')
+
+	local -a missing=()
+	local f base rel owner is_ours covered pat pkg
+	for f in "${MNT}"/etc/default/*; do
+		[[ -f "${f}" ]] || continue
+		base="$(basename "${f}")"
+		rel="etc/default/${base}"
+
+		# Which package claims it, if any?
+		owner=""
+		owner="$(grep -lFx "/${rel}" "${MNT}"/var/lib/dpkg/info/*.list 2>/dev/null | head -1)"
+		is_ours=0
+		if [[ -z "${owner}" ]]; then
+			is_ours=1
+		else
+			pkg="$(basename "${owner}" .list)"; pkg="${pkg%%:*}"
+			for p in "${ours[@]}"; do [[ "${pkg}" == "${p}" ]] && { is_ours=1; break; }; done
+		fi
+		[[ "${is_ours}" -eq 1 ]] || continue
+
+		covered=0
+		for pat in "${pats[@]}"; do
+			# shellcheck disable=SC2053 -- pattern match is the point
+			[[ "${rel}" == ${pat} ]] && { covered=1; break; }
+		done
+		[[ "${covered}" -eq 1 ]] || missing+=("${base}")
+	done
+
+	if [[ "${#missing[@]}" -gt 0 ]]; then
+		fail "aryaos-config-backup would not back up: ${missing[*]}"
+	else
+		ok "aryaos-config-backup covers every AryaOS config in /etc/default"
+	fi
+}
+backup_covers_gateway_configs
+
 echo "== ${PASS} ok, ${FAIL} failed =="
 [[ "${FAIL}" -eq 0 ]]

--- a/shared_files/aryaos/aryaos-config-backup
+++ b/shared_files/aryaos/aryaos-config-backup
@@ -35,6 +35,20 @@ require_root() {
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 # Config paths to capture. Missing paths are skipped, not errors.
+#
+# Entries may be GLOBS. They used to be a literal, hand-maintained list, and it
+# went stale: every gateway added after the list was written was silently left
+# out of the backup. Measured on a live box, these existed in /etc/default but
+# were NOT captured -- aprscot, sapientcot, ais-catcher, dronecot-ble,
+# dronecot-wifi, dronecot-dronescout, readsb, dump1090-fa, dump978-fa.
+#
+# That is a data-loss bug in the one tool whose entire job is not losing data:
+# a factory reset and restore would come back with APRS, SAPIENT, Bluetooth
+# Remote ID, Wi-Fi Remote ID, DroneScout and the AIS/ADS-B receiver settings all
+# reverted to defaults, and nothing would say so.
+#
+# Globbing by family means a new gateway is captured the day it lands, with no
+# edit here. That is the point: the failure mode was "someone must remember".
 config_paths() {
 	cat <<'EOF'
 etc/aryaos
@@ -42,15 +56,13 @@ etc/charontak.ini
 etc/charontak
 etc/comitup.conf
 etc/comitup.json
-etc/default/adsbcot
-etc/default/aiscot
-etc/default/dronecot
-etc/default/lincot
-etc/default/gpstak
-etc/default/gdltak
-etc/default/sikw00fcot
-etc/default/charontak
+etc/default/*cot*
+etc/default/*tak
+etc/default/ais-catcher
 etc/default/gpsd
+etc/default/readsb
+etc/default/dump1090-fa
+etc/default/dump978-fa
 etc/adsbcot
 etc/aiscot
 etc/dronecot
@@ -85,7 +97,9 @@ do_backup() {
 	[[ "${1:-}" == "--no-secrets" ]] && include_secrets=0
 
 	local host stamp name root
-	host="$(hostname | tr -c 'A-Za-z0-9.-' '-')"
+	# tr -d '\n' first: tr -c would otherwise translate hostname's trailing
+	# newline into a '-', producing names like aryaos-config_aryaos-4f11-_2026...
+	host="$(hostname | tr -d '\n' | tr -c 'A-Za-z0-9.-' '-')"
 	# Second-granularity stamp plus the PID, so two backups in the same second
 	# (e.g. a full then a --no-secrets from the UI) get distinct names instead
 	# of one silently overwriting the other.
@@ -101,9 +115,14 @@ do_backup() {
 
 	# Build the list of existing paths (relative to /).
 	local -a paths=()
-	local p
+	local p m
 	while IFS= read -r p; do
-		[[ -e "/${p}" ]] && paths+=("${p}")
+		# Entries may be globs, so expand rather than testing the pattern
+		# literally. A pattern that matches nothing stays unexpanded and fails
+		# the -e test, preserving "missing paths are skipped, not errors".
+		for m in /${p}; do
+			[[ -e "${m}" ]] && paths+=("${m#/}")
+		done
 	done < <(config_paths)
 	if [[ "${include_secrets}" == "1" ]]; then
 		while IFS= read -r p; do

--- a/shared_files/aryaos/aryaos-config.txt
+++ b/shared_files/aryaos/aryaos-config.txt
@@ -31,9 +31,6 @@ PYTAK_MULTICAST_LOCAL_ADDR=10.41.0.1
 # DEPRECATED: Legacy setting.
 WIFI_AP_IP=10.41.0.1
 
-# Product line: AryaAir (airspace SA) | AryaSea (maritime SA) | DragonEgg (general SIGINT).
-ARYAOS_PRODUCT="DragonEgg"
-
 # Active sensor capabilities: adsb ais dji wifi-rid ble-rid rid sik sapient
 #
 # EMPTY BY DEFAULT — the image ships with every sensor gateway disabled. A box
@@ -42,8 +39,8 @@ ARYAOS_PRODUCT="DragonEgg"
 # so an out-of-box unit is still a working TAK node.
 #
 # Turn capabilities on with:
-#   sudo aryaos-role product AryaAir     # applies that line's defaults
-#   sudo aryaos-role caps adsb wifi-rid  # or pick them explicitly
+#   sudo aryaos-role caps adsb wifi-rid  # pick them explicitly
+#   sudo aryaos-role discover --apply    # or enable what the box can detect
 ARYAOS_CAPABILITIES=""
 
 # 1090 MHz ADS-B decoder: readsb or dump1090_fa (only one may be enabled). Must match image build

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -26,7 +26,6 @@ SERVICES = (
 
 SITE_CONFIG = "/etc/aryaos/aryaos-config.txt"
 CAP_SCAN = "/usr/local/sbin/aryaos-capability-scan"
-DEFAULT_PRODUCT = "DragonEgg"
 
 # Capability key -> (human label, capability unit, default sensor description).
 # Mirrors the capability registry in aryaos-role.
@@ -338,12 +337,12 @@ def main() -> int:
     hostname = socket.gethostname().split(".", 1)[0]
     load1, load5, load15 = _loadavg()
 
-    root = ET.Element("__aryaos", {"version": "3"})
-    ET.SubElement(
-        root,
-        "product",
-        {"line": _config("ARYAOS_PRODUCT") or DEFAULT_PRODUCT},
-    )
+    # version 4 drops <product line="...">. It claimed a product line that was
+    # baked into the image at build time and never derived from anything, so
+    # every box in the fleet advertised the same value regardless of what was
+    # actually attached to it. A consumer trusting that field was worse off than
+    # one ignoring it. Capabilities carry the real answer and are measured.
+    root = ET.Element("__aryaos", {"version": "4"})
     ET.SubElement(
         root,
         "host",

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -1,19 +1,19 @@
 #!/bin/bash
-# aryaos-role — set the device's product line + sensor capabilities at runtime.
+# aryaos-role — set the device's sensor capabilities at runtime.
 #
-# AryaOS boxes are modeled as a PRODUCT LINE (identity/branding) carrying a set
-# of CAPABILITIES (what receivers are attached and active):
-#   - AryaAir   — airspace SA (ADS-B/UAT, Wi-Fi/DJI drone Remote ID)
-#   - AryaSea   — maritime SA (AIS)
-#   - DragonEgg — general-purpose SIGINT + TAK gateway (any capability)
+# A box is described by its CAPABILITIES: which receivers are attached and
+# active. There is deliberately no product-line label. One used to exist, but it
+# was written into the image at build time and never derived from anything, so
+# every box advertised the same value regardless of its hardware -- a field that
+# was worse than absent, because it looked authoritative. What differs between
+# boxes is the capability mix, and that is measured (aryaos-capability-scan).
 #
 # Capabilities map to sensor systemd units; a capability set enables the union of
 # those units and disables the rest. The CoT core (charontak, lincot, gpstak,
 # gpsd) is never touched — it always runs.
 #
 # Subcommands:
-#   list                 JSON: product, capabilities, available caps/units, roles.
-#   product LINE         Set the product line and apply its default capabilities.
+#   list                 JSON: capabilities, available caps/units, roles.
 #   caps CAP...          Set the active capability set (space/comma separated).
 #                        Use "none" to disable every sensor (bare CoT node).
 #   discover [--apply]   Detect attached hardware and report which capabilities
@@ -32,14 +32,15 @@
 set -euo pipefail
 
 SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
-PRODUCTS="AryaAir AryaSea AryaUAS DragonEgg"
+# No product line. It was a label baked into the image at build time and never
+# derived from anything, so every box claimed the same one no matter what was
+# attached. Capabilities are what differ between boxes, and unlike the product
+# they are measured -- see aryaos-capability-scan.
 CAPS="adsb ais dji wifi-rid ble-rid rid sik sapient"
 LEGACY_ROLES="multi air maritime cuas relay"
-DEFAULT_PRODUCT="DragonEgg"
 
 usage() {
-	echo "usage: aryaos-role {list | discover [--apply] | product LINE | caps CAP... | set ROLE}" >&2
-	echo "  products: ${PRODUCTS}" >&2
+	echo "usage: aryaos-role {list | discover [--apply] | caps CAP... | set ROLE}" >&2
 	echo "  caps:     ${CAPS}  (or 'none' for a bare CoT node)" >&2
 	echo "  roles:    ${LEGACY_ROLES}  (legacy presets)" >&2
 	exit 2
@@ -104,26 +105,6 @@ cap_label() {
 		sik)      echo "SiK Telemetry" ;;
 		sapient)  echo "SAPIENT C-UAS" ;;
 		*)        echo "$1" ;;
-	esac
-}
-
-# Product line -> default capability set applied by `product`.
-# Product line -> default capability set applied by `product`.
-#
-# The lines describe what the box is FOR, and the capability mix is what makes
-# that true:
-#   AryaAir  air picture: ADS-B/UAT *plus* Remote ID, so crewed and uncrewed
-#            traffic appear together.
-#   AryaUAS  uncrewed only: drone detection with NO ADS-B.
-#   AryaSea  maritime: AIS.
-#   DragonEgg general SIGINT: no assumption, operator chooses.
-product_default_caps() {
-	case "$1" in
-		AryaAir)   echo "adsb rid" ;;
-		AryaUAS)   echo "dji rid" ;;
-		AryaSea)   echo "ais" ;;
-		DragonEgg) echo "" ;;
-		*)         return 1 ;;
 	esac
 }
 
@@ -289,17 +270,6 @@ discover() {
 	set_caps "${detected}"
 }
 
-set_product() {
-	local product="$1" defaults
-	if ! defaults="$(product_default_caps "${product}")"; then
-		echo "aryaos-role: unknown product '${product}' (products: ${PRODUCTS})" >&2
-		exit 2
-	fi
-	config_set ARYAOS_PRODUCT "${product}"
-	set_caps "${defaults}"
-	echo "Product line set to '${product}'."
-}
-
 set_role() {
 	local role="$1" caps
 	if ! caps="$(role_caps "${role}")"; then
@@ -311,13 +281,9 @@ set_role() {
 }
 
 list_json() {
-	local product caps
-	product="$(config_get ARYAOS_PRODUCT)"; [[ -n "${product}" ]] || product="${DEFAULT_PRODUCT}"
+	local caps
 	caps="$(config_get ARYAOS_CAPABILITIES)"
-	printf '{"product": "%s", "products": [' "${product}"
-	local p sep=""
-	for p in ${PRODUCTS}; do printf '%s"%s"' "${sep}" "${p}"; sep=", "; done
-	printf '], "capabilities": "%s", "caps": {' "${caps}"
+	printf '{"capabilities": "%s", "caps": {' "${caps}"
 	local c first=1
 	for c in ${CAPS}; do
 		[[ "${first}" == "1" ]] || printf ', '
@@ -345,11 +311,6 @@ cmd="${1:-}"
 case "${cmd}" in
 	list)
 		list_json
-		;;
-	product)
-		require_root
-		[[ $# -eq 2 ]] || usage
-		set_product "$2"
 		;;
 	caps)
 		require_root

--- a/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
+++ b/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
@@ -41,12 +41,21 @@ for unit in ${SENSOR_UNITS}; do
 	fi
 done
 
-# Make the default explicit rather than implied by an empty variable, so
-# `aryaos-role list` and the capability beacon report something meaningful on a
+# Make the empty capability set explicit rather than implied by a missing
+# variable, so `aryaos-role list` and the beacon report something meaningful on a
 # fresh image.
+#
+# ARYAOS_PRODUCT is deliberately NOT written here any more. Writing a product line
+# at build time meant every box in the fleet advertised the same one -- most of
+# them "DragonEgg" -- no matter what hardware was attached, which is how a box
+# with an AntSDR and a DroneScout ended up claiming to be a DragonEgg. A field
+# that is always the same carries no information but looks authoritative, so it
+# was removed rather than guessed at. Capabilities are measured instead.
+#
+# Boxes flashed from an older image keep an inert ARYAOS_PRODUCT line in their
+# config until they are re-flashed; nothing reads it.
 CONFIG="/etc/aryaos/aryaos-config.txt"
 if [[ -f "${CONFIG}" ]]; then
-	grep -qE '^#?\s*ARYAOS_PRODUCT=' "${CONFIG}" || printf 'ARYAOS_PRODUCT="DragonEgg"\n' >>"${CONFIG}"
 	grep -qE '^#?\s*ARYAOS_CAPABILITIES=' "${CONFIG}" || printf 'ARYAOS_CAPABILITIES=""\n' >>"${CONFIG}"
 fi
 


### PR DESCRIPTION
Came out of asking why a box with an **AntSDR and a DroneScout attached** was calling itself a DragonEgg. It wasn't a mislabeled box:

```
stages/stage-bt-pan/01-sensors-off:  ARYAOS_PRODUCT="DragonEgg"
```

That's written into the image at **build time**, and nothing ever derived or updated it. So *every box in the fleet* advertised the same product line regardless of its hardware. The field looked authoritative and carried no information — worse than absent, because a consumer trusting it was worse off than one ignoring it.

It also drove **no behavior**. Grepping every reference, the product line fed exactly three things: the beacon element, a caps preset, and display in `aryaos-role list`. Every other mention (`aryaos-sdr`, `aryaos-capability-scan`, `verify-image.sh`) was a comment.

So rather than derive it from hardware, remove it. What differs between boxes is the capability mix — and unlike the product line, that is *measured*.

## Changes

- **beacon**: `<product line="..."/>` gone, schema **v3 → v4**
- **aryaos-role**: no `PRODUCTS`/`DEFAULT_PRODUCT`, no `product` subcommand, no `product_default_caps()`, no product keys in `list` JSON
- **aryaos-config.txt**: `ARYAOS_PRODUCT` gone — and the comment no longer tells operators to run a subcommand that doesn't exist
- **build stage**: stops baking the default in
- **verify-image**: asserts the beacon does *not* carry a product, and that none is baked into the shipped config

## Verified by running it, not reading it

```
root: __aryaos version = 4
child elements: ['host','system','time','nap','services','capabilities','roles']
<product> present: False

aryaos-role list -> keys ['capabilities','caps','current','roles']
aryaos-role product AryaUAS -> exit 2, prints usage (no traceback)
```

A legacy `ARYAOS_PRODUCT` left in a config is inert and does not resurface in the beacon. Boxes flashed from an older image keep that inert line until re-flashed.

## Needs a companion change — and a correction

**gutcheck consumes this field:**

```python
src/gutcheck/classes.py:110   if (item.get("product") or {}).get("line"):
src/gutcheck/static/gutcheck.js:105   tr.appendChild(textCell(dev.product));
```

The read is guarded, so its device table degrades to a **blank Product column** rather than breaking — but the column is now dead and should come out, along with the assertions in `tests/test_cot.py` and `tests/test_workers.py`.

I earlier said "nothing consumes it" having grepped only aryaos and the cockpit repos. That was wrong, and it's the kind of claim worth checking across the fleet before deleting a published field.

## README

Product lines kept as **build configurations / branding** — the marks are real and in the design kit — but no longer presented as something the OS labels itself with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM