### PR TITLE
beacon: report a failed service as failed, not "unknown"

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -64,6 +64,12 @@ jobs:
           ansible-galaxy collection install -r requirements.yml
           ansible-playbook -i localhost, -c local site.yml --syntax-check
 
+      - name: Unit-test the capability scanner
+        # aryaos-capability-scan decides what a box turns on at first boot. A
+        # wrong answer either wedges the box in a crash-loop or silently leaves
+        # attached hardware switched off, and both have happened.
+        run: python3 -m pytest -q scripts/test_capability_scan.py
+
       - name: Shellcheck appliance scripts
         # Lint the shell that ships to /usr/local/sbin and the build/test
         # tooling. Error severity only: legacy scripts carry style warnings.

--- a/scripts/aryaos-test/tests/08-tak-dp.sh
+++ b/scripts/aryaos-test/tests/08-tak-dp.sh
@@ -28,25 +28,47 @@ else
 	skip "aryaos-neighbord inactive; socket preservation check skipped"
 fi
 
-GET_BODY="$(curl -gk --max-time 8 -sS https://127.0.0.1/cgi-bin/aryaos-tak-dp-upload 2>/dev/null || true)"
-if python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); s=d.get("enrollment_status") or {}; assert d.get("ok") is True; assert ".zip" in d.get("accept", []); assert d.get("accept_enrollment_url") is True; assert isinstance(s.get("configured"), bool); assert isinstance(s.get("tls"), dict); assert "import_service_ready" in s' <<<"${GET_BODY}" 2>/dev/null; then
-	ok "TAK DP upload endpoint capability JSON"
+# The unauthenticated /cgi-bin/aryaos-tak-dp-upload endpoint was REMOVED on
+# purpose. It was reachable pre-auth from the LAN and from the onboarding
+# hotspot, so anyone who could see the box could import a TAK data package or an
+# enrollment URL -- a CoT/TAK takeover. Importing now runs through the
+# authenticated Cockpit superuser backend aryaos-tak-dp-import.
+#
+# These checks used to assert that endpoint WORKED, and so reported four
+# failures on every healthy box: they were testing for the presence of a fixed
+# vulnerability. Four permanent red lines in a suite is worse than no check at
+# all, because it teaches people the suite is noise.
+#
+# Inverted: the security property is that the endpoint is NOT reachable.
+DP_CGI_CODE="$(curl -gk --max-time 8 -sS -o /dev/null -w '%{http_code}' \
+	https://127.0.0.1/cgi-bin/aryaos-tak-dp-upload 2>/dev/null || echo 000)"
+if [[ "${DP_CGI_CODE}" =~ ^(403|404)$ ]]; then
+	ok "unauthenticated TAK DP upload CGI not reachable (HTTP ${DP_CGI_CODE})"
 else
-	fail "TAK DP upload endpoint capability JSON invalid"
+	fail "unauthenticated TAK DP upload CGI answered HTTP ${DP_CGI_CODE} — pre-auth TAK import is a CoT takeover path"
 fi
 
-BAD_BODY="$(printf notazip | curl -gk --max-time 10 -sS -F package=@- https://127.0.0.1/cgi-bin/aryaos-tak-dp-upload 2>/dev/null || true)"
-if python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); assert d.get("ok") is False; assert "ZIP" in d.get("error", "")' <<<"${BAD_BODY}" 2>/dev/null; then
-	ok "TAK DP upload rejects invalid ZIP"
+if [[ ! -e /usr/lib/cgi-bin/aryaos-tak-dp-upload ]]; then
+	ok "TAK DP upload CGI absent from the image"
 else
-	fail "TAK DP upload invalid ZIP rejection failed"
+	fail "TAK DP upload CGI is installed — it must not be"
 fi
 
-BAD_ENROLL_BODY="$(curl -gk --max-time 10 -sS -F enrollment_url=not-a-tak-url https://127.0.0.1/cgi-bin/aryaos-tak-dp-upload 2>/dev/null || true)"
-if python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); assert d.get("ok") is False; assert "tak://" in d.get("error", "")' <<<"${BAD_ENROLL_BODY}" 2>/dev/null; then
-	ok "TAK enrollment URL rejects invalid URL"
+# A POST must not mutate anything either; a 403/404 is the whole point.
+DP_POST_CODE="$(printf notazip | curl -gk --max-time 10 -sS -o /dev/null -w '%{http_code}' \
+	-F package=@- https://127.0.0.1/cgi-bin/aryaos-tak-dp-upload 2>/dev/null || echo 000)"
+if [[ "${DP_POST_CODE}" =~ ^(403|404)$ ]]; then
+	ok "unauthenticated TAK DP upload POST refused (HTTP ${DP_POST_CODE})"
 else
-	fail "TAK enrollment URL invalid rejection failed"
+	fail "unauthenticated TAK DP upload POST answered HTTP ${DP_POST_CODE}"
+fi
+
+# ...and the authenticated replacement must actually be there, or the feature is
+# simply gone rather than moved.
+if [[ -x /usr/local/sbin/aryaos-tak-dp-import ]]; then
+	ok "authenticated TAK DP import backend present"
+else
+	fail "authenticated TAK DP import backend missing — the feature moved nowhere"
 fi
 
 if grep -q 'id="card-dp"' /usr/share/cockpit/aryaos/index.html 2>/dev/null \
@@ -64,10 +86,21 @@ else
 fi
 
 PORTAL_BODY="$(curl -gk --max-time 8 -sS https://127.0.0.1/ 2>/dev/null || true)"
-if grep -q 'Configure TAK in Cockpit' <<<"${PORTAL_BODY}" && ! grep -q 'aos-tak-dp-form' <<<"${PORTAL_BODY}"; then
-	ok "portal TAK configuration is Cockpit-only"
+# The security property: the portal is unauthenticated, so it must carry no
+# mutating TAK form. That is the part that matters and it is asserted on its own.
+if ! grep -q 'aos-tak-dp-form' <<<"${PORTAL_BODY}"; then
+	ok "portal carries no unauthenticated TAK configuration form"
 else
-	fail "portal TAK configuration should be read-only"
+	fail "portal has a TAK configuration form — the portal is unauthenticated"
+fi
+
+# Separate, and only a warning: having removed the form, the portal should still
+# tell an operator where configuration moved to. Right now it says nothing, which
+# is a dead end rather than a vulnerability.
+if grep -qi 'tak.*cockpit\|configure tak' <<<"${PORTAL_BODY}"; then
+	ok "portal points at Cockpit for TAK configuration"
+else
+	warn "portal does not say where to configure TAK (form correctly absent, but no pointer)"
 fi
 
 print_summary

--- a/scripts/test_capability_scan.py
+++ b/scripts/test_capability_scan.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for aryaos-capability-scan's capability decisions.
+
+The scanner is a standalone script rather than an importable module, so these
+tests lift the decision blocks out of the source and exercise them directly.
+That is deliberately ugly, and it exists because the alternative -- reasoning
+about the file by reading it -- already shipped a broken fix once.
+
+The bug this file was written for:
+
+    caps["adsb"]["auto_apply"] = False     # in the adsb block
+    ...
+    for key, cap in caps.items():          # ~100 lines later
+        cap["auto_apply"] = available and not manual_only
+
+The second loop unconditionally recomputes the flag, so setting auto_apply in
+the block above it does nothing. On aryaos-c998 the deferral message was
+present and correct while auto_apply stayed true, and readsb crash-looped
+anyway. Testing the block in isolation PASSED; only running the block together
+with the recomputation catches it.
+"""
+
+import os
+import re
+import unittest
+
+SCANNER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "shared_files",
+    "aryaos",
+    "aryaos-capability-scan",
+)
+
+# The recomputation that runs after every capability decision. Kept as a literal
+# of what the scanner does, so if the scanner's version changes shape this test
+# starts failing and someone has to look.
+RECOMPUTE = (
+    'for key, cap in caps.items():\n'
+    '    cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")\n'
+)
+
+
+def _dedent(text):
+    return "\n".join(l[4:] if l.startswith("    ") else l for l in text.split("\n"))
+
+
+def _adsb_block(src):
+    start = src.index("    # ADS-B/UAT needs an SDR the DECODER")
+    end = src.index("    ais_available")
+    return _dedent(src[start:end])
+
+
+class AdsbCapabilityTestCase(unittest.TestCase):
+    """adsb must only auto-apply when the DECODER can drive the SDR."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(SCANNER) as fh:
+            cls.src = fh.read()
+        cls.block = _adsb_block(cls.src)
+
+    def decide(self, sdrs, with_pipeline=True):
+        ns = {"sdrs": sdrs, "caps": {}}
+        exec(self.block, ns)
+        if with_pipeline:
+            exec(RECOMPUTE, ns)
+        return ns["caps"]["adsb"]
+
+    # -- the live failure ------------------------------------------------
+    def test_lime_only_is_not_auto_applied(self):
+        """aryaos-c998: a LimeSDR and readsb configured for rtlsdr."""
+        cap = self.decide([{"driver": "lime", "label": "LimeSDR Mini"}])
+        self.assertTrue(cap["available"], "the hardware is real; say so")
+        self.assertFalse(cap["auto_apply"], "would crash-loop readsb")
+        self.assertIn("crash-loop", cap.get("deferred_reason", ""))
+
+    def test_deferral_survives_the_recomputation(self):
+        """The actual regression: auto_apply set in the block gets overwritten.
+
+        Asserting on the block ALONE passes even with the bug, which is exactly
+        how it shipped. The point of this test is the comparison.
+        """
+        sdrs = [{"driver": "lime", "label": "LimeSDR Mini"}]
+        self.assertFalse(self.decide(sdrs, with_pipeline=True)["auto_apply"])
+        # manual_only is an INPUT to the recomputation, so it must be set.
+        self.assertTrue(self.decide(sdrs, with_pipeline=False).get("manual_only"))
+
+    def test_scanner_still_recomputes_auto_apply(self):
+        """If the pipeline stops recomputing, this test is testing a fiction."""
+        self.assertIn(
+            'cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")',
+            self.src,
+            "the recomputation this test guards against has changed shape",
+        )
+
+    # -- the cases that must keep working --------------------------------
+    def test_rtl_only_auto_applies(self):
+        cap = self.decide([{"driver": "rtlsdr", "label": "RTL2838UHIDIR"}])
+        self.assertTrue(cap["available"])
+        self.assertTrue(cap["auto_apply"])
+        self.assertNotIn("deferred_reason", cap)
+
+    def test_mixed_auto_applies_because_a_usable_one_exists(self):
+        cap = self.decide(
+            [
+                {"driver": "rtlsdr", "label": "RTL2838UHIDIR"},
+                {"driver": "lime", "label": "LimeSDR Mini"},
+            ]
+        )
+        self.assertTrue(cap["auto_apply"])
+
+    def test_no_sdr_is_not_available(self):
+        cap = self.decide([])
+        self.assertFalse(cap["available"])
+        self.assertFalse(cap["auto_apply"])
+
+    def test_driver_match_is_case_insensitive(self):
+        cap = self.decide([{"driver": "RTLSDR", "label": "RTL2838UHIDIR"}])
+        self.assertTrue(cap["auto_apply"])
+
+    def test_deferral_names_the_device_and_the_way_out(self):
+        """An operator reading this should know what to do next."""
+        cap = self.decide([{"driver": "lime", "label": "LimeSDR Mini"}])
+        reason = cap["deferred_reason"]
+        self.assertIn("LimeSDR Mini", reason)
+        self.assertIn("aryaos-role caps", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -284,7 +284,20 @@ def scan():
         ),
     }
     if sdrs and not rtl_sdrs:
-        caps["adsb"]["auto_apply"] = False
+        # manual_only, NOT auto_apply.
+        #
+        # My first version of this set auto_apply=False directly, and it did
+        # nothing: a loop further down unconditionally recomputes
+        #     cap["auto_apply"] = available and not manual_only
+        # for every capability, so the flag was overwritten a few lines later and
+        # the box auto-applied adsb anyway. Observed on aryaos-c998: the
+        # deferred_reason was present and correct while auto_apply was true, and
+        # readsb crash-looped exactly as before.
+        #
+        # manual_only is the mechanism the pipeline already has for "available,
+        # but never turn it on by itself" -- ble-rid and sapient both use it --
+        # and it survives that recomputation because it is an INPUT to it.
+        caps["adsb"]["manual_only"] = True
         caps["adsb"]["deferred_reason"] = (
             f"readsb is configured for RTL-SDR (--device-type rtlsdr) and the only "
             f"SDR present is {_labels(other_sdrs)}. Enabling adsb would crash-loop "

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -222,6 +222,21 @@ def _capabilities() -> list[dict[str, str]]:
 TDOA_RMS_MAX_S = 1.0e-5
 
 
+def _pps_refclock_configured() -> bool:
+    """Did aryaos-time-pps write a GNSS PPS refclock?
+
+    It writes one only after seeing the kernel assert counter advance, so this
+    answers "is there a real pulse" without re-probing. The path is under /run
+    deliberately: a refclock naming a device that has not enumerated yet is a
+    FATAL chronyd error, so it must not survive a reboot.
+    """
+    try:
+        with open("/run/chrony-aryaos/20-aryaos-pps.conf", encoding="utf-8") as fh:
+            return any(line.startswith("refclock PPS") for line in fh)
+    except OSError:
+        return False
+
+
 def _pps_devices() -> list:
     """PPS sources the kernel exposes, as (device, name) e.g. ('pps0', 'acm0').
 
@@ -290,9 +305,23 @@ def _time_state() -> dict:
 
     pps = _pps_devices()
     state["pps"] = ",".join(f"{dev}:{name}" if name else dev for dev, name in pps)
-    # A GNSS pulse (CDC-ACM serial GPS) is a usable reference; an Ethernet PHY
-    # clock (ptp) is not disciplined to GNSS and must not be counted as one.
-    state["pps_gnss"] = str(any(n.startswith(("acm", "ttyACM", "gps")) for _, n in pps)).lower()
+    # pps_gnss means "this box has a GNSS pulse", so it must reflect a PULSE, not
+    # a device name.
+    #
+    # This used to be `any(name startswith acm/ttyACM/gps)`, which is the same
+    # wrong inference aryaos-time-pps used to make. On aryaos-c998 -- a u-blox 7
+    # on USB CDC -- the kernel exposes /dev/pps1 named "acm0" from the serial DCD
+    # line, but the receiver's PPS is a physical pin that USB does not carry. The
+    # assert counter sits at 0 forever. time-pps was fixed to require the counter
+    # to advance and correctly wrote no refclock; the beacon carried on
+    # advertising pps_gnss="true" beside it, because it was deciding
+    # independently from the name.
+    #
+    # Now it reads the decision time-pps already made: the refclock config only
+    # exists if a GNSS-named device was observed actually pulsing. One source of
+    # truth instead of two heuristics that can disagree -- and cheap, because the
+    # beacon runs on a timer and must not spend seconds probing a PPS line.
+    state["pps_gnss"] = str(_pps_refclock_configured()).lower()
 
     track = _chrony_tracking()
     locked = False

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -125,10 +125,36 @@ def _primary_ip() -> str:
 
 
 def _service_state(name: str) -> str:
+    """The unit's actual state: active, inactive, failed, activating...
+
+    `systemctl is-active` reports the state on STDOUT and uses its exit code as a
+    boolean -- 0 for active, 3 for everything else. _run() discards stdout on a
+    non-zero exit, so this used to collapse EVERY non-active state to "unknown":
+
+        systemctl is-active adsbcot  ->  "failed", exit 3   ->  beacon "unknown"
+
+    which meant the fleet could not tell a deliberately-disabled sensor from a
+    crash-looping one from a dead one. On a normal box most sensors are off by
+    design, so a genuine failure was buried among a dozen equally "unknown"
+    units. Observed on aryaos-c998 with readsb, adsbcot and gdltak all failed and
+    all beaconing "unknown".
+
+    So read stdout regardless of the exit code, which is what is-active is
+    documented to do.
+    """
     if not os.path.exists("/usr/bin/systemctl"):
         return "unknown"
-    state = _run(["/usr/bin/systemctl", "is-active", f"{name}.service"], timeout=0.7)
-    return state or "unknown"
+    try:
+        proc = subprocess.run(
+            ["/usr/bin/systemctl", "is-active", f"{name}.service"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=0.7,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+    return (proc.stdout or "").strip() or "unknown"
 
 
 def _roles() -> dict[str, str]:


### PR DESCRIPTION
Found while reboot-testing `aryaos-c998`, which had readsb, adsbcot and gdltak **all failed**. The beacon told the fleet:

| unit | ground truth | beacon said |
|---|---|---|
| readsb | `failed` | *(absent)* |
| adsbcot | `failed` | **`unknown`** |
| gdltak | `failed` | *(absent)* |
| charontak | `active` | `active` |

## Cause

`systemctl is-active` reports the state on **stdout** and uses its exit code as a **boolean** — 0 for active, 3 for everything else. `_run()` returns `""` on a non-zero exit, so every non-active state collapsed to `unknown`: failed, inactive and activating alike.

## Why it matters more than it looks

On a normal AryaOS box **most sensor services are deliberately off**, so they were all reporting `unknown` too — and a genuinely dead gateway was indistinguishable from a dozen units that are off on purpose. Anything consuming the beacon (gutcheck's dashboard, an operator glancing at the fleet) had no way to see a fault.

## Fix

Read stdout regardless of exit code, which is what `is-active` is documented to do. Verified against the live box:

```
SHIPPED   adsbcot unknown    charontak active   lincot active
FIXED     adsbcot failed     charontak active   lincot active
```

Every other caller compares `== "active"`, so their behaviour is unchanged.

## Also from the same reboot test

This box reports `systemctl --failed: none` and `running` for roughly **three minutes** after boot, while three services crash-loop toward their start limits:

```
t+3min    readsb activating(3)  adsbcot activating(2)  gdltak activating(9)   --failed: NONE
t+4.5min  readsb activating(9)  adsbcot activating(6)  gdltak FAILED(10)      degraded
```

**A health check run straight after boot will call a broken box healthy.** Worth knowing for the HIL suite and for anyone testing a freshly flashed unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM