### PR TITLE
Security updates never ran: one stage disabled what another relied on

### DIFF
--- a/scripts/aryaos-test/tests/09-security.sh
+++ b/scripts/aryaos-test/tests/09-security.sh
@@ -61,6 +61,23 @@ fi
 # --- unattended security upgrades ---
 if [[ -f /etc/apt/apt.conf.d/52unattended-upgrades-aryaos ]]; then
 	ok "unattended-upgrades AryaOS policy present"
+
+	# A policy file and a working dry-run prove unattended-upgrades COULD run.
+	# Neither proves anything ever STARTS it. On aryaos-c998 both of those
+	# passed while apt-daily-upgrade.timer was disabled, so no Debian security
+	# fix would ever have been applied -- the check reported a security posture
+	# the box did not have.
+	if systemctl is-enabled apt-daily-upgrade.timer >/dev/null 2>&1; then
+		ok "apt-daily-upgrade.timer enabled (something actually triggers upgrades)"
+	else
+		fail "apt-daily-upgrade.timer disabled — unattended-upgrades will never run"
+	fi
+	if systemctl is-enabled apt-daily.timer >/dev/null 2>&1; then
+		ok "apt-daily.timer enabled (package lists get refreshed)"
+	else
+		fail "apt-daily.timer disabled — package lists never refresh, so upgrades find nothing"
+	fi
+
 	if sudo -n unattended-upgrade --dry-run --debug >/dev/null 2>&1; then
 		ok "unattended-upgrade dry-run succeeds"
 	else

--- a/stages/stage-adsbcot/00-sys-tweaks/00-run-chroot.sh
+++ b/stages/stage-adsbcot/00-sys-tweaks/00-run-chroot.sh
@@ -17,9 +17,30 @@
 apt update
 
 systemctl disable dphys-swapfile.service
-systemctl disable apt-daily.timer
-systemctl disable apt-daily-upgrade.timer
 systemctl disable man-db.timer
+
+# The apt timers are deliberately NOT disabled here any more.
+#
+# This stage runs AFTER stage-aryaos (see STAGE_LIST in config), and
+# stage-aryaos installs the unattended-upgrades policy on the explicit
+# assumption that they exist:
+#
+#   stage-aryaos/00-install/01-run-chroot.sh:
+#     "unattended-upgrades runs via the static apt-daily timers; no enable
+#      needed."
+#
+# Disabling them here silently undid that. Measured on aryaos-c998:
+#
+#   apt-daily.timer          active=inactive  enabled=disabled
+#   apt-daily-upgrade.timer  active=inactive  enabled=disabled
+#
+# and unattended-upgrades had only ever run its SHUTDOWN unit -- never an
+# actual upgrade. The box was never going to apply a Debian security fix,
+# while the code comments and the security test both said it would.
+#
+# Disabling man-db indexing and dphys-swapfile is about media longevity and
+# is kept. Disabling security updates is a different kind of decision and
+# was not an intentional one.
 
 # Media longevity: dphys-swapfile is off (no swapfile writes to the SD/NVMe).
 # Provide zram compressed RAM swap so memory spikes do not OOM-kill services,


### PR DESCRIPTION
`aryaos-c998`, a freshly flashed box:

```
apt-daily.timer          active=inactive  enabled=disabled
apt-daily-upgrade.timer  active=inactive  enabled=disabled
```

…and unattended-upgrades had only ever run its **shutdown** unit. **No Debian security fix would ever have been applied** to this box, or to any box built from this image.

## Two stages disagree, and the later one wins

```
stage-aryaos/00-install/01-run-chroot.sh
  "unattended-upgrades runs via the static apt-daily timers; no enable needed."

stage-adsbcot/00-sys-tweaks/00-run-chroot.sh
  systemctl disable apt-daily.timer
  systemctl disable apt-daily-upgrade.timer
```

`STAGE_LIST` runs **stage-aryaos before stage-adsbcot**, so the ADS-B stage silently undid the security posture the AryaOS stage had just established.

The disable sits among `dphys-swapfile` and `man-db.timer`, which are there for SD-card longevity and are **kept** — those are inherited flight-tracker tweaks and reasonable. Turning off security updates is a different kind of decision, and as far as the comments show, not an intentional one.

## Why the security test missed it

It asserted only that the policy file exists and that a dry-run works. **Both pass on a box where nothing ever triggers an upgrade** — they prove unattended-upgrades *could* run, never that anything *starts* it.

Same shape as the rest of today: configured, asserted by a test, doing nothing.

`09-security` now checks both timers are enabled and fails naming the consequence:

```
FAIL apt-daily-upgrade.timer disabled — unattended-upgrades will never run
FAIL apt-daily.timer disabled — package lists never refresh, so upgrades find nothing
```

**Verified against the live box: both new assertions fail there today**, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM