### PR TITLE
docs: lead with AryaOS Imager, and be honest about what it cannot verify

### DIFF
--- a/docs/get-started/flash-the-image.md
+++ b/docs/get-started/flash-the-image.md
@@ -30,7 +30,13 @@ Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads 
 
 === "AryaOS Imager"
 
-    [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases) is a single-purpose build of Raspberry Pi Imager that offers **only AryaOS**. It downloads the image for you, so there is no file to find and no way to pick the wrong operating system. Available for Windows and Linux.
+    [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases) is a single-purpose build of Raspberry Pi Imager that offers **only AryaOS**. It downloads the image for you, so there is no file to find and no way to pick the wrong operating system.
+
+    | Platform | Download |
+    |---|---|
+    | Windows | `AryaOS-Imager-Setup-*.exe` (installer) or `aryaos-imager.exe` (portable) |
+    | Linux | `aryaos-imager` — an x86-64 binary |
+    | macOS | **not built yet** — use Raspberry Pi Imager or balenaEtcher |
 
     1. Download and install AryaOS Imager.
     2. Insert the microSD card into your workstation.
@@ -38,8 +44,12 @@ Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads 
     4. Under storage, select the microSD card. **Confirm the device — this erases the card.**
     5. Write, and wait for the verify step to finish.
 
-    !!! note "Windows shows a SmartScreen warning"
-        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info → Run anyway**. Each release publishes a `SHA256SUMS.txt` if you would rather verify the download first.
+    !!! warning "Windows shows a SmartScreen warning, and you cannot yet checksum the fix"
+        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info → Run anyway**.
+
+        Releases publish a `SHA256SUMS.txt`, but as of `v1.0.0` it covers **only the Linux binary** — the Windows installer, the portable `.exe` and the callback relay have no published checksum. So on Windows there is currently no way to verify the download, and the "run anyway" step is a genuine trust decision. Prefer the Linux build where you have the choice, and re-check `SHA256SUMS.txt` on newer releases.
+
+    The image itself is a separate matter and *is* verifiable: every AryaOS release publishes an SBOM and an uncompressed-image SHA, and the imager verifies what it wrote after writing it.
 
     There is no OS-customization step to skip: AryaOS configures itself on [first boot](first-boot.md), so the imager deliberately leaves those settings alone.
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -13,10 +13,26 @@ apply to every mission.
 
 ## 1. Flash the card
 
-1. Download the latest `aryaos-*.img.xz` from
-   [GitHub Releases](https://github.com/snstac/aryaos/releases).
-2. Write it to the microSD card with **Raspberry Pi Imager** (choose *Use custom*)
-   or **balenaEtcher**. Full instructions: [Flash the image](flash-the-image.md).
+The short way, on **Windows or Linux**, is
+[**AryaOS Imager**](https://github.com/snstac/aryaos-imager/releases) — a
+single-purpose build of Raspberry Pi Imager that offers only AryaOS and
+downloads the image itself, so there is nothing to find and no wrong operating
+system to pick by accident.
+
+1. Install [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases).
+2. Insert the microSD card, open the imager, and choose
+   **AryaOS (latest release)**.
+3. Select the card — **this erases it** — then write and let it verify.
+
+On **macOS**, or if you already have the tools, download the latest
+`aryaos-*.img.xz` from [GitHub Releases](https://github.com/snstac/aryaos/releases)
+and write it with **Raspberry Pi Imager** (choose *Use custom*) or
+**balenaEtcher**. There is no macOS build of AryaOS Imager yet.
+
+Do not fill in the OS-customization prompt if one appears. AryaOS sets its own
+hostname and hotspot on first boot, and pre-seeding those settings can conflict.
+
+Full instructions, including verification: [Flash the image](flash-the-image.md).
 
 ## 2. Boot the box
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,8 @@ Two things are **not** capabilities, because they are not optional receivers:
 
     ---
 
-    Write AryaOS to a microSD card with Raspberry Pi Imager or Etcher.
+    Write AryaOS to a microSD card with AryaOS Imager, which fetches the image
+    for you — or Raspberry Pi Imager or Etcher.
 
     [:octicons-arrow-right-24: Flash the image](get-started/flash-the-image.md)
 

--- a/docs/stylesheets/suite.css
+++ b/docs/stylesheets/suite.css
@@ -130,17 +130,32 @@ body,
   letter-spacing: -0.03em;
 
   /* Material's own rule is `color: var(--md-default-fg-color--light)`, which
-     our bridge maps to Slate, so the page title was rendering MUTED -- the
-     display role, at 800 weight, as the faintest text on the page. Measured on
-     Paper:
+     our bridge maps to Slate, so the page title rendered MUTED -- the display
+     role, at 800 weight, as the faintest text on the page. Measured on Paper:
 
        Slate #6B7169   4.36:1   legal for large text, fails body contrast
        Ink   #12211A  14.53:1
 
-     Slate is legal here, but it is the kit's secondary/muted role and display
-     is its strongest. A dimmed h1 is a Material styling default, not a kit
-     decision, so it is overridden rather than inherited. */
-  color: var(--sns-ink);
+     Slate is legal there, but it is the kit's secondary/muted role and display
+     is its strongest, so it is overridden rather than inherited.
+
+     THE VARIABLE, NOT THE LITERAL. This first said `var(--sns-ink)`, and that
+     shipped an h1 nobody could read in dark mode: ink is #12211A against
+     slate's #1E2129 ground, which measures
+
+       1.04:1
+
+     -- dark text on a dark background, reported from the live site. The
+     contrast work behind this whole stylesheet was done against Paper only,
+     and a hardcoded colour cannot follow a theme that has two grounds.
+
+     --md-default-fg-color is scheme-aware and already carries the intent:
+     our :root maps it to --sns-ink for the light scheme, and Material's own
+     [data-md-color-scheme="slate"] block replaces it with a light value.
+
+       light  ink #12211A on Paper    14.53:1   (unchanged)
+       dark   #BFC1C6 on #1E2129       8.94:1 */
+  color: var(--md-default-fg-color);
 }
 
 .md-typeset h2,
@@ -216,7 +231,12 @@ img {
 }
 
 .md-header {
-  border-bottom: var(--sns-rule) solid var(--sns-ink);
+  /* Hairline, not ink. The header's own background IS --sns-ink (set above via
+     --md-primary-fg-color), so an ink rule on it was invisible in both schemes
+     -- a separator that looked applied and separated nothing.
+     It matters most in dark mode, where the header (#12211A) and the body
+     ground (#1E2129) are both dark and nearly the same value. */
+  border-bottom: var(--sns-rule) solid var(--sns-hairline);
 }
 
 .md-typeset .admonition,
@@ -226,7 +246,10 @@ img {
 }
 
 .md-typeset table:not([class]) th {
-  border-bottom: var(--sns-rule) solid var(--sns-ink);
+  /* Scheme-aware for the same reason as the h1 colour: a literal --sns-ink rule
+     is correct on Paper and invisible on slate's dark ground, so table headers
+     silently lost their underline in dark mode. */
+  border-bottom: var(--sns-rule) solid var(--md-default-fg-color);
 }
 
 /* Flush left everywhere — including the label inside a wide button. */


### PR DESCRIPTION
We ship our own imager and then told people to use someone else's.

`flash-the-image.md` had a good AryaOS Imager section, but the two pages most readers actually start from didn't mention it at all:

| page | said |
|---|---|
| quickstart | *"Download the latest `aryaos-*.img.xz` … write it with Raspberry Pi Imager (choose Use custom) or balenaEtcher"* |
| index card | *"Write AryaOS to a microSD card with Raspberry Pi Imager or Etcher"* |

Both now lead with AryaOS Imager, which fetches the image itself.

## Platform support stated, not implied

Checked against the actual `v1.0.0` release assets:

| platform | ships |
|---|---|
| Windows | installer + portable `.exe` |
| Linux | `aryaos-imager`, x86-64 ELF |
| macOS | **nothing** |

macOS readers are now sent to Raspberry Pi Imager / balenaEtcher up front, rather than discovering there's no build after following a recommendation. The page previously said only "Available for Windows and Linux" — which a Mac user reads *after* trying.

## A security claim that was wrong

The Windows note said the installer isn't code-signed, then offered this as the mitigation:

> *"Each release publishes a `SHA256SUMS.txt` if you would rather verify the download first."*

That file is **80 bytes** on `v1.0.0` and contains **one line — the Linux binary**:

```
4c5a8b237e75efdd713358246b776e856410f66d6825e76e28f29e6d8467c2b9  aryaos-imager
```

The Windows installer, portable `.exe` and callback relay have **no published checksum**. So the artifacts requiring the most trust — the unsigned ones triggering SmartScreen — are exactly the ones that cannot be verified. The docs now say so plainly and point readers at the Linux build where they have the choice.

The **image** itself is unaffected and remains verifiable: SBOM plus uncompressed-image SHA per release, and the imager verifies what it wrote.

**Follow-up not done here:** the real fix is in `snstac/aryaos-imager` — have the release workflow checksum every artifact and assert the line count matches the artifact count. I didn't file that issue, since it's a different repo and wasn't asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM