### PR TITLE
verify-image: my backup check failed main on false positives

### DIFF
--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -590,29 +590,41 @@ backup_covers_gateway_configs() {
 		base="$(basename "${f}")"
 		rel="etc/default/${base}"
 
-		# Which package claims it, if any? An UNOWNED file is the normal case
-		# for anything our stage scripts wrote, so grep finding nothing must not
-		# be treated as an error: under `set -euo pipefail` the failing grep
-		# propagated through `head` and killed the whole script, which is exactly
-		# how this check took down a build -- silently, with no FAIL line and no
-		# summary, because the script died rather than reporting anything.
-		owner=""
-		owner="$(grep -lFx "/${rel}" "${MNT}"/var/lib/dpkg/info/*.list 2>/dev/null | head -1 || true)"
+		# Is this file ours? Two independent signals, either is sufficient:
+		#
+		#   1. it is NAMED like one of our gateways, or
+		#   2. the package that ships it is in the build manifest.
+		#
+		# Ownership alone is not enough in either direction. UNOWNED does not
+		# mean ours -- Debian generates console-setup, keyboard and locale here
+		# at configure time and no package .list claims them, and treating
+		# unowned as ours flagged all three and failed a build. OWNED does not
+		# mean Debian's either: aprscot and sapientcot ship their own
+		# /etc/default file but are installed outside the manifest, so an
+		# ownership-only rule skipped them silently -- the exact blind spot this
+		# check exists to prevent.
+		#
+		# Trade-off, stated: a future gateway named outside these families AND
+		# absent from the manifest would not be checked.
 		is_ours=0
-		if [[ -z "${owner}" ]]; then
-			is_ours=1
-		else
-			pkg="$(basename "${owner}" .list)"
-			pkg="${pkg%%:*}"
-			# ${arr[@]+...} so an empty manifest does not trip `set -u`, and an
-			# explicit if so a non-matching last iteration does not leave the
-			# loop with a non-zero status for `set -e` to act on.
-			for p in ${ours[@]+"${ours[@]}"}; do
-				if [[ "${pkg}" == "${p}" ]]; then
-					is_ours=1
-					break
-				fi
-			done
+		case "${base}" in
+			*cot*|*tak*|ais-catcher|readsb|dump*-fa|gpsd) is_ours=1 ;;
+		esac
+		if [[ "${is_ours}" -eq 0 ]]; then
+			# grep finding nothing must not be an error: under `set -euo
+			# pipefail` a failing grep propagated through `head` and killed the
+			# whole script -- no FAIL line, no summary, just a dead build.
+			owner="$(grep -lFx "/${rel}" "${MNT}"/var/lib/dpkg/info/*.list 2>/dev/null | head -1 || true)"
+			if [[ -n "${owner}" ]]; then
+				pkg="$(basename "${owner}" .list)"
+				pkg="${pkg%%:*}"
+				for p in ${ours[@]+"${ours[@]}"}; do
+					if [[ "${pkg}" == "${p}" ]]; then
+						is_ours=1
+						break
+					fi
+				done
+			fi
 		fi
 		[[ "${is_ours}" -eq 1 ]] || continue
 

--- a/shared_files/aryaos/aryaos-config-backup
+++ b/shared_files/aryaos/aryaos-config-backup
@@ -57,7 +57,7 @@ etc/charontak
 etc/comitup.conf
 etc/comitup.json
 etc/default/*cot*
-etc/default/*tak
+etc/default/*tak*
 etc/default/ais-catcher
 etc/default/gpsd
 etc/default/readsb


### PR DESCRIPTION
**`main` has been red since #218.** The check I added flagged Debian's own files:

```
FAIL: aryaos-config-backup would not back up: console-setup keyboard locale takproto
== 237 ok, 1 failed ==
```

`console-setup`, `keyboard` and `locale` are **unowned** on a real image — Debian generates them at configure time and no package `.list` claims them — and my rule said *"unowned means ours"*. `takproto` **is** ours, but the backup glob was `etc/default/*tak`, which doesn't match a trailing `proto`.

## Same root cause, third time

This is my third bug in this one check, and the cause was identical each time: **the fixture didn't match the real image.** I had `console-setup`/`keyboard`/`locale` *owned by base-files* in my synthetic tree — which is precisely why it passed locally and failed on hardware. The fixture now mirrors real ownership.

## Fixing it exposed a blind spot in the same rule

Ownership isn't a reliable signal in **either** direction:

| | |
|---|---|
| unowned ≠ ours | Debian's debconf-generated configs are unowned |
| owned ≠ Debian's | `aprscot` and `sapientcot` ship their own `/etc/default` file but are installed **outside** the build manifest — so an ownership-only rule skipped them **silently**, the exact blind spot this check exists to prevent |

So a file is ours if **either** it's named like one of our gateways **or** the package shipping it is in the manifest. Either signal suffices.

**Trade-off, stated rather than hidden:** a future gateway named outside these families *and* absent from the manifest wouldn't be checked.

Also widened `etc/default/*tak` → `*tak*` so `takproto` is genuinely backed up, rather than weakening the check to stop it complaining.

## Retested against real ownership

| Case | Result |
|---|---|
| real-image ownership (the build breaker) | ok |
| stale literal list | **FAIL — names 18 gaps** |
| new unowned gateway `foocot` | ok |
| Debian unowned config `rsyslog` | ignored |
| `console-setup` / `keyboard` / `locale` | ignored |

Case 2 naming **18** gaps rather than the 7 it found before is the proof the simplification closed the blind spot — `aprscot`, `sapientcot` and `takproto` are now among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM