### PR TITLE
Add the `acars` capability

### DIFF
--- a/scripts/test_capability_scan.py
+++ b/scripts/test_capability_scan.py
@@ -131,3 +131,64 @@ class AdsbCapabilityTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AcarsCapabilityTestCase(unittest.TestCase):
+    """The `acars` capability wiring.
+
+    ACARS must never auto-apply. It is VHF (~131 MHz) and the box can see which
+    SDRs are attached but NOT what antenna is on the end of the coax -- and the
+    antenna decides everything. Measured this session on a dragonegg box:
+    identical software and SDR went from 0 usable ADS-B messages on a short
+    indoor whip to 5173 on an outdoor antenna. Auto-enabling ACARS because an
+    SDR exists would start a decoder that hears nothing while claiming the
+    capability.
+    """
+
+    def _scan_acars(self, sdrs):
+        """Run the acars block plus the auto_apply recomputation together.
+
+        Run in isolation this passes while the shipped scanner does the
+        opposite: a later loop recomputes auto_apply from manual_only, and an
+        earlier fix that set auto_apply directly was silently overwritten a few
+        lines later. That bug reached hardware.
+        """
+        caps = {}
+        caps["acars"] = {
+            "available": bool(sdrs),
+            "evidence": f"{len(sdrs)} SDR(s)" if sdrs else "no SDR detected",
+            "manual_only": True,
+            "deferred_reason": "ACARS is VHF and needs a matching antenna",
+        }
+        for cap in caps.values():
+            cap["auto_apply"] = bool(cap.get("available")) and not cap.get("manual_only")
+        return caps["acars"]
+
+    def test_available_when_an_sdr_is_present(self):
+        cap = self._scan_acars([{"driver": "lime"}])
+        self.assertTrue(cap["available"])
+
+    def test_never_auto_applies_even_with_an_sdr(self):
+        cap = self._scan_acars([{"driver": "lime"}])
+        self.assertFalse(cap["auto_apply"], "acars must never auto-enable")
+
+    def test_unavailable_with_no_sdr(self):
+        cap = self._scan_acars([])
+        self.assertFalse(cap["available"])
+        self.assertFalse(cap["auto_apply"])
+
+    def test_deferred_reason_names_the_antenna(self):
+        """The operator has to know WHY, or they will just force it on."""
+        cap = self._scan_acars([{"driver": "lime"}])
+        self.assertIn("antenna", cap["deferred_reason"].lower())
+
+    def test_shipped_scanner_declares_acars_manual_only(self):
+        """Guards the real file, not this reconstruction."""
+        import pathlib
+
+        src = pathlib.Path(__file__).parent.parent / "shared_files/aryaos/aryaos-capability-scan"
+        text = src.read_text()
+        idx = text.find('caps["acars"]')
+        self.assertGreater(idx, 0, "acars capability block missing from the scanner")
+        block = text[idx : idx + 900]
+        self.assertIn('"manual_only": True', block)

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -355,7 +355,8 @@ forbid_enabled() {
 }
 for _u in readsb.service dump978-fa.service adsbcot.service aiscot.service \
 	dronecot.service sikw00fcot.service ais-catcher.service sapientcot.service \
-	dronecot-wifi.service dronecot-ble.service dronecot-dronescout.service; do
+	dronecot-wifi.service dronecot-ble.service dronecot-dronescout.service \
+	acarsdec.service acarscot.service; do
 	forbid_enabled "${_u}"
 done
 require_grep '^ARYAOS_CAPABILITIES=""$' /etc/aryaos/aryaos-config.txt "no sensor capabilities enabled out of the box"

--- a/shared_files/aryaos/acarsdec.default
+++ b/shared_files/aryaos/acarsdec.default
@@ -1,0 +1,26 @@
+# /etc/default/acarsdec — AryaOS runtime configuration for the ACARS decoder.
+#
+# acarsdec decodes ACARS from VHF and hands JSON to acarscot, which turns it
+# into CoT. Both units belong to the `acars` capability; enable with:
+#   sudo aryaos-role caps ... acars
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# SDR selection. Any SoapySDR device works; a LimeSDR Mini v2 is verified.
+# For an RTL dongle use: ACARSDEC_DEVICE_ARGS="--rtlsdr 0 -g 40"
+ACARSDEC_DEVICE_ARGS="--soapysdr driver=lime -a LNAW -g 40"
+
+# Where acarscot listens. Loopback: this feed is not for the network.
+ACARSDEC_JSON_HOST=127.0.0.1
+ACARSDEC_JSON_PORT=5555
+
+# Channels to decode, in MHz. These are the common US ACARS frequencies and
+# they fit inside one tuner bandwidth. acarsdec handles up to 8 at once.
+# Europe/other regions differ -- check what is used where the box is deployed.
+ACARSDEC_FREQS="130.025 130.425 130.450 131.125 131.550 131.725"
+
+# ANTENNA MATTERS MORE THAN ANYTHING HERE. ACARS is VHF (~131 MHz), so a
+# 1090 MHz ADS-B antenna will hear almost nothing. Measured on a dragonegg box:
+# swapping a short indoor whip for an outdoor antenna took ADS-B from 0 usable
+# messages to 5173. The same applies here, in the opposite band.

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -48,6 +48,7 @@ CONTENTION_PRIORITY = ("adsb", "ais")
 CAP_UNITS = {
     "adsb": "adsbcot",
     "ais": "aiscot",
+    "acars": "acarscot",
     "dji": "dronecot",
     "wifi-rid": "dronecot-wifi",
     "ble-rid": "dronecot-ble",
@@ -390,6 +391,33 @@ def scan():
         "deferred_reason": (
             "present on every box, so it is never auto-enabled; turn it on with "
             "`aryaos-role caps ... ble-rid`"
+        ),
+    }
+
+    # ACARS: needs an SDR, and needs it pointed at VHF.
+    #
+    # manual_only, and the reason is the antenna rather than the radio. ACARS
+    # lives around 131 MHz; ADS-B is at 1090 and AIS at 162. A box can see which
+    # SDRs are attached but has NO WAY to know what antenna is on the end of the
+    # coax, and the antenna decides everything here. Measured on a dragonegg box
+    # this session: identical software and SDR went from 0 usable ADS-B messages
+    # on a short indoor whip to 5173 on an outdoor antenna, and the same antenna
+    # that hears 131 MHz well is the wrong one for 1090.
+    #
+    # So auto-enabling ACARS because an SDR exists would, on most boxes, start a
+    # decoder that hears nothing and claim the capability while doing it. It is
+    # reported as available so an operator can find it, and waits to be asked.
+    caps["acars"] = {
+        "available": bool(sdrs),
+        "evidence": (
+            f"{len(sdrs)} SDR(s): " + _labels(sdrs) if sdrs else "no SDR detected"
+        ),
+        "manual_only": True,
+        "deferred_reason": (
+            "ACARS is VHF (~131 MHz) and needs an antenna to match; a 1090 MHz "
+            "ADS-B antenna will hear almost nothing. The box cannot detect which "
+            "antenna is attached, so enable it deliberately with "
+            "`aryaos-role caps ... acars`."
         ),
     }
 

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -35,6 +35,7 @@ CAPABILITIES = {
     "dji": ("DJI DroneID", "dronecot", "AntSDR (DJI OcuSync)"),
     "wifi-rid": ("Wi-Fi Remote ID", "dronecot-wifi", "Wi-Fi monitor-mode adapter"),
     "ble-rid": ("Bluetooth Remote ID", "dronecot-ble", "onboard Bluetooth adapter"),
+    "acars": ("ACARS", "acarscot", "VHF SDR"),
     "rid": ("Remote ID receiver", "dronecot-dronescout", "BlueMark DroneScout (OpenDroneID)"),
     "sik": ("SiK Telemetry", "sikw00fcot", "SiK radio"),
     "sapient": ("SAPIENT C-UAS", "sapientcot", "SAPIENT sensor (BSI Flex 335)"),

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -20,7 +20,7 @@
 #                        it supports; --apply enables them.
 #   set ROLE             Back-compat: apply a legacy role as a capability preset.
 #
-# Capability keys: adsb ais dji wifi-rid ble-rid rid sik sapient
+# Capability keys: adsb ais acars dji wifi-rid ble-rid rid sik sapient
 # The ADS-B decoder unit follows ARYAOS_ADSB_DECODER (readsb | dump1090_fa).
 # Units missing from the image are skipped, not errors.
 #
@@ -36,7 +36,7 @@ SITE_CONFIG="/etc/aryaos/aryaos-config.txt"
 # derived from anything, so every box claimed the same one no matter what was
 # attached. Capabilities are what differ between boxes, and unlike the product
 # they are measured -- see aryaos-capability-scan.
-CAPS="adsb ais dji wifi-rid ble-rid rid sik sapient"
+CAPS="adsb ais acars dji wifi-rid ble-rid rid sik sapient"
 LEGACY_ROLES="multi air maritime cuas relay"
 
 usage() {
@@ -83,6 +83,9 @@ cap_units() {
 	case "$1" in
 		adsb)     echo "$(adsb_decoder_unit) dump978-fa adsbcot gdltak" ;;
 		ais)      echo "ais-catcher aiscot" ;;
+		# Decoder and gateway, same split as readsb/adsbcot: acarsdec
+		# demodulates VHF, acarscot turns its JSON into CoT.
+		acars)    echo "acarsdec acarscot" ;;
 		dji)      echo "dronecot" ;;
 		wifi-rid) echo "dronecot-wifi" ;;
 		ble-rid)  echo "dronecot-ble" ;;
@@ -98,6 +101,7 @@ cap_label() {
 	case "$1" in
 		adsb)     echo "ADS-B / UAT" ;;
 		ais)      echo "AIS" ;;
+		acars)    echo "ACARS" ;;
 		dji)      echo "DJI DroneID" ;;
 		wifi-rid) echo "Wi-Fi Remote ID" ;;
 		ble-rid)  echo "Bluetooth Remote ID" ;;

--- a/shared_files/aryaos/systemd/acarsdec.service
+++ b/shared_files/aryaos/systemd/acarsdec.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=acarsdec: ACARS VHF decoder (feeds acarscot)
+Documentation=https://github.com/snstac/acarsdec
+Wants=network.target
+After=network.target
+# The gateway is the consumer, so it may start first and wait; acarsdec does
+# not depend on it. Ordering only.
+Before=acarscot.service
+
+[Service]
+EnvironmentFile=-/etc/aryaos/aryaos-config.txt
+EnvironmentFile=/etc/default/acarsdec
+ExecStart=/bin/sh -c '/usr/bin/acarsdec $ACARSDEC_DEVICE_ARGS \
+  --output json:udp:host=$ACARSDEC_JSON_HOST,port=$ACARSDEC_JSON_PORT \
+  $ACARSDEC_FREQS'
+SyslogIdentifier=acarsdec
+Type=simple
+Restart=always
+RestartSec=20
+# Cap the restarts. A decoder whose SDR is absent or held by another service
+# will fail instantly and forever; without a limit it burns CPU retrying and
+# buries the journal. readsb crash-looping this way once took adsbcot and
+# gdltak down with it and left a box in `degraded` with no clue why.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+Nice=-1
+
+[Install]
+WantedBy=default.target

--- a/stages/stage-aryaos/00-install/00-run.sh
+++ b/stages/stage-aryaos/00-install/00-run.sh
@@ -175,6 +175,15 @@ install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/aryaos-zeroize.service" \
 install -v -m 0755 "${SHARED_FILES}/aryaos/aryaos-spectrum-survey" \
 	"${ROOTFS_DIR}/usr/local/sbin/aryaos-spectrum-survey"
 
+## ACARS decoder unit. acarsdec's own package ships only the binary -- upstream
+# has no service -- so the unit and its defaults come from here, mirroring the
+# readsb/adsbcot split where the decoder and the CoT gateway are separate units.
+# Installed disabled; the `acars` capability turns both on together.
+install -v -m 0644 "${SHARED_FILES}/aryaos/systemd/acarsdec.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/acarsdec.service"
+install -v -m 0644 "${SHARED_FILES}/aryaos/acarsdec.default" \
+	"${ROOTFS_DIR}/etc/default/acarsdec"
+
 ## NBFM demodulator: the missing front end for every audio-domain decoder on a
 # non-RTL radio. direwolf (APRS) and multimon-ng (POCSAG/FLEX/AFSK) consume PCM,
 # and the usual source is rtl_fm, which only speaks to RTL dongles. Debian

--- a/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
+++ b/stages/stage-bt-pan/01-sensors-off/00-run-chroot.sh
@@ -32,6 +32,8 @@ dronecot-ble
 dronecot-dronescout
 sikw00fcot
 sapientcot
+acarsdec
+acarscot
 "
 
 for unit in ${SENSOR_UNITS}; do


### PR DESCRIPTION
ACARS decodes on the fleet and now reaches TAK via [acarscot](https://github.com/snstac/acarscot), but there was no way to **manage** it — not in `CAPS`, no units, invisible to the scanner and the beacon.

| file | change |
|---|---|
| `aryaos-role` | `CAPS += acars`; units `acarsdec acarscot`; label `ACARS` |
| `aryaos-capability-scan` | `CAP_UNITS` + detection block |
| `aryaos-cot-detail` | beacon entry, so the fleet can see which boxes have it |
| `stage-aryaos` | installs the acarsdec unit + defaults |
| `sensors-off` | both units disabled in the image |
| `verify-image.sh` | both added to `forbid_enabled` |

AryaOS ships the **acarsdec unit** because acarsdec's package contains only the binary — upstream provides no service. Decoder and gateway stay separate units, mirroring `readsb`/`adsbcot`.

## `acars` is manual_only, and the reason is the antenna

It lives around **131 MHz**; ADS-B is at 1090 and AIS at 162. A box can enumerate its SDRs but has **no way to know what antenna is on the end of the coax** — and the antenna decides everything.

Measured on a dragonegg box this session: identical software and SDR went from **0 usable ADS-B messages** on a short indoor whip to **5,173** on an outdoor antenna. The antenna that hears 131 MHz well is the wrong one for 1090.

So auto-enabling ACARS because an SDR exists would, on most boxes, start a decoder that hears nothing *while advertising the capability to the whole fleet*. It reports available and waits to be asked.

The acarsdec unit also **caps its restarts** — a decoder whose SDR is absent or held elsewhere fails instantly and forever, and readsb crash-looping that way once took adsbcot and gdltak with it, leaving a box `degraded` with no clue why.

## Verified live on `aryaos-c998`

```
available=True  auto_apply=False  manual_only=True
evidence: 1 SDR(s): LimeSDR Mini [USB 3.0] 1DBB4189078E3F
aryaos-role list -> "acars": units ["acarsdec", "acarscot"]
```

Five tests, including one that reads the **shipped** scanner rather than a reconstruction, and one that runs the detection block together with the `auto_apply` recomputation — an earlier fix in this file set `auto_apply` directly and was silently overwritten a few lines later, and that bug reached hardware. Mutation-checked: flipping `manual_only` to `False` fails the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM