### PR TITLE
Beacon: report a generic `sdr` cape instead of three speculative ones

### DIFF
--- a/scripts/test_beacon_caps.py
+++ b/scripts/test_beacon_caps.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Beacon capability reporting.
+
+stdlib unittest, not pytest -- the CI runner has no pytest.
+
+Copyright Sensors & Signals LLC https://www.snstac.com/
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import importlib.machinery
+import importlib.util
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TOOL = os.path.join(HERE, "..", "shared_files", "aryaos", "aryaos-cot-detail")
+
+spec = importlib.util.spec_from_loader(
+    "cot_detail", importlib.machinery.SourceFileLoader("cot_detail", TOOL)
+)
+beacon = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(beacon)
+
+
+class SdrCapeTestCase(unittest.TestCase):
+    """A box with an SDR and no decoder chosen reports `sdr`, not three claims.
+
+    It used to beacon adsb, ais AND acars, each available=true. That reads as
+    three capabilities and is one radio -- and it overstates even that, because
+    which of them decodes anything is decided by the antenna, which the box
+    cannot see. Measured this session: the same software and SDR went from 0
+    usable ADS-B messages on an indoor whip to 5173 on an outdoor antenna.
+    """
+
+    def _caps(self, active, detected):
+        beacon._config = lambda key: ",".join(active) if key == "ARYAOS_CAPABILITIES" else ""
+        beacon._detected_caps = lambda: set(detected)
+        beacon._service_state = lambda unit: "inactive"
+        beacon._wifi_adapter = lambda: ""
+        return {c["key"]: c for c in beacon._capabilities()}
+
+    def test_idle_sdr_collapses_to_one_cape(self):
+        caps = self._caps(active=[], detected=["adsb", "ais", "acars"])
+        self.assertIn("sdr", caps)
+        for specific in ("adsb", "ais", "acars"):
+            self.assertNotIn(specific, caps, f"{specific} should be folded into sdr")
+
+    def test_sdr_cape_is_available_but_never_active(self):
+        caps = self._caps(active=[], detected=["adsb"])
+        self.assertEqual(caps["sdr"]["available"], "true")
+        self.assertEqual(caps["sdr"]["enabled"], "false")
+        self.assertEqual(caps["sdr"]["active"], "false")
+
+    def test_enabled_decoder_is_named(self):
+        """Once an operator chooses one, report it by name."""
+        caps = self._caps(active=["acars"], detected=["adsb", "ais", "acars"])
+        self.assertIn("acars", caps)
+        self.assertEqual(caps["acars"]["enabled"], "true")
+
+    def test_enabled_decoder_does_not_suppress_the_others(self):
+        """The unchosen ones still collapse, so the radio is still advertised."""
+        caps = self._caps(active=["acars"], detected=["adsb", "ais", "acars"])
+        self.assertIn("sdr", caps)
+        self.assertNotIn("adsb", caps)
+
+    def test_non_sdr_capabilities_are_untouched(self):
+        """ble-rid has its own radio and must keep reporting itself."""
+        caps = self._caps(active=[], detected=["ble-rid", "adsb"])
+        self.assertIn("ble-rid", caps)
+        self.assertIn("sdr", caps)
+
+    def test_no_sdr_means_no_sdr_cape(self):
+        caps = self._caps(active=[], detected=["ble-rid"])
+        self.assertNotIn("sdr", caps)
+
+    def test_sensor_text_names_what_is_possible(self):
+        caps = self._caps(active=[], detected=["adsb", "acars"])
+        sensor = caps["sdr"]["sensor"]
+        self.assertIn("adsb", sensor)
+        self.assertIn("acars", sensor)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared_files/aryaos/aryaos-cot-detail
+++ b/shared_files/aryaos/aryaos-cot-detail
@@ -214,6 +214,12 @@ def _detected_caps() -> set:
     return set(out.split())
 
 
+# Capabilities whose "available" means nothing more than "an SDR is attached".
+# They share one radio and one antenna, and which of them actually WORKS is
+# decided by the antenna, which the box cannot see.
+SDR_CAPS = frozenset({"adsb", "ais", "acars"})
+
+
 def _capabilities() -> list[dict[str, str]]:
     """Every capability this box has hardware for OR has switched on.
 
@@ -224,8 +230,28 @@ def _capabilities() -> list[dict[str, str]]:
     active_caps = _config("ARYAOS_CAPABILITIES").replace(",", " ").split()
     detected = _detected_caps()
 
+    keys = set(active_caps) | detected
+
+    # Collapse the merely-possible SDR capabilities into one honest `sdr`.
+    #
+    # A box with one SDR and nothing switched on used to beacon adsb, ais AND
+    # acars, each available=true. That reads as three capabilities and is really
+    # one radio -- and it overstates even that, because whether any of them
+    # decodes anything depends on the antenna. Measured this session: identical
+    # software and SDR went from 0 usable ADS-B messages on an indoor whip to
+    # 5173 on an outdoor antenna, and the antenna that hears ACARS at 131 MHz is
+    # the wrong one for 1090.
+    #
+    # So: an SDR capability that is ENABLED is reported by name, because an
+    # operator chose it and it is running. The rest become a single `sdr`
+    # meaning "this box has a radio, nothing is claimed about what it can hear".
+    sdr_enabled = {k for k in keys if k in SDR_CAPS and k in active_caps}
+    sdr_idle = {k for k in keys if k in SDR_CAPS} - sdr_enabled
+    if sdr_idle:
+        keys -= sdr_idle
+
     out: list[dict[str, str]] = []
-    for key in sorted(set(active_caps) | detected):
+    for key in sorted(keys):
         label, unit, sensor = CAPABILITIES.get(key, (key, "", ""))
         if key == "wifi-rid":
             sensor = _wifi_adapter() or sensor
@@ -239,6 +265,23 @@ def _capabilities() -> list[dict[str, str]]:
                 "sensor": sensor,
             }
         )
+
+    if sdr_idle:
+        out.append(
+            {
+                "key": "sdr",
+                "label": "SDR",
+                # No unit of its own: `sdr` is the absence of a chosen decoder,
+                # so it is never "active".
+                "active": "false",
+                "available": "true",
+                "enabled": "false",
+                "sensor": "software-defined radio ("
+                + ", ".join(sorted(sdr_idle))
+                + " possible, none enabled)",
+            }
+        )
+
     return out
 
 


### PR DESCRIPTION
A box with one SDR and no decoder chosen used to advertise **adsb, ais AND acars**, each `available=true`. That reads as three capabilities and it is **one radio**.

Worse, it overstates even that. Which of them decodes anything is decided by the **antenna**, which the box cannot see. Measured this session on a dragonegg box: identical software and SDR went from **0 usable ADS-B messages** on a short indoor whip to **5,173** on an outdoor antenna — and the antenna that hears ACARS at 131 MHz is the wrong one for 1090.

So *"this box can do ADS-B and AIS and ACARS"* was never a claim the hardware supported.

## Now

- An SDR capability that is **enabled** is reported by name — an operator chose it and it's running.
- The rest collapse into a single **`sdr`**: *this box has a radio, nothing is claimed about what it can hear*.
- Capabilities with their own radio (`ble-rid`, `wifi-rid`, `sik`) are untouched.

Verified live on `aryaos-c998`:

```
ble-rid  available=true enabled=false  onboard Bluetooth adapter
sdr      available=true enabled=false  software-defined radio (... none enabled)
```

Seven tests. Mutation-checked: removing the collapse fails two of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM