### PR TITLE
adsb deferral: use manual_only, because auto_apply gets recomputed

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -64,6 +64,12 @@ jobs:
           ansible-galaxy collection install -r requirements.yml
           ansible-playbook -i localhost, -c local site.yml --syntax-check
 
+      - name: Unit-test the capability scanner
+        # aryaos-capability-scan decides what a box turns on at first boot. A
+        # wrong answer either wedges the box in a crash-loop or silently leaves
+        # attached hardware switched off, and both have happened.
+        run: python3 -m pytest -q scripts/test_capability_scan.py
+
       - name: Shellcheck appliance scripts
         # Lint the shell that ships to /usr/local/sbin and the build/test
         # tooling. Error severity only: legacy scripts carry style warnings.

--- a/scripts/test_capability_scan.py
+++ b/scripts/test_capability_scan.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for aryaos-capability-scan's capability decisions.
+
+The scanner is a standalone script rather than an importable module, so these
+tests lift the decision blocks out of the source and exercise them directly.
+That is deliberately ugly, and it exists because the alternative -- reasoning
+about the file by reading it -- already shipped a broken fix once.
+
+The bug this file was written for:
+
+    caps["adsb"]["auto_apply"] = False     # in the adsb block
+    ...
+    for key, cap in caps.items():          # ~100 lines later
+        cap["auto_apply"] = available and not manual_only
+
+The second loop unconditionally recomputes the flag, so setting auto_apply in
+the block above it does nothing. On aryaos-c998 the deferral message was
+present and correct while auto_apply stayed true, and readsb crash-looped
+anyway. Testing the block in isolation PASSED; only running the block together
+with the recomputation catches it.
+"""
+
+import os
+import re
+import unittest
+
+SCANNER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "shared_files",
+    "aryaos",
+    "aryaos-capability-scan",
+)
+
+# The recomputation that runs after every capability decision. Kept as a literal
+# of what the scanner does, so if the scanner's version changes shape this test
+# starts failing and someone has to look.
+RECOMPUTE = (
+    'for key, cap in caps.items():\n'
+    '    cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")\n'
+)
+
+
+def _dedent(text):
+    return "\n".join(l[4:] if l.startswith("    ") else l for l in text.split("\n"))
+
+
+def _adsb_block(src):
+    start = src.index("    # ADS-B/UAT needs an SDR the DECODER")
+    end = src.index("    ais_available")
+    return _dedent(src[start:end])
+
+
+class AdsbCapabilityTestCase(unittest.TestCase):
+    """adsb must only auto-apply when the DECODER can drive the SDR."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(SCANNER) as fh:
+            cls.src = fh.read()
+        cls.block = _adsb_block(cls.src)
+
+    def decide(self, sdrs, with_pipeline=True):
+        ns = {"sdrs": sdrs, "caps": {}}
+        exec(self.block, ns)
+        if with_pipeline:
+            exec(RECOMPUTE, ns)
+        return ns["caps"]["adsb"]
+
+    # -- the live failure ------------------------------------------------
+    def test_lime_only_is_not_auto_applied(self):
+        """aryaos-c998: a LimeSDR and readsb configured for rtlsdr."""
+        cap = self.decide([{"driver": "lime", "label": "LimeSDR Mini"}])
+        self.assertTrue(cap["available"], "the hardware is real; say so")
+        self.assertFalse(cap["auto_apply"], "would crash-loop readsb")
+        self.assertIn("crash-loop", cap.get("deferred_reason", ""))
+
+    def test_deferral_survives_the_recomputation(self):
+        """The actual regression: auto_apply set in the block gets overwritten.
+
+        Asserting on the block ALONE passes even with the bug, which is exactly
+        how it shipped. The point of this test is the comparison.
+        """
+        sdrs = [{"driver": "lime", "label": "LimeSDR Mini"}]
+        self.assertFalse(self.decide(sdrs, with_pipeline=True)["auto_apply"])
+        # manual_only is an INPUT to the recomputation, so it must be set.
+        self.assertTrue(self.decide(sdrs, with_pipeline=False).get("manual_only"))
+
+    def test_scanner_still_recomputes_auto_apply(self):
+        """If the pipeline stops recomputing, this test is testing a fiction."""
+        self.assertIn(
+            'cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")',
+            self.src,
+            "the recomputation this test guards against has changed shape",
+        )
+
+    # -- the cases that must keep working --------------------------------
+    def test_rtl_only_auto_applies(self):
+        cap = self.decide([{"driver": "rtlsdr", "label": "RTL2838UHIDIR"}])
+        self.assertTrue(cap["available"])
+        self.assertTrue(cap["auto_apply"])
+        self.assertNotIn("deferred_reason", cap)
+
+    def test_mixed_auto_applies_because_a_usable_one_exists(self):
+        cap = self.decide(
+            [
+                {"driver": "rtlsdr", "label": "RTL2838UHIDIR"},
+                {"driver": "lime", "label": "LimeSDR Mini"},
+            ]
+        )
+        self.assertTrue(cap["auto_apply"])
+
+    def test_no_sdr_is_not_available(self):
+        cap = self.decide([])
+        self.assertFalse(cap["available"])
+        self.assertFalse(cap["auto_apply"])
+
+    def test_driver_match_is_case_insensitive(self):
+        cap = self.decide([{"driver": "RTLSDR", "label": "RTL2838UHIDIR"}])
+        self.assertTrue(cap["auto_apply"])
+
+    def test_deferral_names_the_device_and_the_way_out(self):
+        """An operator reading this should know what to do next."""
+        cap = self.decide([{"driver": "lime", "label": "LimeSDR Mini"}])
+        reason = cap["deferred_reason"]
+        self.assertIn("LimeSDR Mini", reason)
+        self.assertIn("aryaos-role caps", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -284,7 +284,20 @@ def scan():
         ),
     }
     if sdrs and not rtl_sdrs:
-        caps["adsb"]["auto_apply"] = False
+        # manual_only, NOT auto_apply.
+        #
+        # My first version of this set auto_apply=False directly, and it did
+        # nothing: a loop further down unconditionally recomputes
+        #     cap["auto_apply"] = available and not manual_only
+        # for every capability, so the flag was overwritten a few lines later and
+        # the box auto-applied adsb anyway. Observed on aryaos-c998: the
+        # deferred_reason was present and correct while auto_apply was true, and
+        # readsb crash-looped exactly as before.
+        #
+        # manual_only is the mechanism the pipeline already has for "available,
+        # but never turn it on by itself" -- ble-rid and sapient both use it --
+        # and it survives that recomputation because it is an INPUT to it.
+        caps["adsb"]["manual_only"] = True
         caps["adsb"]["deferred_reason"] = (
             f"readsb is configured for RTL-SDR (--device-type rtlsdr) and the only "
             f"SDR present is {_labels(other_sdrs)}. Enabling adsb would crash-loop "


### PR DESCRIPTION
**My #222 fix did not work.** Caught on `aryaos-c998`, a freshly flashed LimeSDR box that came up `caps=[adsb]` and **degraded**, with readsb and adsbcot restarting exactly as before:

```json
"available": true,
"auto_apply": true,        <- should be false
"deferred_reason": "readsb is configured for RTL-SDR ... would crash-loop readsb"
```

The deferral message was there and correct. The flag next to it was wrong.

## Cause

I set `caps["adsb"]["auto_apply"] = False` in the adsb block. About a hundred lines further down:

```python
for key, cap in caps.items():
    cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")
```

That recomputes the flag for **every** capability and threw mine away.

`manual_only` is the mechanism the pipeline already has for *"available, but never turn it on by itself"* — `ble-rid` and `sapient` both use it — and it works because it's an **input** to that recomputation rather than an output.

## Why it shipped

I tested the original fix by exercising the adsb block **in isolation**, which passes with the bug present. Reading one block and not the pipeline it feeds is what let this through.

## Tests

The tests now run the block **and** the recomputation together. One of them asserts the recomputation still exists — if it's ever removed or reshaped, the test guarding against it is testing a fiction and should fail loudly.

**8 tests.** Reverting to `auto_apply = False` fails exactly two:

```
FAILED test_lime_only_is_not_auto_applied
FAILED test_deferral_survives_the_recomputation
```

| Case | available | auto_apply |
|---|---|---|
| LimeSDR only (the live box) | true | **false** + reason |
| RTL only | true | true |
| RTL + Lime | true | true |
| no SDR | false | false |

Wired into CI. This file decides what a box switches on at first boot, and a wrong answer either wedges it in a crash-loop or silently leaves attached hardware off — **both have now happened**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM