### PR TITLE
adsb: require an SDR the decoder can actually drive

### DIFF
--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -254,15 +254,43 @@ def scan():
     caps = {}
 
     # ADS-B/UAT: needs at least one SDR.
+    # ADS-B/UAT needs an SDR the DECODER can actually drive, not merely an SDR.
+    #
+    # readsb ships with --device-type rtlsdr (see /etc/default/readsb), so a
+    # non-RTL SDR makes it exit immediately:
+    #
+    #   FATAL: rtlsdr: no supported devices found.
+    #   sdrOpen() failed, exiting!
+    #
+    # Measured on aryaos-270d, which has a LimeSDR Mini and nothing else: the
+    # probe said "1 SDR(s)" -> adsb auto-applied at firstboot -> readsb
+    # crash-looped 10 times, took adsbcot and gdltak down with it (29 restarts
+    # between them) and left the box in systemd `degraded` with its whole reason
+    # for existing dead. Out of the box, with no operator error.
+    #
+    # So a usable SDR is an RTL one. A non-RTL SDR still REPORTS the capability,
+    # because the hardware genuinely is there and pretending otherwise is its own
+    # kind of lie -- but it is not auto-applied, and it says why.
+    rtl_sdrs = [d for d in sdrs if str(d.get("driver", "")).lower() == "rtlsdr"]
+    other_sdrs = [d for d in sdrs if d not in rtl_sdrs]
+
+    def _labels(ds):
+        return ", ".join(d.get("label") or d.get("driver", "?") for d in ds)
+
     caps["adsb"] = {
         "available": bool(sdrs),
         "evidence": (
-            f"{len(sdrs)} SDR(s): "
-            + ", ".join(d.get("label") or d.get("driver", "?") for d in sdrs)
-            if sdrs
-            else "no SDR detected"
+            f"{len(sdrs)} SDR(s): " + _labels(sdrs) if sdrs else "no SDR detected"
         ),
     }
+    if sdrs and not rtl_sdrs:
+        caps["adsb"]["auto_apply"] = False
+        caps["adsb"]["deferred_reason"] = (
+            f"readsb is configured for RTL-SDR (--device-type rtlsdr) and the only "
+            f"SDR present is {_labels(other_sdrs)}. Enabling adsb would crash-loop "
+            f"readsb. Retune readsb for this device first, then "
+            f"`aryaos-role caps ... adsb`."
+        )
 
     # AIS: a dedicated NMEA receiver, or a spare SDR. Flag the contention: with
     # a single SDR, enabling both adsb and ais fights over one radio.


### PR DESCRIPTION
Found by testing `aryaos-270d` (192.168.0.60). The box was in systemd **`degraded`**, with its entire reason for existing dead:

```
failed: adsbcot.service, gdltak.service, readsb.service
churn:  adsbcot=9  readsb=10  gdltak=10
```

```
readsb: FATAL: rtlsdr: no supported devices found.
        sdrOpen() failed, exiting!
```

The box **has** an SDR — a LimeSDR Mini — and no RTL dongle. The capability probe asked only *"is there an SDR?"*:

```python
caps["adsb"] = {"available": bool(sdrs), ...}
```

…while readsb ships `--device-type rtlsdr` in `/etc/default/readsb`. So firstboot saw one SDR, auto-applied `adsb`, readsb exited immediately, restarted 10 times, hit the start limit, and took `adsbcot` and `gdltak` down with it. **29 restarts between the three, with no operator error involved** — this is what the box does out of the box with that hardware.

## Fix

`adsb` still **reports available** when a non-RTL SDR is present — the hardware genuinely is there, and claiming otherwise is its own kind of lie. But it isn't auto-applied, and it says exactly why and what to do:

> readsb is configured for RTL-SDR (`--device-type rtlsdr`) and the only SDR present is LimeSDR Mini. Enabling adsb would crash-loop readsb. Retune readsb for this device first, then `aryaos-role caps ... adsb`.

Same shape as the existing `ble-rid` deferral, so the UI already understands it.

## Exercised against the four real hardware states

| State | Result |
|---|---|
| LimeSDR only (the degraded box) | available, **auto_apply=False** + reason |
| RTL only | available, auto_apply |
| RTL + Lime | available, auto_apply (a usable one exists) |
| no SDR | not available |

## Scope

This is the concrete reproduction of #75.

It does **not** make readsb work with a LimeSDR — that's #78, where readsb streams but decodes 0 Mode-S, still unproven. This only stops AryaOS promising a capability the decoder can't deliver, and wedging the box in the attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM