### PR TITLE
firstboot: don't latch a PARTIAL capability scan

### DIFF
--- a/shared_files/aryaos/aryaos-firstboot.sh
+++ b/shared_files/aryaos/aryaos-firstboot.sh
@@ -172,11 +172,32 @@ if [[ ! -f "$CAP_MARKER" ]] \
 	# back empty, because SoapySDRUtil blocks activating Avahi over dbus this
 	# early; the box then recorded "bare node" permanently.
 	udevadm settle --timeout=30 >/dev/null 2>&1 || true
+	# Accumulate the UNION across tries, and stop only once two consecutive
+	# scans agree.
+	#
+	# This loop used to break on the first NON-EMPTY result, which guarded
+	# against seeing nothing but not against seeing only PART of the kit. Buses
+	# come up at very different speeds: on aryaos-4f11 the AntSDR sits on a
+	# point-to-point Ethernet link and answered immediately, while the DroneScout
+	# is an ESP32 on USB that had not started streaming MAVLink yet. Try 1
+	# returned "dji", the loop broke, and the box latched caps="dji" with the
+	# Remote ID receiver plugged in and idle -- and because the marker file is
+	# then written, autodetect never looks again.
+	#
+	# Union rather than last-wins, so a device that answers once and is busy on a
+	# later pass cannot be dropped again. The probes only ever report hardware
+	# they can see, so this cannot invent a capability.
 	DETECTED=""
+	_prev=""
 	for _try in 1 2 3; do
-		DETECTED="$(/usr/local/sbin/aryaos-capability-scan --caps 2>/dev/null | xargs || true)"
-		[[ -n "$DETECTED" ]] && break
-		sleep 10
+		_this="$(/usr/local/sbin/aryaos-capability-scan --caps 2>/dev/null \
+			| tr ' ' '\n' | sed '/^$/d' | sort -u | xargs || true)"
+		DETECTED="$(printf '%s %s' "${DETECTED}" "${_this}" \
+			| tr ' ' '\n' | sed '/^$/d' | sort -u | xargs || true)"
+		# Settled: same set twice running, and not empty.
+		[[ -n "${_this}" && "${_this}" == "${_prev}" ]] && break
+		_prev="${_this}"
+		[[ "${_try}" -lt 3 ]] && sleep 10
 	done
 
 	if [[ -n "$DETECTED" ]]; then


### PR DESCRIPTION
Found on `aryaos-4f11`, which has **both** an AntSDR and a DroneScout DS110 attached, and came up with `ARYAOS_CAPABILITIES="dji"` — the Remote ID receiver plugged in, working, and switched off. A rescan minutes later reported `rid` as `available: true, auto_apply: true`, but by then the marker file was written and autodetect never runs again.

## The retry loop was already there — it just guarded the wrong thing

```bash
for _try in 1 2 3; do
    DETECTED="$(aryaos-capability-scan --caps | xargs)"
    [[ -n "$DETECTED" ]] && break     # <-- breaks on the first NON-EMPTY result
    sleep 10
done
```

That guards against seeing **nothing**. It does not guard against seeing only **part** of the kit. Buses come up at very different speeds: the AntSDR is on a point-to-point Ethernet link and answered immediately, while the DroneScout is an ESP32 on USB that hadn't started streaming MAVLink yet. Try 1 returned `dji`, the loop broke, done.

## Fix

Accumulate the **union** across tries and stop only once two consecutive scans agree.

Union rather than last-wins, so a device that answers once and is *busy* on a later pass can't be dropped again. The probes only ever report hardware they can see, so this cannot invent a capability.

## Verified against the real timing

Sleep stubbed, scan scripted per try:

| Case | Scenario | Result |
|---|---|---|
| A | fast Ethernet try1, slow USB appears try2 | `[dji rid]` — **was `[dji]`** |
| B | nothing ever appears (bare node) | `[]` |
| C | stable from try 1 | `[adsb]`, settles early |
| D | answers try1, **busy** try2 | `[dji rid]`, not dropped |
| E | three different partial views | `[ais dji rid]` |

Case A run against the **old** loop yields `[dji]`, reproducing the bug.

## Cost

Worst case ~20 s added to a first boot. Case C still settles on the second scan, so a box whose hardware is all present stays fast.

## Why this matters now

This is a prerequisite for gold-mastering `aryaos-4f11`: without it, reflashing that box comes up as `dji`-only again and the capability set has to be set by hand, which defeats the point of a reference image.

Addresses the auto-apply half of #82. The broader "re-detect hardware plugged in after firstboot" question is deliberately **not** solved here — that's a behaviour change against "everything off by default" and needs its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM