### PR TITLE
aryaos-spectrum-survey: measure band occupancy with any SoapySDR receiver

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -72,7 +72,18 @@ jobs:
         # installed on the runner, so requiring it failed the validate job on
         # every PR in this stack. stdlib is the right dependency for a test that
         # guards a shell-adjacent script.
-        run: python3 -m unittest discover -s scripts -p 'test_*.py' -v
+        #
+        # numpy is the one exception, and it is installed rather than skipped
+        # around. test_spectrum_survey exercises aryaos-spectrum-survey's signal
+        # classification, which is numpy maths end to end -- the DC-spike guard
+        # and the continuous-carrier check are both FFT work. Making the import
+        # optional would turn the whole suite into a silent no-op on the runner,
+        # which is exactly the failure mode those tests exist to catch. The tool
+        # itself depends on python3-numpy on the image, so testing without it
+        # would not be testing the shipped thing anyway.
+        run: |
+          python3 -m pip install --quiet numpy
+          python3 -m unittest discover -s scripts -p 'test_*.py' -v
 
       - name: Shellcheck appliance scripts
         # Lint the shell that ships to /usr/local/sbin and the build/test

--- a/docs/deploy/sigint-limesdr.md
+++ b/docs/deploy/sigint-limesdr.md
@@ -35,16 +35,56 @@ sudo LimeUtil --update                # one-time gateware/firmware update
 
 ## Using the LimeSDR
 
-### As the ADS-B 1090 front-end
+### As the AIS receiver
 
-The Lime can replace an RTL-SDR for ADS-B:
+`AIS-catcher` is built with SoapySDR from **0.68-snstac3** onward, so it can drive the Lime
+directly:
+
+```bash
+AIS-catcher -gu DEVICE driver=lime ANTENNA LNAW GAIN LNA=30 -s 1536000 -v
+```
+
+Note the syntax: `SOAPYSDR:` in `AIS-catcher -h` is a section heading, not part of the
+argument, and passing `-d SOAPYSDR` sends it looking for a device with the literal serial
+`SOAPYSDR` instead of using the one you selected.
+
+Earlier builds were compiled **without** SoapySDR (`readelf -d` showed zero `libSoapySDR`
+entries), so the Lime was invisible to them no matter how it was configured — `-l` listed only
+the GPS.
+
+### As the ADS-B 1090 front-end
 
 ```bash
 sudo scripts/readsb-use-lime.sh          # driver=lime, gain 40
 ```
 
 This sets `readsb` to `--device-type soapysdr --soapy-device driver=lime` and restarts it.
-CoT then flows through `adsbcot` → Charontak as usual.
+CoT then flows through `adsbcot` → Charontak as usual. Two `readsb` bugs that made this path
+useless are fixed from **3.16.15-4** onward: `--gain` was applied ten times too large on the
+SoapySDR path, and a block was filled with a single `readStream()` call, which returns at most
+the driver's stream MTU — 2040 samples on a Lime against a 65536-sample buffer.
+
+!!! warning "A bare Lime is not a usable ADS-B receiver"
+    Fixing those bugs is necessary but **not sufficient**. Measured on a dragonegg box with a
+    1090&nbsp;MHz antenna, after both fixes:
+
+    - SNR sits at roughly **0&nbsp;dB at every gain setting**, with the LNA already pinned at
+      its 30&nbsp;dB maximum and only the baseband PGA still moving. PGA amplifies signal and
+      noise equally, so it cannot buy sensitivity.
+    - Burst analysis at 1090&nbsp;MHz against a 1040&nbsp;MHz control found **18 samples
+      >20&nbsp;dB over median versus 0** — real traffic, but very weak.
+    - Result: **~2 usable messages**, no position reports.
+
+    The LimeSDR Mini has **no 1090&nbsp;MHz SAW filter and no LNA**, unlike a ProStick-class
+    ADS-B dongle, so its own noise floor swamps the signal. For ADS-B on a Lime, fit an
+    **inline 1090&nbsp;MHz filtered LNA** ahead of the RX port. An RTL-SDR remains the better
+    choice if ADS-B is the box's job.
+
+!!! note "USB stability"
+    The FT601 bridge has been observed dropping off the bus under sustained streaming —
+    repeated `reset SuperSpeed USB device` messages, then a fallback to high-speed, then a full
+    disconnect requiring a reboot or re-plug to recover. If a capture stops without explanation,
+    check `lsusb` and `dmesg` before suspecting the decoder. A powered hub is worth trying.
 
 ### Remote access (SoapyRemote) {#remote-access-soapyremote}
 

--- a/docs/stylesheets/suite.css
+++ b/docs/stylesheets/suite.css
@@ -26,12 +26,40 @@
 
   /* One accent per surface, ~5% of it. This is the AryaOS property, so Signal
      Orange. Sibling properties carry their own accent and must not appear here
-     at the same time. */
+     at the same time.
+
+     TWO ROLES, KEPT APART -- the same split already applied to the Cockpit
+     plugins, the operator portal and the AryaOS Imager, and the reason it is
+     applied here too.
+
+       --sns-brand      Signal Orange. Fills, rules and the mark. NEVER a label.
+       --sns-interactive  Link and control text.
+
+     The kit token --sns-accent is Signal Orange (#E4610F) for this property and
+     is vendored, so it is not edited; the interactive role is introduced here
+     instead and the vendored value keeps its fills-only job.
+
+     Measured on Paper (#F2EFE7), which is what this surface actually is:
+
+       Signal Orange  #E4610F   3.04:1   deltaE 34.6 from the nearest status
+       Okabe-Ito blue #0072B2   4.51:1   deltaE 62.1 from the nearest status
+
+     3.04:1 fails the 4.5:1 body-text floor outright -- links were legible only
+     as large text -- and deltaE 34.6 is against `fault` #A32820, so orange body
+     text on a documentation page reads as an error state on a page that is not
+     reporting one. Both problems are the same colour doing two jobs.
+
+     NOT #56B4E9: that is the console's interactive blue and it is correct on
+     Console dark, but it measures 2.01:1 on Paper. Light and dark surfaces need
+     different blues; see the slate block below. */
+  --sns-brand:                  var(--sns-accent);
+  --sns-interactive:            #0072b2;
+
   --md-primary-fg-color:        var(--sns-ink);
   --md-primary-bg-color:        var(--sns-paper);
-  --md-accent-fg-color:         var(--sns-accent);
+  --md-accent-fg-color:         var(--sns-interactive);
 
-  --md-typeset-a-color:         var(--sns-accent);
+  --md-typeset-a-color:         var(--sns-interactive);
 
   /* Code is machine output: mono, on the secondary paper. */
   --md-code-bg-color:           var(--sns-paper-2);
@@ -42,6 +70,27 @@
 
   --md-text-font-family:        var(--sns-font-body);
   --md-code-font-family:        var(--sns-font-mono);
+}
+
+/* mkdocs.yml offers a light/dark toggle, and Material sets its scheme variables
+   on [data-md-color-scheme], which outranks the :root block above. So the dark
+   scheme needs its own interactive colour or it inherits a value chosen for
+   Paper and used on a dark ground.
+
+   Measured on Material's slate ground (#1F2129):
+
+     Okabe-Ito blue #0072B2   3.10:1   fails the 4.5:1 body-text floor
+     Okabe-Ito sky  #56B4E9   6.96:1   passes
+
+   the exact mirror of the Paper result, where the sky blue is the one that
+   fails. One blue cannot serve both grounds, so each surface names its own --
+   and the dark value is the same #56B4E9 the Cockpit console already uses, so
+   an operator moving between docs and console sees one interactive colour. */
+[data-md-color-scheme="slate"] {
+  --sns-interactive:            #56b4e9;
+
+  --md-accent-fg-color:         var(--sns-interactive);
+  --md-typeset-a-color:         var(--sns-interactive);
 }
 
 /* --- Non-negotiables from the guide ------------------------------------- */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,21 +33,32 @@ theme:
   icon:
     repo: fontawesome/brands/github
   palette:
+    # The auto entry needs the colours spelled out too. With them omitted
+    # Material falls back to its stock indigo, which shipped in the built HTML
+    # as data-md-color-primary="indigo" for every visitor whose browser has no
+    # explicit colour-scheme preference -- the default state.
     - media: "(prefers-color-scheme)"
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-auto
         name: Switch to light mode
+    # `custom` tells Material to emit no palette of its own and defer to the
+    # variables set in docs/stylesheets/suite.css, which bridge the vendored
+    # design-kit tokens. This used to say `teal` — the pre-kit colour the whole
+    # fleet has now been moved off (the Cockpit plugins carried the same
+    # #35a58f). Material's teal still won anywhere our overrides did not reach.
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: teal
-      accent: teal
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: teal
-      accent: teal
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to system preference

--- a/scripts/test_spectrum_survey.py
+++ b/scripts/test_spectrum_survey.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Tests for aryaos-spectrum-survey's classification logic.
+
+These run on synthetic captures, so they need no SDR and no radio environment.
+That is the point: the classifier is the part that was wrong twice during
+development, and both mistakes are reproducible without hardware.
+
+stdlib unittest, not pytest -- the CI runner does not have pytest.
+
+Copyright Sensors & Signals LLC https://www.snstac.com/
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TOOL = os.path.join(HERE, "..", "shared_files", "aryaos", "aryaos-spectrum-survey")
+
+spec = importlib.util.spec_from_loader(
+    "spectrum_survey",
+    importlib.machinery.SourceFileLoader("spectrum_survey", TOOL),
+)
+survey = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(survey)
+
+NFFT = 4096
+RATE = 4e6
+RNG = np.random.default_rng(20260731)
+
+
+def noise_frames(count=32, scale=200.0):
+    return [
+        (RNG.normal(0, scale, NFFT) + 1j * RNG.normal(0, scale, NFFT)).astype(np.complex64)
+        for _ in range(count)
+    ]
+
+
+def add_tone(frames, bin_offset, amp):
+    """Add a steady complex tone `bin_offset` bins away from centre."""
+    n = np.arange(NFFT)
+    tone = amp * np.exp(2j * np.pi * bin_offset * n / NFFT)
+    return [(f + tone).astype(np.complex64) for f in frames]
+
+
+def mags_from(frames):
+    return np.abs(np.concatenate(frames)).astype(np.float32)
+
+
+class TestClassification(unittest.TestCase):
+    def analyze(self, mags, frames):
+        return survey.analyze_capture(mags, frames, RATE, NFFT, np)
+
+    def test_pure_noise_is_quiet(self):
+        f = noise_frames()
+        res = self.analyze(mags_from(f), f)
+        self.assertFalse(res["occupied"])
+        self.assertEqual(res["detection"], "none")
+
+    def test_continuous_carrier_is_detected(self):
+        """A steady tone scores ZERO excursion occupancy but must still be found.
+
+        This is the FM-broadcast case. The first version of this tool reported
+        FM broadcast as 'quiet' at 0.000% occupancy on a box where two stations
+        had already been positively identified, because a continuous carrier
+        raises the very median it would have to exceed.
+        """
+        f = add_tone(noise_frames(), bin_offset=500, amp=900.0)
+        res = self.analyze(mags_from(f), f)
+        self.assertGreaterEqual(res["carrier_over_noise_db"], survey.CARRIER_DB)
+        self.assertTrue(res["occupied"])
+        self.assertIn("continuous", res["detection"])
+        # And it should report roughly where, not just that.
+        self.assertAlmostEqual(
+            res["carrier_offset_hz"], 500 * (RATE / NFFT), delta=RATE / NFFT * 2
+        )
+
+    def test_dc_spike_alone_is_not_a_carrier(self):
+        """THE regression test.
+
+        A direct-conversion receiver always has a large artefact at exactly its
+        centre frequency. An early pass 'detected' signals at exactly 433.920,
+        1090.000 and 98.500 MHz -- every one of them that artefact. If the DC
+        guard is removed, this test fails and every band reads as occupied.
+        """
+        f = add_tone(noise_frames(), bin_offset=0, amp=5000.0)
+        res = self.analyze(mags_from(f), f)
+        self.assertLess(
+            res["carrier_over_noise_db"], survey.CARRIER_DB,
+            "DC/LO artefact was reported as a carrier -- the DC guard is not working",
+        )
+        self.assertNotIn("continuous", res["detection"])
+
+    def test_bursty_traffic_is_detected(self):
+        f = noise_frames()
+        m = mags_from(f)
+        # 2% of samples well above the floor, as a packetised emitter looks.
+        idx = RNG.choice(m.size, size=int(m.size * 0.02), replace=False)
+        m[idx] = float(np.median(m)) * 40.0
+        res = self.analyze(m, f)
+        self.assertGreaterEqual(res["occupancy_pct"], survey.OCCUPIED_PCT)
+        self.assertTrue(res["occupied"])
+        self.assertIn("bursty", res["detection"])
+
+    def test_clipping_is_flagged(self):
+        """Saturated samples inflate occupancy, so they must not pass silently.
+
+        Measured on the first validation sweep: gain 40 produced peaks of +1.3,
+        +2.5 and +3.0 dBFS -- above full scale -- and a 4.6% 'occupancy' that
+        was an artefact of the gain setting, not of any emitter.
+        """
+        f = noise_frames()
+        m = mags_from(f)
+        m[: int(m.size * 0.05)] = 32767.0
+        res = self.analyze(m, f)
+        self.assertTrue(res["clipped"])
+        self.assertGreater(res["clipped_pct"], 0.01)
+
+    def test_no_iq_frames_still_returns_time_domain_stats(self):
+        f = noise_frames()
+        res = self.analyze(mags_from(f), [])
+        self.assertEqual(res["carrier_over_noise_db"], 0.0)
+        self.assertIsNone(res["carrier_offset_hz"])
+        self.assertIn("occupancy_pct", res)
+
+    def test_extra_fields_are_merged(self):
+        f = noise_frames()
+        res = survey.analyze_capture(
+            mags_from(f), f, RATE, NFFT, np, extra={"tuned_hz": 1.0, "reads": 7}
+        )
+        self.assertEqual(res["tuned_hz"], 1.0)
+        self.assertEqual(res["reads"], 7)
+
+
+class TestBandPlan(unittest.TestCase):
+    def test_band_names_unique(self):
+        names = [b["name"] for b in survey.DEFAULT_BANDS]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_bands_have_required_keys(self):
+        for b in survey.DEFAULT_BANDS:
+            for key in ("name", "center", "span", "label"):
+                self.assertIn(key, b, f"band {b.get('name')} missing {key}")
+
+    def test_labels_make_no_detection_claim(self):
+        """Labels are operator context, never an assertion about what was heard."""
+        for b in survey.DEFAULT_BANDS:
+            self.assertNotIn("detected", b["label"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -195,6 +195,17 @@ apply_units() {
 		else
 			echo "disable ${unit}"
 			systemctl disable --now "${unit}" >/dev/null 2>&1 || true
+			# Clear any leftover failed state. `disable --now` stops a unit but
+			# does NOT clear a failure it recorded earlier, so a service that
+			# crash-looped under a previous capability set stays in
+			# `systemctl --failed` forever and holds the whole box in
+			# `degraded` -- for a service we just deliberately switched off.
+			#
+			# Seen on aryaos-c998: switching from adsb (a LimeSDR that readsb
+			# cannot drive) to ble-rid left readsb, adsbcot and gdltak listed as
+			# failed while ble-rid ran perfectly. The box reported degraded and
+			# an operator had no way to tell that from a real fault.
+			systemctl reset-failed "${unit}" >/dev/null 2>&1 || true
 		fi
 	done
 }

--- a/shared_files/aryaos/aryaos-spectrum-survey
+++ b/shared_files/aryaos/aryaos-spectrum-survey
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""aryaos-spectrum-survey — measure band occupancy with a SoapySDR receiver.
+
+What this is FOR
+----------------
+A wideband SDR (LimeSDR Mini, HackRF, Airspy, PlutoSDR, or an RTL dongle within
+its tuning range) makes a useful survey instrument even where no protocol
+decoder applies: "which parts of the spectrum are busy here, and how busy" is
+answerable without knowing what any of the emitters are. That question is the
+one a SIGINT box can always answer, unlike ADS-B or AIS, which need traffic in
+range and enough sensitivity to hear it.
+
+So this reports MEASUREMENTS, never identifications. A band being occupied does
+not tell you what is transmitting, and this tool does not guess. The band plan
+supplies human labels for context only; nothing here claims a decode.
+
+Two measurement traps this is built to avoid
+--------------------------------------------
+1. THE DC / LO SPIKE. A direct-conversion receiver puts a large artefact at
+   exactly its centre frequency. A naive "find the strongest bin" survey reports
+   that artefact in EVERY band and concludes everything is occupied. Measured on
+   a LimeSDR Mini v2, a first pass reported peaks at exactly 433.920, 1090.000
+   and 98.500 MHz -- all precisely at centre, all artefact. So the bins nearest
+   DC are excluded from the statistics, and a band is tuned OFFSET from the
+   region of interest so that region never sits under the spike.
+
+2. NOISE FLOOR IS NOT OCCUPANCY. Raising gain raises the noise floor roughly
+   1:1 and tells you nothing about whether anyone is transmitting. Measured on
+   the same box at 1090 MHz: gain 40 -> -31.9 dBFS floor, gain 60 -> -13.4 dBFS
+   floor, and 0 usable ADS-B messages at either. What separates a busy band from
+   a quiet one is EXCURSIONS ABOVE ITS OWN FLOOR, so occupancy is defined
+   relative to each band's median, not against an absolute threshold.
+
+   Validated against a controlled emitter -- the box's own 2.4 GHz AP on channel
+   1 at 31 dBm -- versus an out-of-band control:
+
+     2412 MHz (our AP)      26.7% of samples >20 dB over median
+     2390 MHz (below band)   0.169%
+     2462 MHz (neighbours)   7.1%
+
+   a 158x separation between a known-busy channel and a known-quiet one.
+
+Copyright Sensors & Signals LLC https://www.snstac.com/
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+
+# Bands worth sweeping on a general-purpose SA box. `label` is context for an
+# operator, NOT a claim about what was heard. `span` is the width we care about;
+# the tool tunes offset from centre so the DC spike lands outside it.
+DEFAULT_BANDS = [
+    {"name": "ism433", "center": 433.92e6, "span": 1.0e6, "label": "ISM 433 MHz (sensors, TPMS, remotes)"},
+    {"name": "ais", "center": 162.0e6, "span": 0.2e6, "label": "Marine AIS 161.975/162.025"},
+    {"name": "uat978", "center": 978.0e6, "span": 1.0e6, "label": "UAT 978 MHz"},
+    {"name": "adsb1090", "center": 1090.0e6, "span": 2.0e6, "label": "ADS-B 1090 MHz"},
+    {"name": "ism915", "center": 915.0e6, "span": 2.0e6, "label": "ISM 915 MHz"},
+    {"name": "wifi2g_ch1", "center": 2412.0e6, "span": 20.0e6, "label": "Wi-Fi 2.4 GHz ch1"},
+    {"name": "wifi2g_ch6", "center": 2437.0e6, "span": 20.0e6, "label": "Wi-Fi 2.4 GHz ch6"},
+    {"name": "wifi2g_ch11", "center": 2462.0e6, "span": 20.0e6, "label": "Wi-Fi 2.4 GHz ch11"},
+    {"name": "fmbcast", "center": 98.0e6, "span": 2.0e6, "label": "FM broadcast (propagation check)"},
+]
+
+# An excursion this far over the band's own median counts as a signal event.
+# 20 dB is deliberately conservative: at 6 dB, thermal noise alone produces
+# several percent of samples in every band, which reads as "everything is busy".
+EXCURSION_DB = 20.0
+
+# Occupancy above this is called "occupied". Chosen from the validation above:
+# a known-quiet control measured 0.169% and a known-busy channel 26.7%, so
+# anything approaching a percent is well clear of noise.
+OCCUPIED_PCT = 0.5
+
+# A narrowband spectral peak this far above the band's own spectral median is
+# called a continuous carrier. Calibrated against FM broadcast on the test box,
+# where two identified stations stood 18.8 dB and 18.3 dB over the local median
+# while a genuinely empty band's strongest non-DC bin sat under 8 dB. 12 dB sits
+# clearly between the two.
+CARRIER_DB = 12.0
+
+
+def _db(x):
+    return 20.0 * math.log10(max(float(x), 1e-9))
+
+
+def survey_band(sdr, band, dwell, gain, sample_rate, antenna, np, SoapySDR, fmt):
+    """Measure one band. Returns a dict of measurements, or an error dict."""
+    center = float(band["center"])
+    span = float(band["span"])
+
+    # Tune OFFSET so the DC spike sits outside the span we report on. A quarter
+    # of the sample rate puts it well clear while keeping the region in-band.
+    offset = sample_rate / 4.0
+    tuned = center + offset
+
+    try:
+        sdr.setSampleRate(SoapySDR.SOAPY_SDR_RX, 0, sample_rate)
+        sdr.setFrequency(SoapySDR.SOAPY_SDR_RX, 0, tuned)
+        sdr.setGain(SoapySDR.SOAPY_SDR_RX, 0, gain)
+        if antenna:
+            sdr.setAntenna(SoapySDR.SOAPY_SDR_RX, 0, antenna)
+    except Exception as exc:  # noqa: BLE001 - report, do not abort the sweep
+        return {"error": f"tune failed: {exc}"}
+
+    try:
+        stream = sdr.setupStream(SoapySDR.SOAPY_SDR_RX, fmt)
+        sdr.activateStream(stream)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"stream setup failed: {exc}"}
+
+    n = 16384
+    nfft = 4096
+    buf = np.zeros(n * 2, np.int16)
+    mags = []
+    # Complex frames retained for the frequency-domain (continuous-carrier)
+    # check. Bounded: the time-domain stats want the whole dwell, but 64 frames
+    # is already plenty to average a stable PSD, and keeping every frame on a
+    # long dwell would balloon memory for no gain.
+    iq_frames = []
+    deadline = time.monotonic() + dwell
+    reads = 0
+    short_reads = 0
+
+    try:
+        while time.monotonic() < deadline:
+            res = sdr.readStream(stream, [buf], n, timeoutUs=200000)
+            if res.ret <= 0:
+                short_reads += 1
+                if short_reads > 50:
+                    break
+                continue
+            reads += 1
+            iq = buf[: res.ret * 2].astype(np.float32)
+            i_ch, q_ch = iq[0::2], iq[1::2]
+            mags.append(np.hypot(i_ch, q_ch))
+            if len(iq_frames) < 64 and i_ch.size >= nfft:
+                iq_frames.append((i_ch[:nfft] + 1j * q_ch[:nfft]).astype(np.complex64))
+    finally:
+        try:
+            sdr.deactivateStream(stream)
+            sdr.closeStream(stream)
+        except Exception:  # noqa: BLE001
+            pass
+
+    if not mags:
+        return {"error": "no samples read"}
+
+    return analyze_capture(
+        np.concatenate(mags), iq_frames, sample_rate, nfft, np,
+        extra={"tuned_hz": tuned, "offset_hz": offset, "reads": reads},
+    )
+
+
+def analyze_capture(m, iq_frames, sample_rate, nfft, np, extra=None):
+    """Classify a capture. Pure: no SDR, so it is testable without hardware.
+
+    `m` is a 1-D array of sample magnitudes; `iq_frames` a list of complex
+    arrays of length `nfft` (may be empty, in which case only the time-domain
+    statistics are produced).
+    """
+    median = float(np.median(m))
+    peak = float(m.max())
+    full_scale = 32767.0
+
+    # Occupancy: fraction of samples EXCURSION_DB above this band's own median.
+    # Relative, not absolute -- see the module docstring on why an absolute
+    # threshold measures gain rather than activity.
+    thresh = median * (10.0 ** (EXCURSION_DB / 20.0))
+    occupancy = float((m > thresh).mean() * 100.0)
+
+    # CLIPPING. An excursion count is only meaningful if the samples are real.
+    # Once the ADC saturates, the clipped tops are counted as signal events and
+    # occupancy is inflated by the gain setting rather than by activity. Seen on
+    # the first validation sweep: gain 40 on a LimeSDR gave peaks of +1.3, +2.5
+    # and +3.0 dBFS -- above full scale -- and a 4.6% "occupancy" at 162 MHz
+    # that was an artefact. Flagged rather than silently reported.
+    clip_level = 0.98 * full_scale
+    clipped_pct = float((m >= clip_level).mean() * 100.0)
+    clipped = clipped_pct > 0.01
+
+    # CONTINUOUS CARRIERS. The excursion metric above only sees bursty emitters.
+    # A steady carrier raises the median it is measured against, so it scores
+    # ZERO occupancy no matter how strong it is. The first validation sweep
+    # called FM broadcast "quiet" at 0.000% on a box where two stations had
+    # already been positively identified at 97.313 and 98.906 MHz.
+    #
+    # So the band is also examined in the frequency domain: average a set of
+    # FFTs and look for a narrowband peak standing above the spectral median.
+    # The bins nearest DC are discarded first -- that artefact is always the
+    # strongest thing present and would otherwise be "detected" in every band.
+    carrier_db = 0.0
+    carrier_offset = None
+    if iq_frames:
+        win = np.hanning(nfft)
+        acc = np.zeros(nfft)
+        for frame in iq_frames:
+            acc += np.abs(np.fft.fftshift(np.fft.fft(frame * win))) ** 2
+        psd = 10.0 * np.log10(acc / len(iq_frames) + 1e-12)
+
+        # Mask the LO artefact before looking for a peak. It is always the
+        # strongest bin present, so without this every band "detects a carrier"
+        # at exactly its centre frequency -- the same mistake that made a first
+        # pass report 433.920, 1090.000 and 98.500 MHz as occupied.
+        mid = nfft // 2
+        guard = max(4, nfft // 100)
+        keep = np.ones(nfft, dtype=bool)
+        keep[mid - guard: mid + guard] = False
+        psd_kept = psd[keep]
+        bins_kept = np.arange(nfft)[keep]
+
+        med_psd = float(np.median(psd_kept))
+        best = int(np.argmax(psd_kept))
+        carrier_db = round(float(psd_kept[best]) - med_psd, 1)
+        carrier_offset = float((int(bins_kept[best]) - mid) * (sample_rate / nfft))
+
+    bursty = occupancy >= OCCUPIED_PCT
+    continuous = carrier_db >= CARRIER_DB
+
+    result = {
+        "samples": int(m.size),
+        "noise_floor_dbfs": round(_db(median / full_scale), 1),
+        "peak_dbfs": round(_db(peak / full_scale), 1),
+        "peak_over_median_db": round(_db(peak / max(median, 1e-9)), 1),
+        "occupancy_pct": round(occupancy, 4),
+        "carrier_over_noise_db": carrier_db,
+        "carrier_offset_hz": carrier_offset,
+        "clipped": clipped,
+        "clipped_pct": round(clipped_pct, 4),
+        "occupied": bool(bursty or continuous),
+        "detection": (
+            "bursty+continuous" if (bursty and continuous)
+            else "bursty" if bursty
+            else "continuous" if continuous
+            else "none"
+        ),
+    }
+    if extra:
+        result.update(extra)
+    return result
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Measure band occupancy with a SoapySDR receiver.",
+        epilog="Reports measurements only. Never identifies emitters.",
+    )
+    ap.add_argument("--device", default="", help='SoapySDR args, e.g. "driver=lime". Default: first found.')
+    ap.add_argument("--antenna", default="", help="RX antenna port, e.g. LNAH / LNAW.")
+    ap.add_argument("--gain", type=float, default=40.0, help="RX gain in dB (default 40).")
+    ap.add_argument("--dwell", type=float, default=2.0, help="Seconds per band (default 2).")
+    ap.add_argument("--sample-rate", type=float, default=4e6, help="Sample rate in Hz (default 4e6).")
+    ap.add_argument("--bands", default="", help="Comma-separated band names to sweep (default: all).")
+    ap.add_argument("--json", action="store_true", help="Emit JSON only.")
+    args = ap.parse_args(argv)
+
+    try:
+        import numpy as np
+        import SoapySDR
+    except ImportError as exc:
+        print(f"aryaos-spectrum-survey: missing dependency: {exc}", file=sys.stderr)
+        print("install: apt install python3-numpy python3-soapysdr", file=sys.stderr)
+        return 1
+
+    # A bare {"driver": "lime"} dict is NOT reliable: on the LimeSDR Mini v2 it
+    # fails with "Device::make() no match" while enumeration works fine. The
+    # enumerated args must be passed whole, so that is the default path.
+    try:
+        found = SoapySDR.Device.enumerate(args.device) if args.device else SoapySDR.Device.enumerate()
+    except Exception as exc:  # noqa: BLE001
+        print(f"aryaos-spectrum-survey: enumeration failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not found:
+        print("aryaos-spectrum-survey: no SoapySDR device found", file=sys.stderr)
+        return 1
+
+    try:
+        sdr = SoapySDR.Device(found[0])
+    except Exception as exc:  # noqa: BLE001
+        print(f"aryaos-spectrum-survey: cannot open device: {exc}", file=sys.stderr)
+        return 1
+
+    fmt = SoapySDR.SOAPY_SDR_CS16
+
+    wanted = [b.strip() for b in args.bands.split(",") if b.strip()]
+    bands = [b for b in DEFAULT_BANDS if not wanted or b["name"] in wanted]
+    if wanted and not bands:
+        print(f"aryaos-spectrum-survey: no such band(s): {args.bands}", file=sys.stderr)
+        return 2
+
+    out = {
+        "device": str(found[0]),
+        "gain_db": args.gain,
+        "sample_rate_hz": args.sample_rate,
+        "dwell_s": args.dwell,
+        "excursion_db": EXCURSION_DB,
+        "occupied_threshold_pct": OCCUPIED_PCT,
+        "note": "Measurements only; no emitter is identified.",
+        "bands": [],
+    }
+
+    for band in bands:
+        res = survey_band(sdr, band, args.dwell, args.gain, args.sample_rate,
+                          args.antenna, np, SoapySDR, fmt)
+        entry = {"name": band["name"], "center_hz": band["center"], "label": band["label"]}
+        entry.update(res)
+        out["bands"].append(entry)
+
+        if not args.json:
+            if "error" in res:
+                print(f"  {band['name']:12s} {band['center']/1e6:9.3f} MHz  ERROR: {res['error']}")
+            else:
+                flag = "OCCUPIED" if res["occupied"] else "quiet"
+                clip = "  CLIPPING" if res["clipped"] else ""
+                carrier = ""
+                if res["carrier_over_noise_db"] >= CARRIER_DB and res["carrier_offset_hz"] is not None:
+                    at = (res["tuned_hz"] + res["carrier_offset_hz"]) / 1e6
+                    carrier = f"  carrier +{res['carrier_over_noise_db']:.1f}dB @ {at:.3f} MHz"
+                print(
+                    f"  {band['name']:12s} {band['center']/1e6:9.3f} MHz  "
+                    f"floor={res['noise_floor_dbfs']:6.1f} dBFS  "
+                    f"occ={res['occupancy_pct']:7.3f}%  "
+                    f"{flag:8s} [{res['detection']}]{carrier}{clip}"
+                )
+
+    if args.json:
+        json.dump(out, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -167,6 +167,14 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-factory-reset.service"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-zeroize.service" \
 	"${ROOTFS_DIR}/etc/systemd/system/aryaos-zeroize.service"
 
+## Spectrum survey: band-occupancy measurement with any SoapySDR receiver.
+# Not a decoder and not a service -- an operator-invoked instrument. It answers
+# "which bands are busy here" on a box whose SDR has no applicable decoder, or
+# where the decoders have nothing in range to hear. Installed in sbin next to
+# the other aryaos-* tools; no unit, nothing enabled.
+install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-spectrum-survey" \
+	"${ROOTFS_DIR}/usr/local/sbin/aryaos-spectrum-survey"
+
 ## Radios: WiFi hotspot control + EMCON/radio-silence (Cockpit-driven)
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-radio" "${ROOTFS_DIR}/usr/local/sbin/aryaos-radio"
 install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-radio-silence.service" \


### PR DESCRIPTION
A wideband SDR is a useful survey instrument even where no decoder applies. *"Which parts of the spectrum are busy here"* is answerable without knowing what any emitter is — and unlike ADS-B or AIS it doesn't need traffic in range **and** enough sensitivity to hear it. On the LimeSDR box this is the capability the hardware actually delivers today.

Reports **measurements, never identifications**. Band labels are operator context; a test asserts they make no detection claim.

## Two traps found by measurement

**1. The DC/LO spike.** A direct-conversion receiver puts a large artefact at exactly its centre frequency. My first pass "found signals" at exactly `433.920`, `1090.000` and `98.500` MHz — every one of them that artefact. Bands are now tuned offset and the bins around DC masked before any peak search.

Mutation-checked — with the mask disabled the artefact reads **+59.4 dB** and the test fails:
```
AssertionError: 59.4 not less than 12.0 :
DC/LO artefact was reported as a carrier -- the DC guard is not working
```

**2. Continuous carriers are invisible to an excursion metric.** Occupancy as "samples above the band's own median" only sees *bursty* emitters — a steady carrier raises the median it would have to exceed, so it scores zero. The first version called FM broadcast **"quiet" at 0.000%** on a box where two stations had already been positively identified. A frequency-domain check now runs alongside, and each band reports `bursty` / `continuous` / `both` / `none`.

**Also flags ADC clipping** — saturated samples are counted as signal events, so occupancy silently becomes a function of gain rather than activity. Observed as a 4.6% "occupancy" at 162 MHz that was purely an artefact of gain 40.

## Validation

Against a controlled emitter — the box's own 2.4 GHz AP on ch1 at 31 dBm — versus an out-of-band control:

| frequency | samples >20 dB over median |
|---|---|
| 2412 MHz (our AP) | **26.7%** |
| 2390 MHz (below band) | 0.169% |

A **158×** separation. Independently, the continuous-carrier check re-found the FM station at 98.897 / 98.912 MHz across separate runs — the same station the manual PSD sweep found at 98.906 MHz by a different method.

## Scope

Ships as an operator-invoked tool in `/usr/local/sbin`. **No unit, nothing enabled, no capability wired** — it claims an SDR while running, so it must not compete with a decoder behind the operator's back.

10 tests, stdlib `unittest` (the CI runner has no pytest), on synthetic captures — no SDR or radio environment needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM