### PR TITLE
aryaos-role: clear failed state on units it disables

### DIFF
--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -195,6 +195,17 @@ apply_units() {
 		else
 			echo "disable ${unit}"
 			systemctl disable --now "${unit}" >/dev/null 2>&1 || true
+			# Clear any leftover failed state. `disable --now` stops a unit but
+			# does NOT clear a failure it recorded earlier, so a service that
+			# crash-looped under a previous capability set stays in
+			# `systemctl --failed` forever and holds the whole box in
+			# `degraded` -- for a service we just deliberately switched off.
+			#
+			# Seen on aryaos-c998: switching from adsb (a LimeSDR that readsb
+			# cannot drive) to ble-rid left readsb, adsbcot and gdltak listed as
+			# failed while ble-rid ran perfectly. The box reported degraded and
+			# an operator had no way to tell that from a real fault.
+			systemctl reset-failed "${unit}" >/dev/null 2>&1 || true
 		fi
 	done
 }


### PR DESCRIPTION
`systemctl disable --now` stops a unit but **does not clear a failure it recorded earlier**. So a service that crash-looped under a previous capability set stays in `systemctl --failed` forever and holds the whole box in `degraded` — for a service we just deliberately switched off.

Seen on `aryaos-c998` while turning it into a SIGINT box. It had `caps="adsb"` with a LimeSDR that readsb can't drive, so readsb/adsbcot/gdltak had all crash-looped to their start limits. Switching to `caps="ble-rid"`:

```
enable  dronecot-ble          active, 0 restarts, decoding Remote ID
disable readsb                still listed as failed
disable adsbcot               still listed as failed
disable gdltak                still listed as failed
systemctl is-system-running   degraded
```

The box was working **exactly as asked** and still reporting degraded, with no way for an operator to tell that from a real fault — and after the beacon fix in #228 it would have advertised those units as `failed` to the whole fleet.

**Verified on the box:** after `reset-failed` on the three units, `is-system-running` goes `degraded → running` and `--failed` is empty, with ble-rid still active and decoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM