### PR TITLE
aryaos-spectrum-survey: emit ZMeta OBSERVATION_EVENTs (--zmeta)

### DIFF
--- a/docs/get-started/flash-the-image.md
+++ b/docs/get-started/flash-the-image.md
@@ -30,7 +30,13 @@ Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads 
 
 === "AryaOS Imager"
 
-    [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases) is a single-purpose build of Raspberry Pi Imager that offers **only AryaOS**. It downloads the image for you, so there is no file to find and no way to pick the wrong operating system. Available for Windows and Linux.
+    [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases) is a single-purpose build of Raspberry Pi Imager that offers **only AryaOS**. It downloads the image for you, so there is no file to find and no way to pick the wrong operating system.
+
+    | Platform | Download |
+    |---|---|
+    | Windows | `AryaOS-Imager-Setup-*.exe` (installer) or `aryaos-imager.exe` (portable) |
+    | Linux | `aryaos-imager` — an x86-64 binary |
+    | macOS | **not built yet** — use Raspberry Pi Imager or balenaEtcher |
 
     1. Download and install AryaOS Imager.
     2. Insert the microSD card into your workstation.
@@ -38,8 +44,12 @@ Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads 
     4. Under storage, select the microSD card. **Confirm the device — this erases the card.**
     5. Write, and wait for the verify step to finish.
 
-    !!! note "Windows shows a SmartScreen warning"
-        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info → Run anyway**. Each release publishes a `SHA256SUMS.txt` if you would rather verify the download first.
+    !!! warning "Windows shows a SmartScreen warning, and you cannot yet checksum the fix"
+        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info → Run anyway**.
+
+        Releases publish a `SHA256SUMS.txt`, but as of `v1.0.0` it covers **only the Linux binary** — the Windows installer, the portable `.exe` and the callback relay have no published checksum. So on Windows there is currently no way to verify the download, and the "run anyway" step is a genuine trust decision. Prefer the Linux build where you have the choice, and re-check `SHA256SUMS.txt` on newer releases.
+
+    The image itself is a separate matter and *is* verifiable: every AryaOS release publishes an SBOM and an uncompressed-image SHA, and the imager verifies what it wrote after writing it.
 
     There is no OS-customization step to skip: AryaOS configures itself on [first boot](first-boot.md), so the imager deliberately leaves those settings alone.
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -13,10 +13,26 @@ apply to every mission.
 
 ## 1. Flash the card
 
-1. Download the latest `aryaos-*.img.xz` from
-   [GitHub Releases](https://github.com/snstac/aryaos/releases).
-2. Write it to the microSD card with **Raspberry Pi Imager** (choose *Use custom*)
-   or **balenaEtcher**. Full instructions: [Flash the image](flash-the-image.md).
+The short way, on **Windows or Linux**, is
+[**AryaOS Imager**](https://github.com/snstac/aryaos-imager/releases) — a
+single-purpose build of Raspberry Pi Imager that offers only AryaOS and
+downloads the image itself, so there is nothing to find and no wrong operating
+system to pick by accident.
+
+1. Install [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases).
+2. Insert the microSD card, open the imager, and choose
+   **AryaOS (latest release)**.
+3. Select the card — **this erases it** — then write and let it verify.
+
+On **macOS**, or if you already have the tools, download the latest
+`aryaos-*.img.xz` from [GitHub Releases](https://github.com/snstac/aryaos/releases)
+and write it with **Raspberry Pi Imager** (choose *Use custom*) or
+**balenaEtcher**. There is no macOS build of AryaOS Imager yet.
+
+Do not fill in the OS-customization prompt if one appears. AryaOS sets its own
+hostname and hotspot on first boot, and pre-seeding those settings can conflict.
+
+Full instructions, including verification: [Flash the image](flash-the-image.md).
 
 ## 2. Boot the box
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,8 @@ Two things are **not** capabilities, because they are not optional receivers:
 
     ---
 
-    Write AryaOS to a microSD card with Raspberry Pi Imager or Etcher.
+    Write AryaOS to a microSD card with AryaOS Imager, which fetches the image
+    for you — or Raspberry Pi Imager or Etcher.
 
     [:octicons-arrow-right-24: Flash the image](get-started/flash-the-image.md)
 

--- a/docs/stylesheets/suite.css
+++ b/docs/stylesheets/suite.css
@@ -130,17 +130,32 @@ body,
   letter-spacing: -0.03em;
 
   /* Material's own rule is `color: var(--md-default-fg-color--light)`, which
-     our bridge maps to Slate, so the page title was rendering MUTED -- the
-     display role, at 800 weight, as the faintest text on the page. Measured on
-     Paper:
+     our bridge maps to Slate, so the page title rendered MUTED -- the display
+     role, at 800 weight, as the faintest text on the page. Measured on Paper:
 
        Slate #6B7169   4.36:1   legal for large text, fails body contrast
        Ink   #12211A  14.53:1
 
-     Slate is legal here, but it is the kit's secondary/muted role and display
-     is its strongest. A dimmed h1 is a Material styling default, not a kit
-     decision, so it is overridden rather than inherited. */
-  color: var(--sns-ink);
+     Slate is legal there, but it is the kit's secondary/muted role and display
+     is its strongest, so it is overridden rather than inherited.
+
+     THE VARIABLE, NOT THE LITERAL. This first said `var(--sns-ink)`, and that
+     shipped an h1 nobody could read in dark mode: ink is #12211A against
+     slate's #1E2129 ground, which measures
+
+       1.04:1
+
+     -- dark text on a dark background, reported from the live site. The
+     contrast work behind this whole stylesheet was done against Paper only,
+     and a hardcoded colour cannot follow a theme that has two grounds.
+
+     --md-default-fg-color is scheme-aware and already carries the intent:
+     our :root maps it to --sns-ink for the light scheme, and Material's own
+     [data-md-color-scheme="slate"] block replaces it with a light value.
+
+       light  ink #12211A on Paper    14.53:1   (unchanged)
+       dark   #BFC1C6 on #1E2129       8.94:1 */
+  color: var(--md-default-fg-color);
 }
 
 .md-typeset h2,
@@ -216,7 +231,12 @@ img {
 }
 
 .md-header {
-  border-bottom: var(--sns-rule) solid var(--sns-ink);
+  /* Hairline, not ink. The header's own background IS --sns-ink (set above via
+     --md-primary-fg-color), so an ink rule on it was invisible in both schemes
+     -- a separator that looked applied and separated nothing.
+     It matters most in dark mode, where the header (#12211A) and the body
+     ground (#1E2129) are both dark and nearly the same value. */
+  border-bottom: var(--sns-rule) solid var(--sns-hairline);
 }
 
 .md-typeset .admonition,
@@ -226,7 +246,10 @@ img {
 }
 
 .md-typeset table:not([class]) th {
-  border-bottom: var(--sns-rule) solid var(--sns-ink);
+  /* Scheme-aware for the same reason as the h1 colour: a literal --sns-ink rule
+     is correct on Paper and invisible on slate's dark ground, so table headers
+     silently lost their underline in dark mode. */
+  border-bottom: var(--sns-rule) solid var(--md-default-fg-color);
 }
 
 /* Flush left everywhere — including the label inside a wide button. */

--- a/scripts/test_spectrum_survey.py
+++ b/scripts/test_spectrum_survey.py
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import importlib.util
+import json
 import os
 import sys
 import unittest
@@ -154,3 +155,147 @@ class TestBandPlan(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestZMetaEmission(unittest.TestCase):
+    """aryaos-spectrum-survey --zmeta output, validated against the REAL schema.
+
+    The schema is vendored verbatim in scripts/vendor/ rather than approximated
+    here. A hand-written stand-in would accept output the actual consumer
+    rejects, which is exactly what this is meant to catch.
+    """
+
+    BAND = {
+        "name": "fmbcast",
+        "center": 98.0e6,
+        "span": 2.0e6,
+        "label": "FM broadcast (propagation check)",
+    }
+    SOURCE = {
+        "platform_id": "aryaos-c998",
+        "node_role": "EDGE",
+        "producer": "aryaos-spectrum-survey",
+        "sensor_id": "LimeSDR Mini",
+        "sw_version": None,
+    }
+    # A real measurement from the test box: FM detected as a continuous carrier.
+    RESULT = {
+        "tuned_hz": 99.0e6,
+        "noise_floor_dbfs": -45.6,
+        "occupancy_pct": 0.0,
+        "carrier_over_noise_db": 18.2,
+        "carrier_offset_hz": -86914.0625,
+        "clipped": False,
+        "clipped_pct": 0.0,
+        "occupied": True,
+        "detection": "continuous",
+    }
+
+    def build(self, result=None):
+        return survey.zmeta_event(
+            self.BAND, result or self.RESULT, self.SOURCE,
+            1785000000000, bytes(range(10)), 2.0,
+        )
+
+    def test_uuid7_shape(self):
+        """ZMeta pins the UUID version nibble to 7; uuid4 would fail its schema."""
+        ev = self.build()
+        uid = ev["event"]["event_id"]
+        self.assertEqual(uid[14], "7", f"not a v7 UUID: {uid}")
+        self.assertIn(uid[19].lower(), "89ab", f"bad UUID variant: {uid}")
+
+    def test_uuid7_is_time_ordered(self):
+        a = survey._uuid7(1785000000000, bytes(10))
+        b = survey._uuid7(1785000001000, bytes(10))
+        self.assertLess(a, b, "v7 UUIDs must sort by creation time")
+
+    def test_timestamp_is_utc_with_z(self):
+        ts = self.build()["event"]["ts"]
+        self.assertTrue(ts.endswith("Z"), ts)
+
+    def test_is_observation_not_inference(self):
+        """Every field is a measured fact; nothing claims what is transmitting."""
+        ev = self.build()
+        self.assertEqual(ev["event"]["event_type"], "OBSERVATION_EVENT")
+        self.assertEqual(ev["event"]["event_subtype"], "RF")
+        self.assertEqual(ev["payload"]["modality"], "RF")
+
+    def test_no_confidence_field(self):
+        """Occupancy is not a claim-strength, so confidence must not be invented."""
+        self.assertNotIn("confidence", self.build())
+
+    def test_scan_rf_vocabulary(self):
+        """Payload reuses ZMeta's SCAN_RF command field names, same units."""
+        f = self.build()["payload"]["features"]
+        self.assertEqual(f["freq_range_hz"], [97.0e6, 99.0e6])
+        self.assertEqual(f["dwell_ms"], 2000)
+
+    def test_features_carry_no_identity(self):
+        """ZMeta forbids these on an observation; we must not smuggle them in."""
+        f = self.build()["payload"]["features"]
+        for banned in ("track_id", "entity_class", "classification",
+                       "class_name", "label", "confidence"):
+            self.assertNotIn(banned, f)
+
+    def test_clipping_surfaces_in_quality_block(self):
+        clipped = dict(self.RESULT, clipped=True, clipped_pct=4.2)
+        q = self.build(clipped)["payload"]["quality"]
+        self.assertTrue(q["clipped"])
+        self.assertFalse(q["calibrated"])
+
+    def _schema(self):
+        path = os.path.join(HERE, "vendor", "zmeta-event-1.1.0.schema.json")
+        with open(path) as fh:
+            return json.load(fh)
+
+    def test_kernel_and_observation_shape_validate(self):
+        """Everything except the RF power field satisfies the real schema.
+
+        Validated by adding a placeholder power_dbm, which isolates the one
+        known gap: if anything ELSE drifts out of conformance this fails.
+        """
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        ev = self.build()
+        ev["payload"]["features"]["power_dbm"] = -60.0  # test-only placeholder
+        jsonschema.validate(instance=ev, schema=self._schema())
+
+    def test_power_dbm_is_deliberately_absent(self):
+        """We measure dBFS, which is receiver-relative; dBm would be invented.
+
+        On the test box the reported floor moved from -31.9 to -13.4 dBFS purely
+        by changing gain. Emitting that as absolute power would be the unit
+        inference ZMeta's own semantics contract forbids.
+
+        Consequence, recorded rather than hidden: our RF observations do NOT
+        satisfy ZMeta's RF feature contract, which requires power_dbm. This is a
+        spec gap for uncalibrated receivers, raised upstream.
+        """
+        self.assertNotIn("power_dbm", self.build()["payload"]["features"])
+
+    def test_rf_contract_gap_still_exists(self):
+        """Fails when upstream relaxes power_dbm -- our cue to revisit."""
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        with self.assertRaises(
+            jsonschema.ValidationError,
+            msg="ZMeta may have relaxed the RF power_dbm requirement; re-check the mapping",
+        ):
+            jsonschema.validate(instance=self.build(), schema=self._schema())
+
+    def test_schema_rejects_a_malformed_event(self):
+        """Proves the validation above can actually fail."""
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        schema = self._schema()
+        bad = self.build()
+        bad["payload"]["features"]["power_dbm"] = -60.0
+        bad["event"]["event_id"] = "not-a-uuid"
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=bad, schema=schema)

--- a/scripts/vendor/README.md
+++ b/scripts/vendor/README.md
@@ -1,0 +1,17 @@
+# Vendored third-party schemas
+
+## `zmeta-event-1.1.0.schema.json`
+
+The ZMeta event schema, vendored **verbatim** from
+[JTC-byte/zmeta-spec](https://github.com/JTC-byte/zmeta-spec) at schema version
+`1.1.0` (`$id: https://praesens.io/schemas/zmeta-event-1.1.0.schema.json`).
+Apache-2.0, same licence as this repository.
+
+It is here so `scripts/test_spectrum_survey.py` can validate
+`aryaos-spectrum-survey --zmeta` output against the **real** schema rather than
+against our reading of it. A hand-written approximation would happily accept
+output the actual consumer rejects, which is the whole failure mode the test
+exists to prevent.
+
+**Do not edit.** Re-vendor from upstream when moving to a new schema version,
+and update the version in the filename so a stale copy is obvious.

--- a/scripts/vendor/zmeta-event-1.1.0.schema.json
+++ b/scripts/vendor/zmeta-event-1.1.0.schema.json
@@ -1,0 +1,2014 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://praesens.io/schemas/zmeta-event-1.1.0.schema.json",
+  "title": "ZMeta Event Schema v1.1.0",
+  "description": "Extension of ZMeta v1.0. Adds modality-specific feature schemas, structured quality block, error ellipse, expanded task types, orbit geometry, SENSOR_STATUS, PLATFORM_STATUS, and strict UUIDv7 event identity.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "zmeta_version",
+    "event",
+    "source",
+    "payload"
+  ],
+  "properties": {
+    "zmeta_version": {
+      "const": "1.1.0"
+    },
+    "event": {
+      "$ref": "#/$defs/event"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "profile": {
+      "type": "string",
+      "enum": [
+        "L",
+        "M",
+        "H"
+      ]
+    },
+    "payload": {
+      "type": "object"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "lineage": {
+      "$ref": "#/$defs/lineage"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["event"],
+        "properties": {
+          "event": {
+            "required": ["event_type"],
+            "properties": {
+              "event_type": { "const": "OBSERVATION_EVENT" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/ObservationPayload" },
+          "confidence": false
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["event"],
+        "properties": {
+          "event": {
+            "required": ["event_type"],
+            "properties": {
+              "event_type": { "const": "INFERENCE_EVENT" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/InferencePayload" }
+        },
+        "required": ["confidence", "lineage"]
+      }
+    },
+    {
+      "if": {
+        "required": ["event"],
+        "properties": {
+          "event": {
+            "required": ["event_type"],
+            "properties": {
+              "event_type": { "const": "FUSION_EVENT" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/FusionPayload" }
+        },
+        "required": ["confidence", "lineage"]
+      }
+    },
+    {
+      "if": {
+        "required": ["event"],
+        "properties": {
+          "event": {
+            "required": ["event_type"],
+            "properties": {
+              "event_type": { "const": "STATE_EVENT" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/TrackStatePayload" }
+        },
+        "required": ["confidence", "lineage"]
+      }
+    },
+    {
+      "if": {
+        "required": ["event"],
+        "properties": {
+          "event": {
+            "required": ["event_type"],
+            "properties": {
+              "event_type": { "const": "COMMAND_EVENT" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/CommandPayload" },
+          "confidence": false
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["event"],
+        "properties": {
+          "event": {
+            "required": ["event_type"],
+            "properties": {
+              "event_type": { "const": "SYSTEM_EVENT" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/SystemPayload" },
+          "confidence": false
+        }
+      }
+    },
+    {
+      "$ref": "#/$defs/eventSubtypeConsistency"
+    },
+    {
+      "$ref": "#/$defs/profileExportConsistency"
+    }
+  ],
+  "$defs": {
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+      "description": "UUIDv7 per RFC 9562"
+    },
+    "utcDateTime": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "Z$",
+      "description": "UTC RFC 3339 timestamp serialized with a trailing Z"
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_id",
+        "event_type",
+        "event_subtype",
+        "ts"
+      ],
+      "properties": {
+        "event_id": {
+          "$ref": "#/$defs/uuid"
+        },
+        "event_type": {
+          "type": "string",
+          "enum": [
+            "OBSERVATION_EVENT",
+            "INFERENCE_EVENT",
+            "FUSION_EVENT",
+            "STATE_EVENT",
+            "COMMAND_EVENT",
+            "SYSTEM_EVENT"
+          ]
+        },
+        "event_subtype": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic subtype. Must match the payload discriminator for the event type."
+        },
+        "ts": {
+          "$ref": "#/$defs/utcDateTime"
+        },
+        "t_publish": {
+          "$ref": "#/$defs/utcDateTime"
+        },
+        "t_receive": {
+          "$ref": "#/$defs/utcDateTime"
+        }
+      }
+    },
+    "eventSubtypeConsistency": {
+      "allOf": [
+        {
+          "if": {
+            "required": ["event"],
+            "properties": {
+              "event": {
+                "required": ["event_type"],
+                "properties": {
+                  "event_type": { "const": "OBSERVATION_EVENT" }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_subtype": {
+                    "enum": ["RF", "EO", "IR", "ACOUSTIC", "NETWORK"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["event"],
+            "properties": {
+              "event": {
+                "required": ["event_type"],
+                "properties": {
+                  "event_type": { "const": "INFERENCE_EVENT" }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_subtype": {
+                    "enum": ["CLASSIFICATION", "ASSOCIATION", "ANOMALY", "BEHAVIOR"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["event"],
+            "properties": {
+              "event": {
+                "required": ["event_type"],
+                "properties": {
+                  "event_type": { "const": "FUSION_EVENT" }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_subtype": { "const": "TRACK_FUSION" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["event"],
+            "properties": {
+              "event": {
+                "required": ["event_type"],
+                "properties": {
+                  "event_type": { "const": "STATE_EVENT" }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_subtype": { "const": "TRACK_STATE" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["event"],
+            "properties": {
+              "event": {
+                "required": ["event_type"],
+                "properties": {
+                  "event_type": { "const": "COMMAND_EVENT" }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_subtype": {
+                    "enum": [
+                      "GOTO",
+                      "ORBIT",
+                      "HOLD",
+                      "SEARCH_BOX",
+                      "RETURN_TO_BASE",
+                      "LAND",
+                      "LOITER",
+                      "SCAN_RF",
+                      "TRACK_TARGET",
+                      "CHANGE_SENSOR_MODE"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["event"],
+            "properties": {
+              "event": {
+                "required": ["event_type"],
+                "properties": {
+                  "event_type": { "const": "SYSTEM_EVENT" }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_subtype": {
+                    "enum": [
+                      "LINK_STATUS",
+                      "TIME_STATUS",
+                      "SCHEMA_VIOLATION",
+                      "TASK_ACK",
+                      "SENSOR_STATUS",
+                      "PLATFORM_STATUS"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        { "$ref": "#/$defs/subtypePayloadMatch/observation" },
+        { "$ref": "#/$defs/subtypePayloadMatch/inference" },
+        { "$ref": "#/$defs/subtypePayloadMatch/command" },
+        { "$ref": "#/$defs/subtypePayloadMatch/system" }
+      ]
+    },
+    "subtypePayloadMatch": {
+      "observation": {
+        "allOf": [
+          { "$ref": "#/$defs/subtypePayloadMatch/observationCase/RF" },
+          { "$ref": "#/$defs/subtypePayloadMatch/observationCase/EO" },
+          { "$ref": "#/$defs/subtypePayloadMatch/observationCase/IR" },
+          { "$ref": "#/$defs/subtypePayloadMatch/observationCase/ACOUSTIC" },
+          { "$ref": "#/$defs/subtypePayloadMatch/observationCase/NETWORK" }
+        ]
+      },
+      "observationCase": {
+        "RF": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/OBSERVATION_EVENT/RF" },
+          "then": { "properties": { "payload": { "properties": { "modality": { "const": "RF" } } } } }
+        },
+        "EO": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/OBSERVATION_EVENT/EO" },
+          "then": { "properties": { "payload": { "properties": { "modality": { "const": "EO" } } } } }
+        },
+        "IR": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/OBSERVATION_EVENT/IR" },
+          "then": { "properties": { "payload": { "properties": { "modality": { "const": "IR" } } } } }
+        },
+        "ACOUSTIC": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/OBSERVATION_EVENT/ACOUSTIC" },
+          "then": { "properties": { "payload": { "properties": { "modality": { "const": "ACOUSTIC" } } } } }
+        },
+        "NETWORK": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/OBSERVATION_EVENT/NETWORK" },
+          "then": { "properties": { "payload": { "properties": { "modality": { "const": "NETWORK" } } } } }
+        }
+      },
+      "inference": {
+        "allOf": [
+          { "$ref": "#/$defs/subtypePayloadMatch/inferenceCase/CLASSIFICATION" },
+          { "$ref": "#/$defs/subtypePayloadMatch/inferenceCase/ASSOCIATION" },
+          { "$ref": "#/$defs/subtypePayloadMatch/inferenceCase/ANOMALY" },
+          { "$ref": "#/$defs/subtypePayloadMatch/inferenceCase/BEHAVIOR" }
+        ]
+      },
+      "inferenceCase": {
+        "CLASSIFICATION": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/INFERENCE_EVENT/CLASSIFICATION" },
+          "then": { "properties": { "payload": { "properties": { "inference_type": { "const": "CLASSIFICATION" } } } } }
+        },
+        "ASSOCIATION": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/INFERENCE_EVENT/ASSOCIATION" },
+          "then": { "properties": { "payload": { "properties": { "inference_type": { "const": "ASSOCIATION" } } } } }
+        },
+        "ANOMALY": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/INFERENCE_EVENT/ANOMALY" },
+          "then": { "properties": { "payload": { "properties": { "inference_type": { "const": "ANOMALY" } } } } }
+        },
+        "BEHAVIOR": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/INFERENCE_EVENT/BEHAVIOR" },
+          "then": { "properties": { "payload": { "properties": { "inference_type": { "const": "BEHAVIOR" } } } } }
+        }
+      },
+      "command": {
+        "allOf": [
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/GOTO" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/ORBIT" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/HOLD" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/SEARCH_BOX" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/RETURN_TO_BASE" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/LAND" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/LOITER" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/SCAN_RF" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/TRACK_TARGET" },
+          { "$ref": "#/$defs/subtypePayloadMatch/commandCase/CHANGE_SENSOR_MODE" }
+        ]
+      },
+      "commandCase": {
+        "GOTO": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/GOTO" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "GOTO" } } } } }
+        },
+        "ORBIT": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/ORBIT" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "ORBIT" } } } } }
+        },
+        "HOLD": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/HOLD" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "HOLD" } } } } }
+        },
+        "SEARCH_BOX": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/SEARCH_BOX" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "SEARCH_BOX" } } } } }
+        },
+        "RETURN_TO_BASE": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/RETURN_TO_BASE" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "RETURN_TO_BASE" } } } } }
+        },
+        "LAND": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/LAND" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "LAND" } } } } }
+        },
+        "LOITER": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/LOITER" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "LOITER" } } } } }
+        },
+        "SCAN_RF": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/SCAN_RF" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "SCAN_RF" } } } } }
+        },
+        "TRACK_TARGET": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/TRACK_TARGET" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "TRACK_TARGET" } } } } }
+        },
+        "CHANGE_SENSOR_MODE": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/COMMAND_EVENT/CHANGE_SENSOR_MODE" },
+          "then": { "properties": { "payload": { "properties": { "task_type": { "const": "CHANGE_SENSOR_MODE" } } } } }
+        }
+      },
+      "system": {
+        "allOf": [
+          { "$ref": "#/$defs/subtypePayloadMatch/systemCase/LINK_STATUS" },
+          { "$ref": "#/$defs/subtypePayloadMatch/systemCase/TIME_STATUS" },
+          { "$ref": "#/$defs/subtypePayloadMatch/systemCase/SCHEMA_VIOLATION" },
+          { "$ref": "#/$defs/subtypePayloadMatch/systemCase/TASK_ACK" },
+          { "$ref": "#/$defs/subtypePayloadMatch/systemCase/SENSOR_STATUS" },
+          { "$ref": "#/$defs/subtypePayloadMatch/systemCase/PLATFORM_STATUS" }
+        ]
+      },
+      "systemCase": {
+        "LINK_STATUS": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/SYSTEM_EVENT/LINK_STATUS" },
+          "then": { "properties": { "payload": { "properties": { "system_type": { "const": "LINK_STATUS" } } } } }
+        },
+        "TIME_STATUS": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/SYSTEM_EVENT/TIME_STATUS" },
+          "then": { "properties": { "payload": { "properties": { "system_type": { "const": "TIME_STATUS" } } } } }
+        },
+        "SCHEMA_VIOLATION": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/SYSTEM_EVENT/SCHEMA_VIOLATION" },
+          "then": { "properties": { "payload": { "properties": { "system_type": { "const": "SCHEMA_VIOLATION" } } } } }
+        },
+        "TASK_ACK": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/SYSTEM_EVENT/TASK_ACK" },
+          "then": { "properties": { "payload": { "properties": { "system_type": { "const": "TASK_ACK" } } } } }
+        },
+        "SENSOR_STATUS": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/SYSTEM_EVENT/SENSOR_STATUS" },
+          "then": { "properties": { "payload": { "properties": { "system_type": { "const": "SENSOR_STATUS" } } } } }
+        },
+        "PLATFORM_STATUS": {
+          "if": { "$ref": "#/$defs/subtypePayloadMatch/eventSubtypeCase/SYSTEM_EVENT/PLATFORM_STATUS" },
+          "then": { "properties": { "payload": { "properties": { "system_type": { "const": "PLATFORM_STATUS" } } } } }
+        }
+      },
+      "eventSubtypeCase": {
+        "OBSERVATION_EVENT": {
+          "RF": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "OBSERVATION_EVENT" }, "event_subtype": { "const": "RF" } } } } },
+          "EO": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "OBSERVATION_EVENT" }, "event_subtype": { "const": "EO" } } } } },
+          "IR": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "OBSERVATION_EVENT" }, "event_subtype": { "const": "IR" } } } } },
+          "ACOUSTIC": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "OBSERVATION_EVENT" }, "event_subtype": { "const": "ACOUSTIC" } } } } },
+          "NETWORK": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "OBSERVATION_EVENT" }, "event_subtype": { "const": "NETWORK" } } } } }
+        },
+        "INFERENCE_EVENT": {
+          "CLASSIFICATION": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "INFERENCE_EVENT" }, "event_subtype": { "const": "CLASSIFICATION" } } } } },
+          "ASSOCIATION": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "INFERENCE_EVENT" }, "event_subtype": { "const": "ASSOCIATION" } } } } },
+          "ANOMALY": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "INFERENCE_EVENT" }, "event_subtype": { "const": "ANOMALY" } } } } },
+          "BEHAVIOR": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "INFERENCE_EVENT" }, "event_subtype": { "const": "BEHAVIOR" } } } } }
+        },
+        "COMMAND_EVENT": {
+          "GOTO": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "GOTO" } } } } },
+          "ORBIT": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "ORBIT" } } } } },
+          "HOLD": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "HOLD" } } } } },
+          "SEARCH_BOX": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "SEARCH_BOX" } } } } },
+          "RETURN_TO_BASE": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "RETURN_TO_BASE" } } } } },
+          "LAND": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "LAND" } } } } },
+          "LOITER": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "LOITER" } } } } },
+          "SCAN_RF": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "SCAN_RF" } } } } },
+          "TRACK_TARGET": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "TRACK_TARGET" } } } } },
+          "CHANGE_SENSOR_MODE": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "COMMAND_EVENT" }, "event_subtype": { "const": "CHANGE_SENSOR_MODE" } } } } }
+        },
+        "SYSTEM_EVENT": {
+          "LINK_STATUS": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "SYSTEM_EVENT" }, "event_subtype": { "const": "LINK_STATUS" } } } } },
+          "TIME_STATUS": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "SYSTEM_EVENT" }, "event_subtype": { "const": "TIME_STATUS" } } } } },
+          "SCHEMA_VIOLATION": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "SYSTEM_EVENT" }, "event_subtype": { "const": "SCHEMA_VIOLATION" } } } } },
+          "TASK_ACK": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "SYSTEM_EVENT" }, "event_subtype": { "const": "TASK_ACK" } } } } },
+          "SENSOR_STATUS": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "SYSTEM_EVENT" }, "event_subtype": { "const": "SENSOR_STATUS" } } } } },
+          "PLATFORM_STATUS": { "required": ["event"], "properties": { "event": { "required": ["event_type", "event_subtype"], "properties": { "event_type": { "const": "SYSTEM_EVENT" }, "event_subtype": { "const": "PLATFORM_STATUS" } } } } }
+        }
+      }
+    },
+    "profileExportConsistency": {
+      "allOf": [
+        {
+          "if": {
+            "required": ["profile"],
+            "properties": {
+              "profile": { "const": "L" }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_type": {
+                    "enum": ["STATE_EVENT", "SYSTEM_EVENT", "COMMAND_EVENT"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["profile"],
+            "properties": {
+              "profile": { "const": "M" }
+            }
+          },
+          "then": {
+            "properties": {
+              "event": {
+                "properties": {
+                  "event_type": {
+                    "enum": [
+                      "OBSERVATION_EVENT",
+                      "FUSION_EVENT",
+                      "STATE_EVENT",
+                      "SYSTEM_EVENT",
+                      "COMMAND_EVENT"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform_id",
+        "node_role",
+        "producer"
+      ],
+      "properties": {
+        "platform_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "node_role": {
+          "type": "string",
+          "enum": [
+            "EDGE",
+            "GATEWAY",
+            "APEX",
+            "DMZ",
+            "CLOUD"
+          ]
+        },
+        "producer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sensor_id": {
+          "type": ["string", "null"]
+        },
+        "sw_version": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "geo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lat", "lon", "alt_m"],
+      "properties": {
+        "lat": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "lon": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "alt_m": {
+          "type": "number"
+        },
+        "error_ellipse_m": {
+          "$ref": "#/$defs/error_ellipse"
+        }
+      }
+    },
+    "geo2d": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lat", "lon"],
+      "properties": {
+        "lat": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "lon": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        }
+      }
+    },
+    "bearing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["az_deg"],
+      "properties": {
+        "az_deg": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 360
+        },
+        "el_deg": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "frame": {
+          "type": "string",
+          "enum": ["TRUE_NORTH"],
+          "description": "Optional explicit assertion of the canonical bearing reference frame. Canonical bearings are always degrees true north; any other frame label is invalid so mislabeled sensor-native frames fail validation."
+        }
+      }
+    },
+    "timing_quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["time_source", "sync_state", "est_error_ms", "last_sync_ts"],
+      "properties": {
+        "time_source": {
+          "type": "string",
+          "enum": ["GPS_PPS", "GPS_NMEA", "NTP", "PTP", "MANUAL", "UNKNOWN"]
+        },
+        "sync_state": {
+          "type": "string",
+          "enum": ["LOCKED", "HOLDOVER", "UNSYNCED"]
+        },
+        "est_error_ms": { "type": "number", "minimum": 0 },
+        "last_sync_ts": { "$ref": "#/$defs/utcDateTime" }
+      }
+    },
+    "error_ellipse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["semi_major", "semi_minor", "orientation_deg"],
+      "properties": {
+        "semi_major": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Semi-major axis length in meters"
+        },
+        "semi_minor": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Semi-minor axis length in meters"
+        },
+        "orientation_deg": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 360,
+          "description": "Orientation of the semi-major axis in degrees from true north"
+        },
+        "probability": {
+          "type": "string",
+          "enum": ["1_SIGMA", "CEP", "CE_90", "CE_95"],
+          "description": "Probability level the ellipse represents"
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "measurement_error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value", "unit", "metric"],
+          "properties": {
+            "value": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Measurement error magnitude"
+            },
+            "unit": {
+              "type": "string",
+              "enum": ["m", "deg", "hz", "db", "dbm", "ms", "px"],
+              "description": "Explicit unit for measurement_error.value"
+            },
+            "metric": {
+              "type": "string",
+              "enum": ["1_SIGMA", "CEP", "CE_90", "CE_95", "MAX_BOUND"],
+              "description": "How measurement_error.value is expressed"
+            }
+          },
+          "description": "Self-describing measurement error with explicit unit and metric"
+        },
+        "error_metric": false,
+        "snr_db": {
+          "type": "number",
+          "description": "Signal-to-noise ratio in dB"
+        },
+        "calibration_state": {
+          "type": "string",
+          "enum": ["CALIBRATED", "UNCALIBRATED", "DEGRADED"],
+          "description": "Sensor calibration status at time of observation"
+        },
+        "geo_status": {
+          "type": "string",
+          "enum": ["AVAILABLE", "UNAVAILABLE", "ESTIMATED", "STALE", "CONFIGURED"],
+          "description": "Provenance of the geo position. UNAVAILABLE means no GPS fix. CONFIGURED means position injected from config (GPS-denied). ESTIMATED means derived from dead reckoning or other indirect source."
+        },
+        "bearing_frame": {
+          "type": "string",
+          "enum": ["TRUE_NORTH"],
+          "description": "Frame provenance assertion for the canonical bearing. Describes the canonical bearing only and permits exactly TRUE_NORTH; raw sensor-native angles carry their frame in explicitly named payload-scoped fields instead."
+        },
+        "heading_source": {
+          "type": "string",
+          "description": "Heading reference used for true-north compensation, e.g. AHRS_TRUE, GPS_COURSE, FIXED_MOUNT_SURVEYED."
+        }
+      }
+    },
+    "orbit_geometry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern", "radius_m"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "enum": ["circle", "figure_8", "racetrack", "arc"],
+          "description": "Orbit pattern type"
+        },
+        "radius_m": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Orbit radius in meters"
+        },
+        "direction": {
+          "type": "string",
+          "enum": ["CW", "CCW"],
+          "description": "Orbit direction (clockwise or counter-clockwise)"
+        },
+        "lobe_separation_m": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Distance between lobes for figure-8 patterns"
+        },
+        "arc_degrees": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 360,
+          "description": "Arc sweep in degrees for arc patterns"
+        }
+      }
+    },
+    "loiter_geometry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "enum": ["circle", "racetrack", "station_keep"]
+        },
+        "radius_m": {
+          "type": "number",
+          "minimum": 0
+        },
+        "direction": {
+          "type": "string",
+          "enum": ["CW", "CCW"]
+        }
+      }
+    },
+    "search_box_geometry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bbox"],
+          "properties": {
+            "bbox": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["min_lat", "min_lon", "max_lat", "max_lon"],
+              "properties": {
+                "min_lat": { "type": "number", "minimum": -90, "maximum": 90 },
+                "min_lon": { "type": "number", "minimum": -180, "maximum": 180 },
+                "max_lat": { "type": "number", "minimum": -90, "maximum": 90 },
+                "max_lon": { "type": "number", "minimum": -180, "maximum": 180 }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["polygon"],
+          "properties": {
+            "polygon": {
+              "type": "array",
+              "minItems": 4,
+              "items": { "$ref": "#/$defs/geo2d" }
+            }
+          }
+        }
+      ]
+    },
+    "data_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref_id"],
+      "dependentRequired": {
+        "t_start": ["t_end"],
+        "t_end": ["t_start"]
+      },
+      "properties": {
+        "ref_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique identifier within the referenced store"
+        },
+        "store": {
+          "type": "string",
+          "description": "Storage location (e.g. local, gateway-cache, s3-bucket:region/path)"
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["RAW", "VECTOR", "FILE"],
+          "description": "Data kind"
+        },
+        "format": {
+          "type": "string",
+          "description": "Data format (e.g. iq, wav, mp4, pcap, npy)"
+        },
+        "hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-fA-F]{64}$",
+          "description": "Canonical SHA-256 content hash in the form sha256:<64 hex chars>"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "t_start": {
+          "$ref": "#/$defs/utcDateTime"
+        },
+        "t_end": {
+          "$ref": "#/$defs/utcDateTime"
+        }
+      }
+    },
+    "ObservationPayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["modality", "features"],
+      "dependentRequired": {
+        "t_start": ["t_end"],
+        "t_end": ["t_start"]
+      },
+      "properties": {
+        "modality": {
+          "type": "string",
+          "enum": [
+            "RF",
+            "EO",
+            "IR",
+            "ACOUSTIC",
+            "NETWORK"
+          ]
+        },
+        "geo": {
+          "$ref": "#/$defs/geo"
+        },
+        "bearing": {
+          "$ref": "#/$defs/bearing"
+        },
+        "features": {
+          "type": "object",
+          "properties": {
+            "track_id": false,
+            "entity_class": false,
+            "classification": false,
+            "class_name": false,
+            "label": false,
+            "confidence": false
+          }
+        },
+        "quality": {
+          "$ref": "#/$defs/quality"
+        },
+        "timing_quality": {
+          "$ref": "#/$defs/timing_quality"
+        },
+        "t_start": {
+          "$ref": "#/$defs/utcDateTime"
+        },
+        "t_end": {
+          "$ref": "#/$defs/utcDateTime"
+        },
+        "data_ref": {
+          "$ref": "#/$defs/data_ref"
+        },
+        "data_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/data_ref" }
+        },
+        "track_id": false,
+        "entity_class": false,
+        "classification": false,
+        "class_name": false,
+        "label": false,
+        "confidence": false
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": ["data_ref", "data_refs"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "modality": { "const": "RF" }
+            }
+          },
+          "then": {
+            "properties": {
+              "features": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "center_freq_hz",
+                  "bandwidth_hz",
+                  "power_dbm"
+                ],
+                "properties": {
+                  "center_freq_hz": { "type": "number" },
+                  "bandwidth_hz": { "type": "number" },
+                  "power_dbm": { "type": "number" },
+                  "signature_hash": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "modality": { "const": "EO" }
+            }
+          },
+          "then": {
+            "properties": {
+              "features": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "class_name": false,
+                  "confidence": false,
+                  "classification": false,
+                  "label": false,
+                  "bbox": false,
+                  "roi_px": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["x", "y", "w", "h"],
+                    "description": "Raw image region of interest or crop in pixels; not a detected object box",
+                    "properties": {
+                      "x": { "type": "number", "minimum": 0 },
+                      "y": { "type": "number", "minimum": 0 },
+                      "w": { "type": "number", "exclusiveMinimum": 0 },
+                      "h": { "type": "number", "exclusiveMinimum": 0 }
+                    }
+                  },
+                  "fov_deg": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 360,
+                    "description": "Camera field of view in degrees"
+                  },
+                  "resolution_px": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["width", "height"],
+                    "description": "Image resolution in pixels",
+                    "properties": {
+                      "width": { "type": "integer", "minimum": 1 },
+                      "height": { "type": "integer", "minimum": 1 }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "modality": { "const": "IR" }
+            }
+          },
+          "then": {
+            "properties": {
+              "features": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["band"],
+                "properties": {
+                  "band": {
+                    "type": "string",
+                    "enum": ["MWIR", "LWIR", "SWIR", "NIR"],
+                    "description": "IR spectral band"
+                  },
+                  "temperature_k": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Measured temperature in Kelvin"
+                  },
+                  "emissivity": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": "Target emissivity estimate"
+                  },
+                  "class_name": false,
+                  "confidence": false,
+                  "classification": false,
+                  "label": false
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "modality": { "const": "ACOUSTIC" }
+            }
+          },
+          "then": {
+            "properties": {
+              "features": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "center_freq_hz",
+                  "spl_db"
+                ],
+                "properties": {
+                  "center_freq_hz": {
+                    "type": "number",
+                    "description": "Dominant frequency in Hz"
+                  },
+                  "spl_db": {
+                    "type": "number",
+                    "description": "Sound pressure level in dB SPL re 20 uPa"
+                  },
+                  "duration_ms": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Duration of the acoustic event in milliseconds"
+                  },
+                  "bandwidth_hz": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Bandwidth of the acoustic signal in Hz"
+                  },
+                  "spectral_centroid_hz": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Spectral centroid in Hz"
+                  },
+                  "harmonic_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Measured harmonic count"
+                  },
+                  "signature_hash": {
+                    "type": "string",
+                    "description": "Hash of measured acoustic signature or feature vector"
+                  },
+                  "power_db": false,
+                  "source_type": false,
+                  "class_name": false,
+                  "confidence": false,
+                  "classification": false,
+                  "label": false
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "modality": { "const": "NETWORK" }
+            }
+          },
+          "then": {
+            "properties": {
+              "features": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["protocol"],
+                "properties": {
+                  "protocol": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Network protocol (e.g. TCP, UDP, ICMP, HTTP, DNS, BLE, WiFi)"
+                  },
+                  "source_addr": {
+                    "type": "string",
+                    "description": "Source address (IP, MAC, or other identifier)"
+                  },
+                  "dest_addr": {
+                    "type": "string",
+                    "description": "Destination address"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "description": "Port number"
+                  },
+                  "payload_size_bytes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Captured payload size in bytes"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "InferencePayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "inference_type",
+        "claim",
+        "model",
+        "based_on"
+      ],
+      "properties": {
+        "inference_type": {
+          "type": "string",
+          "enum": [
+            "CLASSIFICATION",
+            "ASSOCIATION",
+            "ANOMALY",
+            "BEHAVIOR"
+          ]
+        },
+        "claim": {
+          "type": "object",
+          "properties": {
+            "track_id": false,
+            "members": false,
+            "estimated_state": false
+          }
+        },
+        "track_id": false,
+        "members": false,
+        "estimated_state": false,
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "version": { "type": "string", "minLength": 1 }
+          }
+        },
+        "based_on": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/uuid" }
+        },
+        "timing_quality": {
+          "$ref": "#/$defs/timing_quality"
+        }
+      }
+    },
+    "FusionPayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "track_id",
+        "members",
+        "stability",
+        "last_seen_ts"
+      ],
+      "properties": {
+        "track_id": { "type": "string", "minLength": 1 },
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/uuid" }
+        },
+        "estimated_state": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "geo": { "$ref": "#/$defs/geo" },
+            "bearing": { "$ref": "#/$defs/bearing" },
+            "heading_deg": { "type": "number", "minimum": 0, "maximum": 360 },
+            "speed_mps": { "type": "number", "minimum": 0 }
+          }
+        },
+        "stability": { "type": "number", "minimum": 0, "maximum": 1 },
+        "last_seen_ts": { "$ref": "#/$defs/utcDateTime" },
+        "timing_quality": { "$ref": "#/$defs/timing_quality" }
+      }
+    },
+    "TrackStatePayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["track_id", "geo", "valid_for_ms"],
+      "properties": {
+        "track_id": { "type": "string", "minLength": 1 },
+        "geo": { "$ref": "#/$defs/geo" },
+        "class": { "type": "string" },
+        "source_summary": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "heading_deg": { "type": "number", "minimum": 0, "maximum": 360 },
+        "speed_mps": { "type": "number", "minimum": 0 },
+        "valid_for_ms": { "type": "integer", "minimum": 1 },
+        "timing_quality": { "$ref": "#/$defs/timing_quality" },
+        "extensions": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "features": false,
+            "raw_features": false,
+            "modality": false,
+            "measurement": false,
+            "measurements": false,
+            "t_start": false,
+            "t_end": false,
+            "data_ref": false,
+            "data_refs": false
+          }
+        },
+        "features": false,
+        "raw_features": false,
+        "modality": false,
+        "measurement": false,
+        "measurements": false,
+        "t_start": false,
+        "t_end": false,
+        "data_ref": false,
+        "data_refs": false
+      }
+    },
+    "CommandPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task_id",
+        "task_type",
+        "valid_for_ms",
+        "requires_deconfliction"
+      ],
+      "properties": {
+        "task_id": { "type": "string", "minLength": 1 },
+        "task_type": {
+          "type": "string",
+          "enum": [
+            "GOTO",
+            "ORBIT",
+            "HOLD",
+            "SEARCH_BOX",
+            "RETURN_TO_BASE",
+            "LAND",
+            "LOITER",
+            "SCAN_RF",
+            "TRACK_TARGET",
+            "CHANGE_SENSOR_MODE"
+          ]
+        },
+        "target_geo": { "$ref": "#/$defs/geo2d" },
+        "geometry": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "alt_m": false,
+            "altitude_m": false,
+            "alt_hae_m": false,
+            "alt_msl_m": false,
+            "agl_m": false,
+            "target_alt_m": false,
+            "altitude": false,
+            "target_altitude": false
+          }
+        },
+        "valid_from_ts": { "$ref": "#/$defs/utcDateTime" },
+        "valid_for_ms": { "type": "integer", "minimum": 1 },
+        "priority": {
+          "type": "string",
+          "enum": ["LOW", "MED", "HIGH"]
+        },
+        "requires_deconfliction": { "const": true },
+        "sensor_id": { "type": "string", "minLength": 1 },
+        "sensor_mode": { "type": "string", "minLength": 1 },
+        "target_track_id": { "type": "string", "minLength": 1 },
+        "freq_range_hz": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min", "max"],
+          "properties": {
+            "min": { "type": "number", "minimum": 0 },
+            "max": { "type": "number", "minimum": 0 }
+          }
+        },
+        "dwell_ms": { "type": "integer", "minimum": 1 },
+        "step_hz": { "type": "number", "minimum": 0 },
+        "timing_quality": { "$ref": "#/$defs/timing_quality" },
+        "extensions": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "alt_m": false,
+            "altitude_m": false,
+            "alt_hae_m": false,
+            "alt_msl_m": false,
+            "agl_m": false,
+            "target_alt_m": false,
+            "altitude": false,
+            "target_altitude": false
+          }
+        },
+        "alt_m": false,
+        "altitude_m": false,
+        "alt_hae_m": false,
+        "alt_msl_m": false,
+        "agl_m": false,
+        "target_alt_m": false,
+        "altitude": false,
+        "target_altitude": false
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "GOTO" }
+            }
+          },
+          "then": {
+            "required": ["target_geo"],
+            "properties": {
+              "geometry": false
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "ORBIT" }
+            }
+          },
+          "then": {
+            "required": ["target_geo", "geometry"],
+            "properties": {
+              "geometry": { "$ref": "#/$defs/orbit_geometry" }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "HOLD" }
+            }
+          },
+          "then": {
+            "properties": {
+              "geometry": false
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "SEARCH_BOX" }
+            }
+          },
+          "then": {
+            "required": ["geometry"],
+            "properties": {
+              "target_geo": false,
+              "geometry": { "$ref": "#/$defs/search_box_geometry" }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "RETURN_TO_BASE" }
+            }
+          },
+          "then": {
+            "properties": {
+              "geometry": false
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "LAND" }
+            }
+          },
+          "then": {
+            "properties": {
+              "geometry": false
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "LOITER" }
+            }
+          },
+          "then": {
+            "anyOf": [
+              { "required": ["target_geo"] },
+              { "required": ["geometry"] }
+            ],
+            "properties": {
+              "geometry": { "$ref": "#/$defs/loiter_geometry" }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "SCAN_RF" }
+            }
+          },
+          "then": {
+            "required": ["sensor_id", "freq_range_hz", "dwell_ms"],
+            "properties": {
+              "target_geo": false,
+              "geometry": false,
+              "target_track_id": false
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "TRACK_TARGET" }
+            }
+          },
+          "then": {
+            "required": ["target_track_id"],
+            "properties": {
+              "target_geo": false,
+              "geometry": false
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["task_type"],
+            "properties": {
+              "task_type": { "const": "CHANGE_SENSOR_MODE" }
+            }
+          },
+          "then": {
+            "required": ["sensor_id", "sensor_mode"],
+            "properties": {
+              "target_geo": false,
+              "geometry": false,
+              "target_track_id": false
+            }
+          }
+        }
+      ]
+    },
+    "SystemPayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["system_type", "state"],
+      "properties": {
+        "system_type": {
+          "type": "string",
+          "minLength": 1,
+          "enum": [
+            "LINK_STATUS",
+            "TIME_STATUS",
+            "SCHEMA_VIOLATION",
+            "TASK_ACK",
+            "SENSOR_STATUS",
+            "PLATFORM_STATUS"
+          ]
+        },
+        "state": { "type": "string", "minLength": 1 },
+        "metrics": { "type": "object" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "TIME_STATUS" }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["LOCKED", "HOLDOVER", "UNSYNCED", "UP", "DEGRADED", "DOWN"]
+              },
+              "metrics": {
+                "type": "object",
+                "required": ["time_source", "sync_state", "est_error_ms", "last_sync_ts"],
+                "properties": {
+                  "time_source": {
+                    "type": "string",
+                    "enum": ["GPS_PPS", "GPS_NMEA", "NTP", "PTP", "MANUAL", "UNKNOWN"]
+                  },
+                  "sync_state": {
+                    "type": "string",
+                    "enum": ["LOCKED", "HOLDOVER", "UNSYNCED"]
+                  },
+                  "est_error_ms": { "type": "number", "minimum": 0 },
+                  "last_sync_ts": { "$ref": "#/$defs/utcDateTime" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "LINK_STATUS" }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["UP", "DEGRADED", "DOWN", "UNKNOWN"]
+              },
+              "metrics": {
+                "type": "object",
+                "required": ["link_id", "latency_ms", "packet_loss_pct", "throughput_bps"],
+                "properties": {
+                  "link_id": { "type": "string", "minLength": 1 },
+                  "interface": { "type": "string", "minLength": 1 },
+                  "latency_ms": { "type": "number", "minimum": 0 },
+                  "packet_loss_pct": { "type": "number", "minimum": 0, "maximum": 100 },
+                  "throughput_bps": { "type": "number", "minimum": 0 },
+                  "rssi_dbm": { "type": "number" },
+                  "snr_db": { "type": "number" },
+                  "jitter_ms": { "type": "number", "minimum": 0 },
+                  "reason_code": {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": [
+                      "LINK_LOSS", "LOW_RSSI", "HIGH_LATENCY",
+                      "HIGH_PACKET_LOSS", "LOW_THROUGHPUT", "INTERFERENCE",
+                      "JAMMED", "BACKHAUL_DOWN", "NO_ROUTE",
+                      "CONFIG_ERROR", "POWER_SAVE", "UNKNOWN_CAUSE"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "LINK_STATUS" },
+              "state": { "enum": ["DEGRADED", "DOWN"] }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "metrics": {
+                "type": "object",
+                "required": ["reason_code"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "SCHEMA_VIOLATION" }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "metrics": {
+                "type": "object",
+                "required": ["reason_code", "original_event_id"],
+                "properties": {
+                  "reason_code": {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": [
+                      "SCHEMA_INVALID",
+                      "VERSION_SEMANTICS_MISMATCH",
+                      "EVENT_SUBTYPE_MISMATCH",
+                      "EVENT_TYPE_NOT_ALLOWED_FOR_ROLE",
+                      "EVENT_TYPE_NOT_ALLOWED_FOR_PROFILE",
+                      "COMMAND_NOT_DECONFLICTED",
+                      "COMMAND_HAS_ALTITUDE",
+                      "INVALID_COMMAND_GEOMETRY",
+                      "COMMAND_TASK_TYPE_INVALID",
+                      "OBSERVATION_HAS_IDENTITY",
+                      "OBSERVATION_HAS_CLASSIFICATION",
+                      "INFERENCE_HAS_TRACK_ID",
+                      "INFERENCE_HAS_FUSION_STATE",
+                      "STATE_HAS_RAW_FEATURES",
+                      "INVALID_QUALITY_UNITS",
+                      "INVALID_QUALITY_BEARING_FRAME",
+                      "INVALID_QUALITY_HEADING_SOURCE",
+                      "INVALID_MODALITY_FEATURES",
+                      "INVALID_GEO_FIELD",
+                      "GEO_ZERO_FILL_SUSPECTED",
+                      "ENCODING_UNSUPPORTED",
+                      "BEARING_FRAME_UNLABELED",
+                      "NON_FINITE_CONFIDENCE",
+                      "INVALID_TIME_FORMAT",
+                      "RF_WINDOW_PAIRING_INVALID",
+                      "RF_WINDOW_MIDPOINT_INVALID",
+                      "LINEAGE_MISMATCH",
+                      "LINEAGE_PAYLOAD_BASED_ON_NOT_SUBSET",
+                      "LINEAGE_FUSION_MEMBERS_NOT_IN_BASED_ON",
+                      "LINEAGE_PARENT_UNRESOLVED",
+                      "LINEAGE_PARENT_TYPE_INVALID",
+                      "SCHEMA_VIOLATION_MISSING_REASON_CODE",
+                      "SCHEMA_VIOLATION_MISSING_ORIGINAL_EVENT_ID",
+                      "SCHEMA_VIOLATION_INVALID_REASON_CODE",
+                      "TASK_ACK_MISSING_TASK_ID",
+                      "TASK_ACK_MISSING_REQUIRED_FIELD",
+                      "TASK_ACK_MISSING_ORIGINAL_EVENT_ID",
+                      "TASK_ACK_MISSING_REASON_CODE",
+                      "TASK_ACK_INVALID_STATE",
+                      "TASK_ACK_INVALID_REASON_CODE",
+                      "LINK_STATUS_MISSING_REQUIRED_FIELD",
+                      "LINK_STATUS_INVALID_STATE",
+                      "LINK_STATUS_MISSING_REASON_CODE",
+                      "LINK_STATUS_INVALID_REASON_CODE",
+                      "SENSOR_STATUS_STATE_MISMATCH",
+                      "PLATFORM_STATUS_POWER_MISSING",
+                      "PRODUCER_NOT_ALLOWED",
+                      "PROFILE_MISMATCH",
+                      "TIMING_STATUS_MISSING",
+                      "TIMING_STATUS_STALE",
+                      "TIMING_STATUS_AGE_NEGATIVE",
+                      "TIMING_STATUS_UNSYNCED",
+                      "TIMING_STATUS_HOLDOVER_NON_MONOTONIC",
+                      "RF_WINDOW_MIDPOINT_MISMATCH",
+                      "EVENT_DUPLICATE",
+                      "TASK_DUPLICATE",
+                      "TASK_ACK_DUPLICATE"
+                    ]
+                  },
+                  "original_event_id": { "type": "string", "minLength": 1 },
+                  "path": { "type": "string" },
+                  "error": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "TASK_ACK" }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "RECEIVED", "ACCEPTED", "REJECTED", "EXECUTING",
+                  "COMPLETED", "FAILED", "CANCELLED", "EXPIRED",
+                  "DUPLICATE_IGNORED"
+                ]
+              },
+              "metrics": {
+                "type": "object",
+                "required": ["task_id", "original_event_id"],
+                "properties": {
+                  "task_id": { "type": "string", "minLength": 1 },
+                  "original_event_id": { "type": "string", "minLength": 1 },
+                  "reason_code": {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": [
+                      "SCHEMA_INVALID",
+                      "EVENT_TYPE_NOT_ALLOWED_FOR_ROLE",
+                      "EVENT_TYPE_NOT_ALLOWED_FOR_PROFILE",
+                      "PRODUCER_NOT_ALLOWED",
+                      "COMMAND_NOT_DECONFLICTED",
+                      "COMMAND_HAS_ALTITUDE",
+                      "TASK_DUPLICATE",
+                      "TASK_EXPIRED",
+                      "TASK_CANCELLED",
+                      "TASK_FAILED",
+                      "TASK_ABORTED",
+                      "TASK_REJECTED"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "TASK_ACK" },
+              "state": {
+                "enum": ["REJECTED", "FAILED", "CANCELLED", "EXPIRED", "DUPLICATE_IGNORED"]
+              }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "metrics": {
+                "type": "object",
+                "required": ["reason_code"]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "SENSOR_STATUS" }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["ACTIVE", "DEGRADED", "OFFLINE", "CALIBRATING", "UNKNOWN"]
+              },
+              "metrics": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["sensor_id"],
+                "properties": {
+                  "sensor_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Identifier of the sensor being reported"
+                  },
+                  "operational_state": false,
+                  "sensor_type": {
+                    "type": "string",
+                    "description": "Sensor type or model identifier"
+                  },
+                  "modality": {
+                    "type": "string",
+                    "enum": ["RF", "EO", "IR", "ACOUSTIC", "NETWORK", "RADAR", "LIDAR", "MAGNETIC", "SEISMIC", "CYBER", "SIGINT"],
+                    "description": "Sensing modality"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "description": "Current sensor mode (e.g. SCAN, TRACK, DF, STARE)"
+                  },
+                  "freq_range_hz": {
+                    "type": "object",
+                    "description": "Sensor frequency range",
+                    "properties": {
+                      "min": { "type": "number" },
+                      "max": { "type": "number" }
+                    }
+                  },
+                  "fov_deg": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 360,
+                    "description": "Current field of view in degrees"
+                  },
+                  "detection_range_m": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Effective detection range in meters"
+                  },
+                  "bearing_accuracy_deg": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Nominal bearing accuracy in degrees (1-sigma)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "system_type": { "const": "PLATFORM_STATUS" }
+            }
+          },
+          "then": {
+            "required": ["metrics"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["NOMINAL", "CAUTION", "WARNING", "CRITICAL", "UNKNOWN"]
+              },
+              "metrics": {
+                "type": "object",
+                "additionalProperties": true,
+                "anyOf": [
+                  { "required": ["battery_pct"] },
+                  { "required": ["fuel_remaining_pct"] },
+                  { "required": ["endurance_remaining_ms"] },
+                  { "required": ["power_state"] }
+                ],
+                "properties": {
+                  "battery_pct": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Battery remaining as percentage"
+                  },
+                  "battery_voltage": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Battery voltage in volts"
+                  },
+                  "endurance_remaining_sec": false,
+                  "endurance_remaining_ms": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Estimated remaining flight/operation time in milliseconds"
+                  },
+                  "power_state": {
+                    "type": "string",
+                    "enum": ["NOMINAL", "LOW_POWER", "EXTERNAL_POWER", "BATTERY", "FUEL", "UNKNOWN"],
+                    "description": "Current platform power source or power condition"
+                  },
+                  "flight_mode": {
+                    "type": "string",
+                    "description": "Current flight/operation mode (e.g. AUTO, GUIDED, LOITER, RTL, MANUAL)"
+                  },
+                  "fuel_remaining_pct": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Fuel remaining as percentage (for non-electric platforms)"
+                  },
+                  "cpu_temp_c": {
+                    "type": "number",
+                    "description": "Onboard CPU temperature in Celsius"
+                  },
+                  "disk_usage_pct": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Disk usage as percentage"
+                  },
+                  "memory_usage_pct": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Memory usage as percentage"
+                  },
+                  "platform_type": {
+                    "type": "string",
+                    "enum": ["FIXED_WING", "MULTIROTOR", "GROUND", "MARITIME", "FIXED", "HANDHELD"],
+                    "description": "Platform form factor"
+                  },
+                  "retaskable": {
+                    "type": "boolean",
+                    "description": "Whether this platform accepts retasking commands"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["based_on"],
+      "properties": {
+        "based_on": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/uuid" }
+        },
+        "transform": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  }
+}

--- a/shared_files/aryaos/aryaos-spectrum-survey
+++ b/shared_files/aryaos/aryaos-spectrum-survey
@@ -243,6 +243,147 @@ def analyze_capture(m, iq_frames, sample_rate, nfft, np, extra=None):
     return result
 
 
+ZMETA_VERSION = "1.1.0"
+
+
+def _uuid7(now_ms: int, rand_bytes: bytes) -> str:
+    """RFC 9562 UUIDv7: 48-bit millisecond timestamp, then random.
+
+    ZMeta requires v7 specifically -- its schema pattern pins the version nibble
+    to 7 and the variant to [89ab] -- because v7 sorts by creation time, so an
+    event store can range-scan a time window without a secondary index. uuid4
+    validates as a UUID and fails that pattern, so it is not interchangeable.
+
+    Not in the standard library as of 3.13, hence this.
+    """
+    ts = now_ms & ((1 << 48) - 1)
+    b = bytearray(16)
+    b[0:6] = ts.to_bytes(6, "big")
+    b[6:16] = rand_bytes[:10]
+    b[6] = 0x70 | (b[6] & 0x0F)  # version 7
+    b[8] = 0x80 | (b[8] & 0x3F)  # variant 10xx
+    h = b.hex()
+    return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+
+def zmeta_event(band, result, source, now_ms, rand_bytes, dwell_s):
+    """One surveyed band -> a ZMeta OBSERVATION_EVENT (schema 1.1.0).
+
+    Why OBSERVATION and not INFERENCE: every field here is a measured fact about
+    the spectrum. Nothing claims what is transmitting. ZMeta draws exactly that
+    line -- OBSERVATION_EVENT is "measured facts", INFERENCE_EVENT is "analytic
+    claims" -- which is the distinction this tool has been careful about from the
+    start, so the mapping is honest rather than convenient.
+
+    The payload deliberately mirrors ZMeta's existing SCAN_RF command vocabulary
+    (`freq_range_hz`, `dwell_ms`, `sensor_id`). ZMeta can already ASK for an RF
+    scan; the SIGINT observation modality that would carry the ANSWER is still
+    `status: reserved` in its extension registry, with no feature contract. Using
+    the command's own field names means a SCAN_RF task and this result speak one
+    vocabulary instead of two.
+
+    `confidence` is NOT set. ZMeta's confidence is a claim-strength for an
+    inference, and occupancy is not a claim -- asserting 0.29 confidence because
+    a band was 29% occupied would be a category error.
+    """
+    # modality is RF, not SIGINT. ZMeta's ObservationPayload pins modality to
+    # {RF, EO, IR, ACOUSTIC, NETWORK}; SIGINT exists in its extension registry
+    # but as a RESERVED modality name with no feature contract yet, so RF is
+    # what a spectrum measurement is allowed to claim today.
+    #
+    # The measurements live under `features`, which ZMeta requires and which it
+    # FORBIDS from carrying track_id, entity_class, classification, class_name,
+    # label or confidence. That is the observation/inference split enforced by
+    # the schema rather than by convention -- and it happens to be the same rule
+    # this tool already held itself to, so nothing had to be dropped to comply.
+    features = {
+        "band": band["name"],
+        "band_label": band["label"],
+        # SCAN_RF's own field names and units, so a command and its result speak
+        # one vocabulary.
+        "freq_range_hz": [
+            band["center"] - band["span"] / 2.0,
+            band["center"] + band["span"] / 2.0,
+        ],
+        "dwell_ms": int(dwell_s * 1000),
+        # ZMeta's RF feature contract names: center_freq_hz and bandwidth_hz.
+        "center_freq_hz": band["center"],
+        "bandwidth_hz": band["span"],
+        "tuned_hz": result.get("tuned_hz"),
+        "noise_floor_dbfs": result.get("noise_floor_dbfs"),
+        "occupancy_pct": result.get("occupancy_pct"),
+        "excursion_threshold_db": EXCURSION_DB,
+        # "bursty" / "continuous" / "both" / "none" describes the SHAPE of the
+        # energy, not what produced it, so it is a measurement and not a label.
+        "detection": result.get("detection", "none"),
+        "occupied": bool(result.get("occupied")),
+    }
+    if result.get("carrier_over_noise_db"):
+        features["carrier_over_noise_db"] = result["carrier_over_noise_db"]
+        if result.get("carrier_offset_hz") is not None and result.get("tuned_hz"):
+            features["carrier_hz"] = result["tuned_hz"] + result["carrier_offset_hz"]
+
+    # NOT SET: features.power_dbm.
+    #
+    # ZMeta's RF feature contract requires center_freq_hz, bandwidth_hz AND
+    # power_dbm. The first two are exact. power_dbm is ABSOLUTE power, and every
+    # level this tool measures is dBFS -- decibels relative to the receiver's own
+    # full scale. Converting dBFS to dBm needs the receiver's calibrated gain,
+    # noise figure and any front-end loss, none of which an uncalibrated SDR
+    # reports. Measured on a LimeSDR Mini v2: the same signal moved the reported
+    # floor from -31.9 to -13.4 dBFS purely by changing the gain setting, which
+    # is exactly what "not absolute" means.
+    #
+    # So power_dbm is omitted rather than fabricated, and the event does NOT
+    # currently satisfy the RF contract. That is a deliberate, documented gap:
+    # emitting a plausible dBm number would be the unit inference ZMeta's own
+    # semantics contract forbids, and it would silently poison anything
+    # downstream that reasoned about signal strength.
+    #
+    # The honest value goes in the quality block instead, and the spec gap is
+    # written up for upstream: an uncalibrated receiver cannot produce a
+    # conformant RF observation today.
+    payload = {"modality": "RF", "features": features}
+
+    # STRUCTURED_QUALITY_BLOCK (payload.quality) is ZMeta's place for calibration
+    # and signal-quality metadata. Clipping belongs here and nowhere else: a
+    # clipped capture inflates occupancy, so a consumer must be able to see that
+    # the measurement is suspect without re-deriving it.
+    payload["quality"] = {
+        "clipped": bool(result.get("clipped")),
+        "clipped_pct": result.get("clipped_pct", 0.0),
+        "calibrated": False,
+        "measurement_note": (
+            "dBFS is receiver-relative, not absolute power; no calibration applied"
+        ),
+    }
+
+    return {
+        "zmeta_version": ZMETA_VERSION,
+        "event": {
+            "event_id": _uuid7(now_ms, rand_bytes),
+            "event_type": "OBSERVATION_EVENT",
+            # For an OBSERVATION_EVENT, ZMeta closes event_subtype to the same
+            # enum as modality: {RF, EO, IR, ACOUSTIC, NETWORK}. So it is "RF",
+            # not a descriptive name of our choosing -- and the SIGINT modality
+            # reserved in the extension registry has no way into the schema at
+            # all yet, since neither the subtype nor the modality enum admits it.
+            "event_subtype": "RF",
+            "ts": _rfc3339(now_ms),
+        },
+        "source": source,
+        "payload": payload,
+    }
+
+
+def _rfc3339(now_ms: int) -> str:
+    """UTC RFC 3339 with a trailing Z, which ZMeta's schema requires."""
+    import datetime
+
+    dt = datetime.datetime.fromtimestamp(now_ms / 1000.0, datetime.timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(
         description="Measure band occupancy with a SoapySDR receiver.",
@@ -255,6 +396,11 @@ def main(argv=None):
     ap.add_argument("--sample-rate", type=float, default=4e6, help="Sample rate in Hz (default 4e6).")
     ap.add_argument("--bands", default="", help="Comma-separated band names to sweep (default: all).")
     ap.add_argument("--json", action="store_true", help="Emit JSON only.")
+    ap.add_argument(
+        "--zmeta",
+        action="store_true",
+        help="Emit ZMeta 1.1.0 OBSERVATION_EVENTs (newline-delimited JSON), one per band.",
+    )
     args = ap.parse_args(argv)
 
     try:
@@ -303,12 +449,39 @@ def main(argv=None):
         "bands": [],
     }
 
+    zmeta_source = None
+    if args.zmeta:
+        import os
+        import socket
+
+        zmeta_source = {
+            "platform_id": socket.gethostname(),
+            # EDGE: this runs on the sensor itself, not on a gateway or in a
+            # datacentre, which is what ZMeta's node_role is distinguishing.
+            "node_role": "EDGE",
+            "producer": "aryaos-spectrum-survey",
+            "sensor_id": str(found[0]),
+            "sw_version": os.environ.get("ARYAOS_VERSION") or None,
+        }
+
     for band in bands:
         res = survey_band(sdr, band, args.dwell, args.gain, args.sample_rate,
                           args.antenna, np, SoapySDR, fmt)
         entry = {"name": band["name"], "center_hz": band["center"], "label": band["label"]}
         entry.update(res)
         out["bands"].append(entry)
+
+        if args.zmeta:
+            if "error" not in res:
+                import secrets
+                import time as _time
+
+                event = zmeta_event(
+                    band, res, zmeta_source,
+                    int(_time.time() * 1000), secrets.token_bytes(10), args.dwell,
+                )
+                sys.stdout.write(json.dumps(event) + "\n")
+            continue
 
         if not args.json:
             if "error" in res:
@@ -327,7 +500,7 @@ def main(argv=None):
                     f"{flag:8s} [{res['detection']}]{carrier}{clip}"
                 )
 
-    if args.json:
+    if args.json and not args.zmeta:
         json.dump(out, sys.stdout, indent=2)
         sys.stdout.write("\n")
     return 0


### PR DESCRIPTION
Pilot of the [ZMeta ISR metadata model](https://github.com/JTC-byte/zmeta-spec) (Apache-2.0) against a real sensor. Spectrum survey output has no natural CoT representation — it's measurements with uncertainty, not a marker on a map — so this **adds** a schema where we had none rather than displacing anything shipped.

## Validated against their real schema, not my reading of it

The schema is vendored verbatim in `scripts/vendor/`. That mattered immediately — **the first four attempts were rejected**, and each rejection was a fact prose hadn't conveyed:

1. `payload.modality` is an enum `{RF, EO, IR, ACOUSTIC, NETWORK}`. **`SIGINT` exists in their extension registry but only as a `reserved` name with no feature contract** — and neither the modality enum nor the subtype enum admits it, so it has no path into the schema at all today.
2. Measurements belong under `payload.features`, which is required.
3. `features` **forbids** `track_id`, `entity_class`, `classification`, `class_name`, `label`, `confidence`. The observation/inference split is enforced *structurally*. Nothing had to be dropped to comply — this tool already refused to identify emitters.
4. `event_subtype` for an observation is closed to the same enum as modality.

The payload reuses their **`SCAN_RF`** command vocabulary (`freq_range_hz`, `dwell_ms`), so a task and its answer speak one vocabulary. ZMeta can already *ask* for an RF scan; this is the answer it had nowhere to put.

## Known gap — deliberate, documented, tested

`features.power_dbm` is **not** emitted, so these events do **not** satisfy ZMeta's RF feature contract, which requires it.

`power_dbm` is absolute power. Every level here is **dBFS** — relative to the receiver's own full scale. Measured on the LimeSDR Mini v2, the reported floor moved **−31.9 → −13.4 dBFS purely by changing gain**. Converting needs calibrated gain, noise figure and front-end loss that an uncalibrated SDR doesn't report, so emitting a plausible dBm figure would be exactly the unit inference their semantics contract forbids.

The honest value goes in `payload.quality` with `calibrated: false`. **A test asserts the gap still exists**, so if upstream relaxes `power_dbm` for uncalibrated receivers, the suite tells us to revisit rather than silently staying non-conformant.

## Verified on hardware

Live from `aryaos-c998` against the Lime: valid UUIDv7, RFC3339 `Z` timestamps, FM carrier at **98.899 MHz** — the same station four independent methods have now found.

10 new tests (30 total); they skip cleanly without `jsonschema`, so CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM