### PR TITLE
Add the ADSBee 1090U hardware receiver, and stop AIS-catcher sharing to a public feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## AryaOS (Unreleased)
 
+- **ADSBee hardware ADS-B receiver support** (see
+  [docs/config/adsbee.md](docs/config/adsbee.md)). An ADSBee 1090U replaces *both*
+  RTL-SDR dongles: it demodulates 1090 Mode S and 978 UAT in its own silicon and
+  emits Beast over USB serial, which `readsb --device-type modesbeast` reads
+  directly. Measured on hardware: `readsb` CPU drops to ~0%, and the box's single
+  SDR is freed for AIS. Plug it in — `aryaos-adsbee` identifies and provisions the
+  device at boot (before `readsb`), and `run_readsb.sh` selects the receiver from
+  `/run/aryaos/adsbee.env`. `/etc/default/readsb` is never rewritten, so SDR boxes
+  are unaffected and unplugging the device reverts to the SDR configuration.
+  `dump978-fa` is dropped from the `adsb` capability while an ADSBee is in use.
+  New knobs `ARYAOS_ADSB_RECEIVER` (auto|adsbee|rtlsdr|soapysdr) and
+  `ARYAOS_ADSBEE_RADIO` (off|on), plus `scripts/readsb-use-adsbee.sh`.
+- **Security: AIS-catcher no longer shares to the public community feed.**
+  AIS-catcher 0.68 embeds the aiscatcher.org hub (185.77.96.227:4242) and enables
+  sharing **by default**, contradicting its own `-h` text. AryaOS passed no `-X`,
+  so a deployed unit was reporting its position and received traffic to a public
+  website. `ais-catcher.service` now passes `-X off` explicitly. A bare `-X` does
+  *not* disable sharing, so this must never be driven from an environment
+  variable. Asserted in `verify-image.sh`.
+- **Security: ADSBee provisioning disables the device's hostile defaults.** Stock
+  firmware ships with its Wi-Fi AP enabled (`ADSBee1090-<serial>` /
+  `yummyflowers`) and four public aggregator feeds preconfigured and active.
+  Provisioning turns off Wi-Fi AP, Wi-Fi station and Ethernet, and clears all ten
+  feed slots, on every boot.
 - dhbridge (DroneHone Bluetooth bridge) and kraktak removed from public builds
   while their source is private. The Bluetooth PAN phone-to-box link stays:
   `stage-dhbridge` is now `stage-bt-pan` (payload in `shared_files/bt-pan/`),

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -1,4 +1,4 @@
-# Agent handoff — state as of 2026-07-21
+# Agent handoff — state as of 2026-08-01
 
 Working notes for agents (and humans) picking up AryaOS and the snstac fleet.
 Supersedes the 2026-05-16 handoff in [portal.md](portal.md).
@@ -6,6 +6,60 @@ Supersedes the 2026-05-16 handoff in [portal.md](portal.md).
 !!! tip "Looking for what to work on next?"
     Outstanding work and follow-ups live in **[Roadmap & next steps](roadmap.md)**.
     This handoff covers the running build/merge state and architecture invariants.
+
+## 2026-08-01 — ADSBee hardware receiver + AIS-catcher leak (SHIPPED)
+
+Bench-proved on `aryaos-584d` (Pi 5) and verified across a full reboot. Docs:
+[ADSBee](config/adsbee.md), [runbook](operations/adsbee-runbook.md).
+
+**The ADSBee 1090U replaces both RTL dongles.** It demodulates 1090 Mode S and
+978 UAT in hardware and emits Beast over USB serial; `readsb --device-type
+modesbeast` reads it directly — no socat, no TCP hop, and the existing
+`readsb → aircraft.json → adsbcot → CoT` chain is untouched. Measured:
+**readsb CPU ~0%** (0.07 s over 4 min), because nothing on the Pi demodulates.
+UAT confirmed live: the ADSBee sends it as Beast frame type **`0xec`**, readsb
+converts via `uat2esnt`, and aircraft surface as `type=adsr_icao`.
+
+Architecture invariants worth keeping:
+
+- **`/etc/default/readsb` is never rewritten.** `aryaos-adsbee` (oneshot,
+  `Before=readsb.service`) writes `/run/aryaos/adsbee.env`; `run_readsb.sh`
+  overrides `RECEIVER_OPTIONS` at runtime. SDR boxes are unaffected and
+  unplugging the ADSBee reverts with no edit. Don't "fix" the stale RTL line.
+- **Identification is an active `AT+DEVICE_INFO?` probe.** The device enumerates
+  as a stock `2e8a:000a` "Raspberry Pi Pico" (shared with every RP2040 board) and
+  **ships silent**, so neither USB descriptors nor passive sniffing can find it.
+- **The console is a single serial port.** `readsb` and a probe cannot both hold
+  it — stop readsb before probing. That is why `probe_adsbee()` in the capability
+  scan reads the boot snapshot rather than re-probing.
+- `dump978-fa` leaves the `adsb` capability while an ADSBee is in use
+  (`uat_decoder_unit()` in `aryaos-role`); otherwise it crash-loops on a missing
+  978 dongle. An ADSBee also **frees the box's SDR for AIS** — the adsb/ais
+  contention in the capability scan no longer fires.
+
+!!! danger "Two hardware traps, both cost bench time"
+    **Never send `AT+ESP32_ENABLE=0`.** It silences the device *completely*,
+    Beast-over-USB included, despite the console having nothing to do with
+    networking. Measured: 0 bytes in 120 s with it off, 63 Beast frames in the
+    next 120 s with it on — same antenna, receivers reporting `ENABLED`
+    throughout. Provisioning pins it to `1`; EMCON is achieved by disabling each
+    radio individually.
+
+    **Clearing a feed slot does not erase its hostname.** The firmware keeps the
+    string, so exact-string comparison never converges and would re-flash on
+    every boot. Compare semantically (`active==0 and protocol==NONE`).
+
+**AIS-catcher was leaking to a public aggregator.** Root cause finally traced:
+AIS-catcher 0.68 embeds the aiscatcher.org hub (`185.77.96.227:4242`) and enables
+sharing **by default**, while its own `-h` claims `(default: off)`. AryaOS passed
+no `-X`, so it inherited that default. Fixed by hardcoding `-X off`.
+**A bare `-X` does not disable sharing** — so this must never come from a
+`${VAR}` that systemd could expand to nothing. Only `-X off` logs a positive
+confirmation (`Community feed sharing disabled.`).
+
+Still owed: a **same-antenna RF A/B against an RTL box**. The power win is
+proven; sensitivity equivalence is not (traffic was sparse all session, 1–4
+aircraft, which points at the antenna rather than the receiver).
 
 ## 2026-07-19→21 sweep — HIL hardening + landing-page features (SHIPPED)
 

--- a/docs/config/adsbee.md
+++ b/docs/config/adsbee.md
@@ -1,0 +1,135 @@
+# ADSBee (hardware ADS-B receiver)
+
+The **ADSBee 1090U** is a dedicated ADS-B receiver that replaces *both* RTL-SDR
+dongles on an air box. It demodulates 1090 MHz Mode S **and** 978 MHz UAT in its
+own silicon (an RP2040 plus a sub-GHz radio) and hands the results to the Pi over
+a single USB cable as a Mode S Beast stream.
+
+`readsb` reads that stream directly with `--device-type modesbeast`, so the rest
+of the pipeline is completely unchanged:
+
+```
+ADSBee --USB serial (Beast)--> readsb --> /run/adsb/aircraft.json --> adsbcot --> CoT
+```
+
+## Why fit one
+
+| | 2 × RTL-SDR | ADSBee 1090U |
+|---|---|---|
+| Bands | 1090 (readsb) + 978 (dump978-fa) | 1090 **and** 978, one device |
+| USB ports | 2 | 1 |
+| readsb CPU | a large fraction of a core, demodulating | **~0%** — nothing on the Pi demodulates |
+| Spare SDR | none | the box's SDR is freed for AIS or ACARS |
+
+The CPU figure is the headline: with an SDR, `readsb` is doing DSP on a 2 MSPS
+sample stream. With an ADSBee it is parsing pre-decoded frames off a serial port.
+That is the power and heat saving, and on a Pi 5 it is the difference between
+comfortable and thermally marginal.
+
+## Setup
+
+Plug it in. That is the whole procedure.
+
+At boot, `aryaos-adsbee.service` runs before `readsb`, finds the device,
+configures it, and writes `/run/aryaos/adsbee.env`. `run_readsb.sh` reads that
+file and switches `readsb` to the ADSBee automatically, because
+[`ARYAOS_ADSB_RECEIVER`](./site-config.md) defaults to `auto`. Plugging one in
+after boot works too — a udev rule re-runs provisioning.
+
+Then enable the ADS-B capability as usual:
+
+```bash
+sudo aryaos-role caps adsb
+```
+
+`dump978-fa` is deliberately **not** started when an ADSBee is in use: the ADSBee
+already covers 978 UAT, and dump978-fa would only crash-loop looking for a 978
+dongle that is not there.
+
+### Checking it
+
+```bash
+sudo aryaos-adsbee info            # what was detected, and its firmware
+jq '.aircraft | length' /run/adsb/aircraft.json
+```
+
+UAT aircraft appear in `aircraft.json` with `"type": "adsr_icao"`. The ADSBee
+encapsulates UAT in Beast **frame type `0xec`**, which readsb unpacks and
+converts through `uat2esnt` — so 978 traffic arrives over the same USB cable as
+1090, with no extra configuration.
+
+## Choosing the receiver by hand
+
+`ARYAOS_ADSB_RECEIVER` in `/etc/aryaos/aryaos-config.txt`:
+
+| Value | Behaviour |
+|---|---|
+| `auto` (default) | Use an ADSBee if one is detected, otherwise the SDR settings in `/etc/default/readsb` |
+| `adsbee` | Always expect an ADSBee; never fall back to an SDR |
+| `rtlsdr`, `soapysdr` | Keep using the SDR even with an ADSBee attached |
+
+```bash
+sudo ./scripts/readsb-use-adsbee.sh          # pin to the ADSBee
+sudo ./scripts/readsb-use-adsbee.sh --auto   # back to automatic
+```
+
+Nothing here edits `/etc/default/readsb`. The SDR line stays exactly as built, so
+removing the ADSBee returns the box to its SDR configuration.
+
+## Emissions and privacy
+
+!!! danger "Stock ADSBee firmware is not field-safe out of the box"
+    A factory ADSBee ships with **its Wi-Fi access point enabled** (SSID
+    `ADSBee1090-<serial>`, password `yummyflowers`) and **four public aggregator
+    feeds preconfigured and active** — `feed.whereplane.xyz`, `feed.adsb.lol`,
+    `feed.airplanes.live` and `feed.adsb.fi`. Those feeds are dormant only while
+    the device has no network of its own. Give it one and it will begin
+    reporting this receiver's position and traffic to the internet.
+
+AryaOS provisioning shuts all of that down, every boot:
+
+- Wi-Fi AP off, Wi-Fi station off, Ethernet off
+- all ten feed slots set inactive with protocol `NONE`
+- console log level silenced (debug text would corrupt the binary Beast stream)
+
+Set `ARYAOS_ADSBEE_RADIO=on` only if you deliberately want the ADSBee on a
+network, then re-run `sudo aryaos-adsbee provision`.
+
+The disabled feed slots still *display* their original hostnames in the device's
+own settings dump. That is cosmetic: the firmware keeps the last hostname string
+even when a slot is cleared. What matters is that each slot reads
+`...,0,0,NONE` — port 0, inactive, no protocol.
+
+!!! warning "Do not disable the ESP32"
+    `AT+ESP32_ENABLE=0` looks like the tidiest way to silence a box that will
+    never use the ADSBee's networking. It is not: it stops the device reporting
+    **entirely**, including Beast over USB, which has nothing to do with
+    networking. Measured on firmware 0.9.0-rc19: zero bytes in 120 s with the
+    ESP32 disabled, 63 Beast frames in the next 120 s with it re-enabled — same
+    antenna, same sky, both receivers reporting `ENABLED` the whole time.
+    Provisioning therefore pins `ESP32_ENABLE=1`, and disables each radio
+    individually instead.
+
+## Troubleshooting
+
+**No aircraft.** Confirm the device was found: `sudo aryaos-adsbee info`. If it
+reports nothing, check the cable is a data cable and that `readsb` is stopped
+while you probe — the console is a single serial port, so `readsb` and a probe
+cannot both hold it. `systemctl stop readsb` first.
+
+**It is not identified.** The ADSBee enumerates with the stock Raspberry Pi Pico
+USB id (`2e8a:000a`), shared with every RP2040 board, and it ships silent. So
+AryaOS cannot recognise it from USB descriptors or by listening; it identifies
+the device by sending `AT+DEVICE_INFO?` and reading the reply. If a probe fails,
+the port is usually busy.
+
+**`readsb` runs but reports nothing.** Verify the device is actually emitting:
+
+```bash
+sudo systemctl stop readsb
+sudo timeout 30 cat /dev/serial/by-id/usb-Raspberry_Pi_Pico_*-if00 | xxd | head
+```
+
+You want `1a 32` / `1a 33` (Mode S short/long) and `1a ec` (UAT) frame markers.
+Air traffic can genuinely be sparse; listen for a minute or more before
+concluding the receiver is at fault, and check the antenna.

--- a/docs/operations/adsbee-runbook.md
+++ b/docs/operations/adsbee-runbook.md
@@ -1,0 +1,128 @@
+# Runbook — fitting an ADSBee to a unit
+
+Operational procedure for swapping a unit's ADS-B RTL-SDR dongles for an
+[ADSBee 1090U](../config/adsbee.md). Written for a technician with SSH or
+console access to the box.
+
+Budget about ten minutes, most of it waiting for aircraft.
+
+## Before you start
+
+- An **ADSBee 1090U** and a **data-capable** USB cable. A charge-only cable
+  enumerates nothing and looks exactly like a dead device.
+- Antennas for **both** bands if you want UAT: the 1090 and sub-GHz ports are
+  separate, and antennas are sold separately.
+- An AryaOS image containing `aryaos-adsbee` (check with
+  `command -v aryaos-adsbee`). Older images will simply ignore the device.
+
+!!! warning "Quiet the radios first on a marginal supply"
+    On a Pi 5, or any unit on a questionable supply or cable, shed load before
+    changing hardware — a brownout *during a write* can corrupt config:
+    ```bash
+    sudo aryaos-safe-mode on "fitting adsbee"
+    #   ... do the work ...
+    sudo aryaos-safe-mode off
+    ```
+
+## Procedure
+
+**1. Fit the hardware.** Power down, remove the 1090 and 978 RTL dongles,
+connect the ADSBee and its antenna(s), power up.
+
+**2. Confirm it was found.**
+
+```bash
+sudo aryaos-adsbee info
+```
+
+Expect `"present": true` with a firmware version and part code. If it reports
+nothing, see *Failure modes* below.
+
+**3. Confirm readsb is driving it.**
+
+```bash
+ps -o args= -C readsb | head -1
+```
+
+Expect `--device-type modesbeast --beast-serial /dev/serial/by-id/usb-Raspberry_Pi_Pico_...`.
+
+`/etc/default/readsb` will still contain the old RTL line. **That is correct and
+deliberate** — the switch happens at runtime, so pulling the ADSBee returns the
+unit to its SDR configuration with no edit required. Do not "fix" it.
+
+**4. Enable the capability** (if not already):
+
+```bash
+sudo aryaos-role caps adsb
+```
+
+`dump978-fa` should be listed as `disable`. The ADSBee covers 978 UAT itself, and
+dump978-fa would only crash-loop hunting a dongle that is no longer fitted.
+
+**5. Confirm aircraft, then CoT.**
+
+```bash
+jq '.aircraft | length' /run/adsb/aircraft.json
+sudo journalctl -u adsbcot -n 5      # "Retrieved N ADS-B aircraft messages."
+```
+
+Give it a few minutes. Traffic is genuinely intermittent, and a quiet sky is the
+most common cause of a "failed" verification.
+
+**6. Record the numbers.** For comparison against the unit's old RTL baseline:
+
+```bash
+ps -o time,%cpu -C readsb --no-headers   # expect ~0% and near-zero CPU time
+vcgencmd measure_temp; vcgencmd get_throttled
+```
+
+## Acceptance checklist
+
+- [ ] `aryaos-adsbee info` reports `present: true`
+- [ ] `readsb` running with `--device-type modesbeast`
+- [ ] `dump978-fa` inactive, and **not** crash-looping
+- [ ] `systemctl --failed` is empty
+- [ ] `aircraft.json` gains aircraft within a few minutes
+- [ ] `adsbcot` logging retrievals; CoT visible on the mesh
+- [ ] `readsb` CPU at or near 0%
+- [ ] `get_throttled` is `0x0`
+
+## Verifying the emissions posture
+
+A factory ADSBee runs a Wi-Fi AP and carries four active public aggregator
+feeds. Provisioning disables these on every boot; verify on any unit going to the
+field:
+
+```bash
+sudo systemctl stop readsb        # the console is one port; readsb holds it
+sudo aryaos-adsbee provision      # expect "configuration already correct"
+sudo systemctl start readsb
+```
+
+To inspect directly, stop `readsb` and query the device — every `FEED` line must
+end `,0,0,NONE`, and `WIFI_AP`/`WIFI_STA`/`ETHERNET` must all be `0`. Disabled
+feed slots still *display* their original hostnames; that is cosmetic, the
+`0,0,NONE` is what matters.
+
+`ESP32_ENABLE` must be **1**. Setting it to 0 silences the device completely,
+Beast over USB included — see [the ADSBee page](../config/adsbee.md).
+
+## Failure modes
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `aryaos-adsbee info` finds nothing | Charge-only USB cable | Swap for a data cable |
+| | `readsb` holds the port | `systemctl stop readsb`, re-probe |
+| | Not an ADSBee (some other RP2040 board) | Probe replies only from ADSBee firmware |
+| Found, but readsb still on `rtlsdr` | `ARYAOS_ADSB_RECEIVER` pinned | Set to `auto`, or run `readsb-use-adsbee.sh` |
+| readsb runs, no aircraft ever | Antenna / sparse traffic | Listen on the port for `1a 32`/`1a 33` markers |
+| No UAT (`adsr_icao`) aircraft | No 978 antenna fitted | Fit one; UAT is sparser than 1090 |
+| `dump978-fa` crash-looping | Capability set stale | Re-run `sudo aryaos-role caps adsb` |
+| Device went silent after config | ESP32 was disabled | `sudo aryaos-adsbee provision` re-pins it on |
+
+## Rolling back
+
+Unplug the ADSBee, refit the RTL dongles, reboot. `run_readsb.sh` finds no
+ADSBee, falls through to the untouched `RECEIVER_OPTIONS` in
+`/etc/default/readsb`, and `aryaos-role caps adsb` restores `dump978-fa`. No
+configuration edit is needed in either direction.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Site configuration: config/site-config.md
       - Device roles: config/device-roles.md
       - Radios & SDRs: config/radios-sdr.md
+      - ADSBee receiver: config/adsbee.md
       - Network SDR sharing: config/network-sdr.md
   - Network:
       - Wi-Fi & onboarding hotspot: networking/wifi-hotspot.md
@@ -124,6 +125,7 @@ nav:
   - Operate:
       - operations/index.md
       - Updates: operations/updates.md
+      - Runbook — fitting an ADSBee: operations/adsbee-runbook.md
       - Support bundles: operations/support-bundles.md
       - SBOM & supply chain: operations/sbom.md
       - Nearby nodes: operations/neighbors.md

--- a/scripts/readsb-use-adsbee.sh
+++ b/scripts/readsb-use-adsbee.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Point readsb at an attached ADSBee (hardware 1090 Mode S + 978 UAT receiver),
+# then restart the ADS-B pipeline. Run on the AryaOS host (needs root).
+#
+# Normally you do not need this: ARYAOS_ADSB_RECEIVER defaults to "auto", so an
+# attached ADSBee is detected at boot and preferred over an SDR automatically.
+# Use this to pin the choice on a box that also has an SDR, or to re-run
+# detection after plugging one in.
+#
+# Usage:
+#   sudo ./scripts/readsb-use-adsbee.sh          # pin readsb to the ADSBee
+#   sudo ./scripts/readsb-use-adsbee.sh --auto   # back to automatic selection
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+
+set -euo pipefail
+
+MODE="adsbee"
+if [[ "${1:-}" == "--auto" ]]; then
+	MODE="auto"
+elif [[ -n "${1:-}" ]]; then
+	echo "Usage: sudo $0 [--auto]" >&2
+	exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+	echo "Run as root (sudo)." >&2
+	exit 1
+fi
+
+AOS_CFG="/etc/aryaos/aryaos-config.txt"
+if [[ ! -f "${AOS_CFG}" ]]; then
+	echo "Missing ${AOS_CFG} — is this an AryaOS box?" >&2
+	exit 1
+fi
+
+if grep -qE '^#?\s*ARYAOS_ADSB_RECEIVER=' "${AOS_CFG}"; then
+	sed -i "s|^#\?\s*ARYAOS_ADSB_RECEIVER=.*|ARYAOS_ADSB_RECEIVER=${MODE}|" "${AOS_CFG}"
+else
+	printf 'ARYAOS_ADSB_RECEIVER=%s\n' "${MODE}" >>"${AOS_CFG}"
+fi
+echo "ARYAOS_ADSB_RECEIVER=${MODE}"
+
+# readsb holds the ADSBee's serial port while it runs, so detection has to
+# happen with readsb stopped — a probe cannot share the port with a Beast stream.
+systemctl stop readsb >/dev/null 2>&1 || true
+/usr/local/sbin/aryaos-adsbee provision || true
+
+if [[ "${MODE}" == "adsbee" ]] && ! grep -q '^ARYAOS_ADSBEE_PRESENT=1' /run/aryaos/adsbee.env 2>/dev/null; then
+	echo "WARNING: no ADSBee detected — readsb will not start until one is attached." >&2
+fi
+
+# Re-apply the capability set so dump978-fa is dropped (an ADSBee already covers
+# 978 UAT) or restored (back on an SDR), rather than left crash-looping.
+CAPS="$(sed -n 's/^ARYAOS_CAPABILITIES="\?\([^"]*\)"\?$/\1/p' "${AOS_CFG}" | tail -1)"
+if [[ " ${CAPS} " == *" adsb "* ]]; then
+	# Unquoted on purpose: `aryaos-role caps` takes one capability per argument.
+	# shellcheck disable=SC2086
+	/usr/local/sbin/aryaos-role caps ${CAPS} || true
+else
+	systemctl start readsb || true
+fi
+
+echo ""
+echo "=== detection ==="
+/usr/local/sbin/aryaos-adsbee info || true
+
+echo ""
+echo "=== readsb ==="
+systemctl --no-pager --full status readsb || true
+
+echo ""
+echo "Confirm aircraft are arriving:  jq '.aircraft | length' /run/adsb/aircraft.json"
+echo "UAT traffic shows up as type \"adsr_icao\" — the ADSBee sends 978 UAT in the"
+echo "same Beast stream (frame type 0xec) and readsb converts it via uat2esnt."

--- a/scripts/test_capability_scan.py
+++ b/scripts/test_capability_scan.py
@@ -62,8 +62,8 @@ class AdsbCapabilityTestCase(unittest.TestCase):
             cls.src = fh.read()
         cls.block = _adsb_block(cls.src)
 
-    def decide(self, sdrs, with_pipeline=True):
-        ns = {"sdrs": sdrs, "caps": {}}
+    def decide(self, sdrs, with_pipeline=True, adsbee=None):
+        ns = {"sdrs": sdrs, "caps": {}, "adsbee": adsbee}
         exec(self.block, ns)
         if with_pipeline:
             exec(RECOMPUTE, ns)
@@ -95,6 +95,39 @@ class AdsbCapabilityTestCase(unittest.TestCase):
             self.src,
             "the recomputation this test guards against has changed shape",
         )
+
+    # -- ADSBee: a receiver that needs no SDR at all ----------------------
+    ADSBEE = {
+        "device": "/dev/serial/by-id/usb-Raspberry_Pi_Pico_E4654C6197481B39-if00",
+        "firmware": "0.9.0-rc19",
+    }
+
+    def test_adsbee_alone_is_available(self):
+        """The whole point of the device: ADS-B with no SDR in the box."""
+        cap = self.decide([], adsbee=self.ADSBEE)
+        self.assertTrue(cap["available"])
+        self.assertTrue(cap["auto_apply"])
+        self.assertIn("ADSBee", cap["evidence"])
+        self.assertNotIn("deferred_reason", cap)
+
+    def test_adsbee_reports_both_bands(self):
+        """It replaces the 1090 AND 978 dongles; the evidence should say so."""
+        cap = self.decide([], adsbee=self.ADSBEE)
+        self.assertIn("1090", cap["evidence"])
+        self.assertIn("978", cap["evidence"])
+
+    def test_adsbee_overrides_the_unusable_sdr_deferral(self):
+        """A LimeSDR next to an ADSBee must NOT defer adsb.
+
+        The #222 deferral exists because readsb cannot drive a non-RTL SDR. With
+        an ADSBee, readsb is not driving an SDR at all -- it is reading Beast off
+        a serial port -- so the reasoning does not apply and deferring would
+        switch off a receiver that works perfectly.
+        """
+        cap = self.decide([{"driver": "lime", "label": "LimeSDR Mini"}], adsbee=self.ADSBEE)
+        self.assertTrue(cap["auto_apply"], "the ADSBee works regardless of the SDR")
+        self.assertNotIn("deferred_reason", cap)
+        self.assertFalse(cap.get("manual_only"))
 
     # -- the cases that must keep working --------------------------------
     def test_rtl_only_auto_applies(self):

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -146,6 +146,27 @@ require_grep 'decoding' /usr/local/sbin/aryaos-cot-detail "beacon reports decode
 # every box, so it looked authoritative while carrying no information.
 forbid_grep '"product"' /usr/local/sbin/aryaos-cot-detail "beacon does not advertise a product line"
 forbid_grep '^ARYAOS_PRODUCT=' /etc/aryaos/aryaos-config.txt "no product line baked into the shipped config"
+# ADSBee: hardware ADS-B/UAT receiver that replaces the 1090 + 978 RTL pair.
+require_path /usr/local/sbin/aryaos-adsbee
+require_path /etc/systemd/system/aryaos-adsbee.service
+require_path /etc/udev/rules.d/99-aryaos-adsbee.rules
+# Without this, an attached ADSBee is simply ignored and readsb keeps looking for
+# an RTL dongle that is not there.
+require_grep 'adsbee.env' /usr/local/sbin/run_readsb.sh \
+	"run_readsb.sh selects the ADSBee when one is detected"
+require_grep 'modesbeast' /usr/local/sbin/run_readsb.sh \
+	"run_readsb.sh can drive a Beast-on-serial receiver"
+# Disabling the ESP32 silences the device completely, Beast-over-USB included --
+# see docs/config/adsbee.md. Finding that cost a bench session. Asserted
+# positively (pin it to 1) rather than as "never write 0", because the source
+# legitimately mentions the 0 case in the comment that explains this trap.
+require_grep 'AT+ESP32_ENABLE=1' /usr/local/sbin/aryaos-adsbee \
+	"provisioning keeps the ADSBee's ESP32 enabled"
+# Stock firmware ships four PUBLIC aggregator feeds active; provisioning must
+# clear them or a networked ADSBee reports our position to the internet.
+require_grep 'AT+FEED=' /usr/local/sbin/aryaos-adsbee \
+	"provisioning clears the preloaded public aggregator feeds"
+
 require_path /usr/local/sbin/aryaos-time-pps
 require_path /etc/systemd/system/aryaos-time-pps.service
 require_path /etc/udev/rules.d/99-aryaos-pps.rules
@@ -443,6 +464,14 @@ require_path /usr/local/sbin/aryaos-serial-assign
 require_unit aryaos-serial-assign.service
 require_grep '^DEVICES=""' /etc/default/gpsd "gpsd device not hardcoded (aryaos-serial-assign owns it)"
 require_grep '^SERIAL_PORT=$' /etc/default/ais-catcher "ais-catcher serial not hardcoded (aryaos-serial-assign owns it)"
+# AIS-catcher 0.68 ships the public aiscatcher.org community feed ON BY DEFAULT
+# (hub 185.77.96.227:4242 is embedded in the binary). Without an explicit
+# `-X off` a tactical receiver reports its position and traffic to a public
+# website. See the comment in shared_files/aiscot/ais-catcher.service.
+# Pattern deliberately starts with a letter: require_grep passes it positionally
+# to `grep -qsE`, which would read a leading "-X" as an option.
+require_grep 'AIS-catcher -X off' /lib/systemd/system/ais-catcher.service \
+	"ais-catcher does not share to the public community feed"
 
 # Lifecycle helpers (Cockpit -> AryaOS Site: backup/restore, factory reset, zeroize)
 require_path /usr/local/sbin/aryaos-config-backup

--- a/shared_files/adsbcot/aryaos-adsbee
+++ b/shared_files/adsbcot/aryaos-adsbee
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""aryaos-adsbee — identify and provision an ADSBee 1090/1090U ADS-B receiver.
+
+The ADSBee is a self-contained dual-band receiver (RP2040 + CC1312 sub-GHz +
+ESP32) that demodulates 1090 MHz Mode S AND 978 MHz UAT in dedicated silicon and
+emits Mode S Beast over its USB console. readsb reads that stream directly with
+`--device-type modesbeast`, so one USB cable replaces both RTL-SDR dongles and
+readsb stops burning CPU on demodulation.
+
+Two things make this device awkward to autodetect, and both drive the design here:
+
+1. It enumerates as `2e8a:000a "Raspberry Pi Pico"` -- the STOCK RP2040 CDC id,
+   shared with every other Pico on earth. USB descriptors cannot identify it.
+2. It ships SILENT (`PROTOCOL_OUT=CONSOLE,NONE`), so passive sniffing sees
+   nothing at all.
+
+So identification is an ACTIVE probe: send `AT+DEVICE_INFO?` and look for the
+ADSBee's reply. Sending that string to some unrelated Pico is harmless.
+
+It also ships hostile-by-default for a tactical box: its Wi-Fi AP is ENABLED
+(SSID `ADSBee1090-<serial>`, password `yummyflowers`) and four PUBLIC aggregator
+feeds are preconfigured and active (whereplane, adsb.lol, airplanes.live,
+adsb.fi). Those are dormant only while it has no network -- give it one and it
+starts telling the internet where we are. Provisioning turns all of that off.
+
+Usage:
+    aryaos-adsbee detect [--json]   # identify only; no writes to the device
+    aryaos-adsbee provision         # identify, configure, persist (boot path)
+    aryaos-adsbee info              # print the last detection snapshot
+
+Exit status is 0 when an ADSBee was found, 1 when none was.
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+try:
+    import serial
+except ImportError:  # pragma: no cover - python3-serial is a package dependency
+    serial = None
+
+# Stock RP2040 CDC identifiers. NOT unique to the ADSBee -- see module docstring.
+USB_VENDOR_ID = "2e8a"
+USB_MODEL_ID = "000a"
+
+STATE_DIR = "/run/aryaos"
+STATE_ENV = os.path.join(STATE_DIR, "adsbee.env")
+STATE_JSON = os.path.join(STATE_DIR, "adsbee.json")
+
+# The console is a USB CDC virtual COM port, so the baud rate is arbitrary.
+BAUD = 115200
+# Line endings MUST be CRLF; the firmware's AT parser ignores bare LF.
+EOL = b"\r\n"
+
+
+def log(msg):
+    print(f"aryaos-adsbee: {msg}", file=sys.stderr)
+
+
+def udev_properties(dev):
+    try:
+        out = subprocess.run(
+            ["udevadm", "info", "-q", "property", "-n", dev],
+            capture_output=True, text=True, timeout=5,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    props = {}
+    for line in out.splitlines():
+        key, _, value = line.partition("=")
+        props[key] = value
+    return props
+
+
+def candidates():
+    """Every serial port that *could* be an ADSBee, by USB id alone."""
+    found = []
+    for dev in sorted(glob.glob("/dev/serial/by-id/*")):
+        props = udev_properties(dev)
+        if (props.get("ID_VENDOR_ID") == USB_VENDOR_ID
+                and props.get("ID_MODEL_ID") == USB_MODEL_ID):
+            found.append(dev)
+    return found
+
+
+def port_is_busy(dev):
+    """True if some other process holds the port (readsb, typically).
+
+    Probing a port readsb is streaming from would steal its bytes, so a busy
+    port is left strictly alone.
+    """
+    try:
+        return subprocess.run(
+            ["fuser", dev], capture_output=True, timeout=5
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+class Console:
+    """Minimal AT console over the ADSBee's USB CDC port.
+
+    Once provisioned the console also carries the binary Beast stream, so every
+    reply is parsed line-wise out of a noisy buffer rather than read whole.
+    """
+
+    def __init__(self, dev, timeout=0.3):
+        self.serial = serial.Serial(dev, BAUD, timeout=timeout)
+        self.serial.reset_input_buffer()
+
+    def close(self):
+        try:
+            self.serial.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def command(self, cmd, wait=1.5):
+        """Send one AT command; return the reply as decoded text lines."""
+        self.serial.reset_input_buffer()
+        self.serial.write(cmd.encode() + EOL)
+        self.serial.flush()
+        buf = b""
+        end = time.monotonic() + wait
+        while time.monotonic() < end:
+            try:
+                chunk = self.serial.read(4096)
+            except serial.SerialException:
+                # A stalled CDC read is not fatal; keep waiting out the window.
+                time.sleep(0.05)
+                continue
+            if chunk:
+                buf += chunk
+        return buf.decode("latin-1", errors="replace").splitlines()
+
+
+def identify(dev):
+    """Active probe. Returns a device-info dict, or None if this is not an ADSBee."""
+    fields = {
+        "part_code": re.compile(r"^Part Code:\s*(\S+)"),
+        "usb_serial": re.compile(r"^RP2040 Flash Unique ID:\s*(\S+)"),
+        "firmware": re.compile(r"^RP2040 Firmware Version:\s*(\S+)"),
+        "esp32_firmware": re.compile(r"^ESP32 Firmware Version:\s*(\S+)"),
+        "rf_frontend": re.compile(r"^1090MHz RF Frontend Version:\s*(\S+)"),
+    }
+    info = {}
+    try:
+        with Console(dev) as con:
+            for line in con.command("AT+DEVICE_INFO?", wait=2.0):
+                for key, pattern in fields.items():
+                    match = pattern.match(line.strip())
+                    if match:
+                        info[key] = match.group(1)
+    except (OSError, serial.SerialException) as exc:
+        log(f"{dev}: probe failed ({exc})")
+        return None
+
+    # The firmware version line is the signature: a bare Pico answers nothing.
+    if "firmware" not in info:
+        return None
+    info["device"] = dev
+    return info
+
+
+def read_settings(dev):
+    """`AT+SETTINGS?DUMP` renders the whole config as AT commands. Parse it.
+
+    Returns {command_key: full_line}, keyed so that settings which take an
+    interface argument (PROTOCOL_OUT, BAUD_RATE, FEED) stay distinct per
+    interface/index instead of overwriting each other.
+    """
+    settings = {}
+    with Console(dev) as con:
+        for line in con.command("AT+SETTINGS?DUMP", wait=3.0):
+            line = line.strip()
+            if not line.startswith("AT+"):
+                continue
+            body = line[3:]
+            name, _, args = body.partition("=")
+            if not args:
+                continue
+            # PROTOCOL_OUT/BAUD_RATE/FEED are per-interface or per-index.
+            if name in ("PROTOCOL_OUT", "BAUD_RATE", "FEED"):
+                key = f"{name}:{args.split(',')[0]}"
+            else:
+                key = name
+            settings[key] = line
+    return settings
+
+
+def desired_settings(current, disable_radio=True):
+    """The configuration AryaOS wants, as {key: AT command}.
+
+    Only what we actually rely on is set, so operator tuning of anything else
+    (trigger level, bias tees, receiver position) is preserved.
+    """
+    wanted = {
+        # Beast on the USB console is the entire point: it carries 1090 Mode S
+        # AND 978 UAT (encapsulated in frame type 0xec), both of which readsb
+        # decodes off the serial port.
+        "PROTOCOL_OUT:CONSOLE": "AT+PROTOCOL_OUT=CONSOLE,BEAST",
+        # Nothing consumes the hardware UART on our builds.
+        "PROTOCOL_OUT:COMMS_UART": "AT+PROTOCOL_OUT=COMMS_UART,NONE",
+        # Debug chatter would be interleaved into the binary Beast stream.
+        "LOG_LEVEL": "AT+LOG_LEVEL=SILENT",
+        # Both bands on -- this is what lets one device retire two dongles.
+        "RX_ENABLE": "AT+RX_ENABLE=1",
+        "SUBG_ENABLE": "AT+SUBG_ENABLE=1",
+        # DO NOT set this to 0, however tempting it looks on a box that will
+        # never use the ADSBee's networking.
+        #
+        # `AT+ESP32_ENABLE=0` silences the device COMPLETELY -- including Beast
+        # on the USB console, which has nothing to do with networking. Measured
+        # on firmware 0.9.0-rc19: 0 bytes in 120 s with the ESP32 disabled,
+        # 63 Beast frames in the next 120 s with it re-enabled, same antenna,
+        # same sky, receivers reporting ENABLED throughout. The reporting
+        # pipeline evidently runs through the ESP32 regardless of transport.
+        #
+        # Pinned to 1 rather than merely left alone, so a box provisioned by an
+        # earlier build that did disable it heals itself on the next boot.
+        "ESP32_ENABLE": "AT+ESP32_ENABLE=1",
+    }
+
+    # OPSEC: clear every aggregator feed slot. Stock firmware ships slots 6-9
+    # pointed at public feeders and marked active.
+    for index in range(10):
+        wanted[f"FEED:{index}"] = f"AT+FEED={index},,0,0,NONE"
+
+    if disable_radio:
+        # We only ever use the USB console, so the ADSBee's own radios are pure
+        # liability: emissions we do not want and power we do not need. Silencing
+        # each interface individually is both necessary and sufficient -- the
+        # ESP32 itself must stay enabled (see ESP32_ENABLE above).
+        # Reversible with ARYAOS_ADSBEE_RADIO=on.
+        wanted["WIFI_STA"] = "AT+WIFI_STA=0,,"
+        wanted["ETHERNET"] = "AT+ETHERNET=0"
+        # WIFI_AP's setter is positional and takes the SSID/password/channel
+        # too, so preserve whatever is there and flip only the enable flag.
+        ap = current.get("WIFI_AP", "")
+        ap_args = ap.partition("=")[2].split(",") if ap else []
+        if len(ap_args) >= 4:
+            ap_args[0] = "0"
+            wanted["WIFI_AP"] = "AT+WIFI_AP=" + ",".join(ap_args[:4])
+        else:
+            wanted["WIFI_AP"] = "AT+WIFI_AP=0,ADSBee,aryaos415,1"
+
+    return wanted
+
+
+def satisfied(key, current_line, wanted_line):
+    """Is this setting already good enough to leave alone?
+
+    Mostly an exact string match, with one exception. Clearing a feed slot with
+    an empty URI deactivates it but does NOT erase the stored hostname: ask for
+        AT+FEED=6,,0,0,NONE
+    and the device afterwards reports
+        AT+FEED=6,feed.whereplane.xyz,0,0,NONE
+    A literal comparison therefore never converges, and we would rewrite and
+    re-flash all four preloaded aggregator slots on every single boot. What
+    actually matters for a feed is that it is inactive and has no protocol, so
+    compare on that. (The leftover hostname is inert: port 0, active 0, protocol
+    NONE. It is cosmetic, not a live feed.)
+    """
+    if current_line is None:
+        return False
+    if not key.startswith("FEED:"):
+        return current_line == wanted_line
+    fields = current_line.partition("=")[2].split(",")
+    if len(fields) < 5:
+        return False
+    active, protocol = fields[3].strip(), fields[4].strip().upper()
+    return active == "0" and protocol == "NONE"
+
+
+def provision(dev, disable_radio=True):
+    """Bring one ADSBee to the AryaOS configuration. Idempotent.
+
+    Writes (and flashes) only when something actually differs -- this runs on
+    every boot and the RP2040's flash has a finite erase budget.
+    """
+    current = read_settings(dev)
+    if not current:
+        log(f"{dev}: could not read settings; leaving device untouched")
+        return False
+
+    wanted = desired_settings(current, disable_radio=disable_radio)
+    changes = [
+        cmd for key, cmd in sorted(wanted.items())
+        if not satisfied(key, current.get(key), cmd)
+    ]
+    if not changes:
+        log(f"{dev}: configuration already correct")
+        return True
+
+    with Console(dev) as con:
+        for cmd in changes:
+            reply = " ".join(con.command(cmd, wait=0.8))
+            if "ERROR" in reply.upper():
+                log(f"{dev}: {cmd} -> {reply.strip()[:120]}")
+            else:
+                log(f"{dev}: {cmd}")
+        con.command("AT+SETTINGS=SAVE", wait=2.0)
+    log(f"{dev}: applied {len(changes)} setting(s) and saved to nonvolatile memory")
+    return True
+
+
+def write_state(info):
+    """Publish the result for run_readsb.sh, the capability scan and Cockpit."""
+    os.makedirs(STATE_DIR, exist_ok=True)
+
+    present = bool(info)
+    tmp = STATE_ENV + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        handle.write("# Written by aryaos-adsbee. Do not edit.\n")
+        handle.write(f"ARYAOS_ADSBEE_PRESENT={1 if present else 0}\n")
+        handle.write(f"ARYAOS_ADSBEE_DEVICE={info.get('device', '') if present else ''}\n")
+    os.replace(tmp, STATE_ENV)
+
+    payload = dict(info or {})
+    payload["present"] = present
+    tmp = STATE_JSON + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.replace(tmp, STATE_JSON)
+
+
+def config_value(key, default=""):
+    """Read one key out of /etc/aryaos/aryaos-config.txt."""
+    path = "/etc/aryaos/aryaos-config.txt"
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line.startswith(f"{key}="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return default
+
+
+def find_adsbee():
+    """First confirmed ADSBee, skipping ports another process already owns."""
+    for dev in candidates():
+        if port_is_busy(dev):
+            # Almost certainly readsb already streaming Beast from it. Trust the
+            # previous detection rather than fighting for the port.
+            log(f"{dev}: busy (in use by another process) — not probing")
+            continue
+        info = identify(dev)
+        if info:
+            return info
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("action", choices=("detect", "provision", "info"),
+                        nargs="?", default="detect")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    if args.action == "info":
+        try:
+            with open(STATE_JSON, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, ValueError):
+            payload = {"present": False}
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0 if payload.get("present") else 1
+
+    if serial is None:
+        log("python3-serial is not installed; cannot talk to the ADSBee")
+        return 1
+
+    info = find_adsbee()
+
+    if info and args.action == "provision":
+        if os.geteuid() != 0:
+            log("provision requires root")
+            return 1
+        radio = config_value("ARYAOS_ADSBEE_RADIO", "off").lower()
+        provision(info["device"], disable_radio=(radio != "on"))
+
+    if args.action == "provision":
+        write_state(info)
+
+    if not info:
+        if args.json:
+            print(json.dumps({"present": False}))
+        else:
+            log("no ADSBee found")
+        return 1
+
+    if args.json:
+        print(json.dumps(dict(info, present=True), indent=2, sort_keys=True))
+    else:
+        log(f"ADSBee on {info['device']} "
+            f"(firmware {info.get('firmware', '?')}, part {info.get('part_code', '?')})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared_files/adsbcot/readsb.service
+++ b/shared_files/adsbcot/readsb.service
@@ -19,6 +19,10 @@ Description=readsb ADS-B receiver
 Documentation=https://github.com/wiedehopf/readsb
 Wants=network.target
 After=network.target
+# Detects and configures a hardware ADSBee receiver and publishes
+# /run/aryaos/adsbee.env, which run_readsb.sh reads to pick the receiver.
+Wants=aryaos-adsbee.service
+After=aryaos-adsbee.service
 
 [Service]
 # EnvironmentFile=/etc/default/readsb

--- a/shared_files/adsbcot/run_readsb.sh
+++ b/shared_files/adsbcot/run_readsb.sh
@@ -32,9 +32,36 @@ if [ -f "${READSB_CONFIG}" ]; then
   . "${READSB_CONFIG}"
 fi
 
+# Written by aryaos-adsbee (ordered Before=readsb.service): says whether a
+# hardware ADSBee receiver was found, and on which by-id path.
+ADSBEE_ENV="/run/aryaos/adsbee.env"
+
+if [ -f "${ADSBEE_ENV}" ]; then
+  # shellcheck source=/dev/null
+  . "${ADSBEE_ENV}"
+fi
+
 set +a
 
 : "${ADSB_JSON:=${ARYAOS_ADSB_JSON_DIR:-/run/adsb}}"
+
+# Receiver selection. "auto" (the default) prefers a hardware ADSBee when one is
+# present, and otherwise leaves the SDR RECEIVER_OPTIONS from /etc/default/readsb
+# untouched -- so SDR boxes are unaffected. Pin to rtlsdr/soapysdr to keep using
+# an SDR even with an ADSBee attached.
+use_adsbee=0
+case "${ARYAOS_ADSB_RECEIVER:-auto}" in
+  adsbee) use_adsbee=1 ;;
+  auto)   [ "${ARYAOS_ADSBEE_PRESENT:-0}" = "1" ] && use_adsbee=1 ;;
+esac
+
+if [ "${use_adsbee}" = "1" ] && [ -n "${ARYAOS_ADSBEE_DEVICE:-}" ]; then
+  # The ADSBee demodulates 1090 Mode S and 978 UAT in hardware and emits both as
+  # Mode S Beast (UAT encapsulated in frame type 0xec, which readsb converts via
+  # uat2esnt). readsb reads that straight off the serial port -- no SDR, no socat
+  # shim, and effectively no CPU, because nothing here demodulates.
+  RECEIVER_OPTIONS="--device-type modesbeast --beast-serial ${ARYAOS_ADSBEE_DEVICE}"
+fi
 
 # RECEIVER_OPTIONS etc. are multiple CLI flags; they must be word-split (not one argv).
 # shellcheck disable=SC2086

--- a/shared_files/aiscot/ais-catcher.service
+++ b/shared_files/aiscot/ais-catcher.service
@@ -23,7 +23,31 @@ After=network.target
 [Service]
 User=ais-catcher
 # FIXME Change ExecStart to allow system overrides via /etc/default/ais-catcher
-ExecStart=/usr/bin/AIS-catcher -u ${UDP_DEST_ADDR} ${UDP_DEST_PORT} -e ${SERIAL_BAUDRATE} ${SERIAL_PORT} -N ${HTTP_PORT}
+#
+# `-X off` is NOT optional, and is deliberately hardcoded rather than driven from
+# /etc/default/ais-catcher.
+#
+# AIS-catcher can share received traffic with the public aiscatcher.org community
+# feed. In this build (0.68) that is ON BY DEFAULT: the binary embeds the hub
+# address 185.77.96.227:4242, and its own hint string says "Currently ON by
+# default" -- while its `-h` output claims "(default: off)". The two disagree, and
+# a deployed AryaOS box was observed holding an active outbound connection to
+# exactly that address while passing no -X flag at all. For a tactical receiver
+# that is a position disclosure: it tells a public website where this unit is and
+# what it can hear.
+#
+# Passing `-X off` explicitly makes us independent of whichever default the
+# packaged build happens to carry, and it is the only form that yields a positive
+# confirmation in the log ("Community feed sharing disabled.").
+#
+# Do NOT rewrite this as `-X ${SOME_VAR}`: systemd drops an unset variable, which
+# would leave a BARE `-X` on the command line -- and a bare `-X` does NOT disable
+# sharing (verified: prints nothing, behaves like the default). An empty variable
+# would therefore silently restore the leak.
+#
+# To deliberately opt IN to community sharing, override ExecStart with a drop-in
+# (`systemctl edit ais-catcher`) rather than editing this line.
+ExecStart=/usr/bin/AIS-catcher -X off -u ${UDP_DEST_ADDR} ${UDP_DEST_PORT} -e ${SERIAL_BAUDRATE} ${SERIAL_PORT} -N ${HTTP_PORT}
 RuntimeDirectory=ais-catcher
 SyslogIdentifier=ais-catcher
 EnvironmentFile=/etc/default/ais-catcher

--- a/shared_files/aryaos/aryaos-capability-scan
+++ b/shared_files/aryaos/aryaos-capability-scan
@@ -214,6 +214,32 @@ def probe_antsdr():
     return None
 
 
+def probe_adsbee():
+    """Is a hardware ADSBee ADS-B/UAT receiver attached? Returns its info dict or None.
+
+    Identification itself lives in aryaos-adsbee, which runs at boot
+    (Before=readsb.service) and leaves its result in /run/aryaos/adsbee.json.
+    Prefer that snapshot: by the time this scan runs readsb usually holds the
+    serial port, and re-probing would steal bytes out of its Beast stream. Fall
+    back to a live probe only when there is no snapshot at all -- e.g. an ADSBee
+    plugged in after boot, before udev has re-triggered provisioning.
+    """
+    snapshot = _read("/run/aryaos/adsbee.json")
+    if snapshot:
+        try:
+            info = json.loads(snapshot)
+        except ValueError:
+            return None
+        return info if info.get("present") else None
+
+    out = _run(["/usr/local/sbin/aryaos-adsbee", "detect", "--json"], timeout=20)
+    try:
+        info = json.loads(out)
+    except ValueError:
+        return None
+    return info if info.get("present") else None
+
+
 def _is_gnss(port):
     """Does udev identify this serial port as a GNSS receiver?"""
     props = _run(["/usr/bin/udevadm", "info", "-q", "property", "-n", port], timeout=5)
@@ -251,6 +277,7 @@ def scan():
     esp32 = probe_esp32_serial()
     antsdr = probe_antsdr()
     ais_serial = probe_ais_serial()
+    adsbee = probe_adsbee()
 
     caps = {}
 
@@ -278,13 +305,26 @@ def scan():
     def _labels(ds):
         return ", ".join(d.get("label") or d.get("driver", "?") for d in ds)
 
-    caps["adsb"] = {
-        "available": bool(sdrs),
-        "evidence": (
-            f"{len(sdrs)} SDR(s): " + _labels(sdrs) if sdrs else "no SDR detected"
-        ),
-    }
-    if sdrs and not rtl_sdrs:
+    # An ADSBee settles all of the above: it is a dedicated ADS-B/UAT receiver
+    # that readsb drives directly over Beast-on-serial, covering BOTH 1090 and
+    # 978 with no SDR involved at all. When one is present it is the receiver,
+    # and none of the SDR reasoning below applies.
+    if adsbee:
+        caps["adsb"] = {
+            "available": True,
+            "evidence": (
+                f"ADSBee on {adsbee.get('device', '?')} "
+                f"(firmware {adsbee.get('firmware', '?')}) — 1090 Mode S + 978 UAT"
+            ),
+        }
+    else:
+        caps["adsb"] = {
+            "available": bool(sdrs),
+            "evidence": (
+                f"{len(sdrs)} SDR(s): " + _labels(sdrs) if sdrs else "no SDR detected"
+            ),
+        }
+    if not adsbee and sdrs and not rtl_sdrs:
         # manual_only, NOT auto_apply.
         #
         # My first version of this set auto_apply=False directly, and it did
@@ -318,7 +358,10 @@ def scan():
         "available": ais_available,
         "evidence": "; ".join(ais_ev) or "no AIS receiver detected",
     }
-    if sdrs and not ais_serial and len(sdrs) < 2:
+    # Only a contention when adsb is actually competing for the radio. An ADSBee
+    # does ADS-B in its own silicon, so the box's single SDR is free for AIS --
+    # which is much of the point of fitting one.
+    if sdrs and not ais_serial and len(sdrs) < 2 and not adsbee:
         caps["ais"]["contended_with"] = ["adsb"]
         caps["adsb"]["contended_with"] = ["ais"]
 

--- a/shared_files/aryaos/aryaos-config.txt
+++ b/shared_files/aryaos/aryaos-config.txt
@@ -61,6 +61,24 @@ AOS_SERVICES="charontak gpstak aiscot lincot adsbcot dronecot adsbxcot aprscot s
 # system, then: sudo systemctl restart dump978-fa
 ARYAOS_UAT_RTL_SERIAL=stx:978:0
 
+# ADS-B receiver selection: auto | adsbee | rtlsdr | soapysdr
+#   auto    - use a hardware ADSBee if one is detected at boot, else the SDR
+#             RECEIVER_OPTIONS in /etc/default/readsb. This is what you want.
+#   adsbee  - always expect an ADSBee; readsb will not fall back to an SDR.
+#   rtlsdr / soapysdr - keep using the SDR even with an ADSBee attached.
+# An ADSBee covers BOTH 1090 Mode S and 978 UAT in hardware, so when it is in use
+# dump978-fa and the 978 RTL dongle are not needed and are left disabled.
+ARYAOS_ADSB_RECEIVER=auto
+
+# ADSBee onboard radios (Wi-Fi AP, Wi-Fi station, Ethernet, ESP32): off | on
+# Default off. AryaOS only uses the ADSBee's USB console, so its radios are pure
+# liability: the stock firmware enables a Wi-Fi AP (SSID ADSBee1090-<serial>,
+# password "yummyflowers") and preloads four PUBLIC aggregator feeds that would
+# report this receiver's position the moment it has a network. Set to "on" only
+# if you deliberately want the ADSBee on a network, then re-run:
+#   sudo aryaos-adsbee provision
+ARYAOS_ADSBEE_RADIO=off
+
 
 # Device identity — set on first boot by aryaos-firstboot.sh; do not modify. NO STEP.
 # DEVICE_SUFFIX: last 4 hex of machine-id (or MAC); hostname aryaos-xxxx and WiFi AryaOS-xxxx.

--- a/shared_files/aryaos/aryaos-role
+++ b/shared_files/aryaos/aryaos-role
@@ -78,10 +78,32 @@ adsb_decoder_unit() {
 	fi
 }
 
+# The 978 MHz UAT decoder, or nothing when an ADSBee is already doing that job.
+#
+# dump978-fa drives a SECOND RTL dongle. An ADSBee receives 978 UAT in hardware
+# and encapsulates it in its Beast stream (frame type 0xec) alongside 1090 Mode S,
+# so readsb already has the UAT picture. Enabling dump978-fa as well only
+# crash-loops it against an RTL that is not there:
+#     Configuration error: No matching SoapySDR device found
+#     (cause: rtlsdr_get_index_by_serial(stx:978:0) - -2)
+uat_decoder_unit() {
+	local receiver
+	receiver="$(config_get ARYAOS_ADSB_RECEIVER)"
+	if [[ -r /run/aryaos/adsbee.env ]]; then
+		# shellcheck source=/dev/null
+		. /run/aryaos/adsbee.env
+	fi
+	case "${receiver:-auto}" in
+		adsbee) return 0 ;;
+		auto)   [[ "${ARYAOS_ADSBEE_PRESENT:-0}" == "1" ]] && return 0 ;;
+	esac
+	echo "dump978-fa"
+}
+
 # Capability -> systemd sensor units.
 cap_units() {
 	case "$1" in
-		adsb)     echo "$(adsb_decoder_unit) dump978-fa adsbcot gdltak" ;;
+		adsb)     echo "$(adsb_decoder_unit) $(uat_decoder_unit) adsbcot gdltak" ;;
 		ais)      echo "ais-catcher aiscot" ;;
 		# Decoder and gateway, same split as readsb/adsbcot: acarsdec
 		# demodulates VHF, acarscot turns its JSON into CoT.

--- a/shared_files/aryaos/aryaos-serial-assign
+++ b/shared_files/aryaos/aryaos-serial-assign
@@ -79,6 +79,20 @@ is_rid_device() {
 	[[ "$vid" == "303a" ]]  # Espressif
 }
 
+# True for an ADSBee hardware ADS-B/UAT receiver. It speaks Mode S Beast (binary)
+# or nothing at all -- never NMEA -- so it must not be probed or swept into the
+# "leftover" pile, where assignment by elimination would hand it to ais-catcher.
+#
+# Matched by the stock RP2040 CDC id, which is NOT unique to the ADSBee. That is
+# deliberately fine here: the cost of skipping some unrelated Pico is nil (a Pico
+# is not a GPS or a dAISy either), whereas mis-assigning a live ADS-B receiver to
+# ais-catcher would break both. Positive identification is aryaos-adsbee's job.
+is_adsbee_device() {
+	local dev="$1" props
+	props="$(udevadm info -q property -n "$dev" 2>/dev/null)"
+	grep -qE '^ID_VENDOR_ID=2e8a$' <<<"$props" && grep -qE '^ID_MODEL_ID=000a$' <<<"$props"
+}
+
 # True for a GNSS receiver, identified by udev rather than by what it is saying.
 #
 # This matters because a GPS is NOT always talking: gpsd is deliberately stopped
@@ -156,6 +170,10 @@ main() {
 		fi
 		if is_antsdr_console "$dev"; then
 			log "skip $dev (AntSDR serial console — not a GPS/AIS receiver)"
+			continue
+		fi
+		if is_adsbee_device "$dev"; then
+			log "skip $dev (ADSBee ADS-B/UAT receiver — Beast, handled by readsb, not GPS/AIS)"
 			continue
 		fi
 		cls="$(classify "$dev")"

--- a/shared_files/aryaos/systemd/aryaos-adsbee.service
+++ b/shared_files/aryaos/systemd/aryaos-adsbee.service
@@ -1,0 +1,32 @@
+# aryaos-adsbee.service — identify and provision the ADSBee ADS-B receiver.
+#
+# Copyright Sensors & Signals LLC https://www.snstac.com/
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=AryaOS ADSBee — identify and provision the ADS-B/UAT receiver
+Documentation=https://github.com/CoolNamesAllTaken/adsbee
+After=local-fs.target
+# Must finish before readsb starts: it writes /run/aryaos/adsbee.env, which
+# run_readsb.sh reads to decide between the ADSBee and an SDR. It must also beat
+# readsb to the serial port, since a probe cannot run while readsb streams Beast.
+Before=readsb.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/aryaos-adsbee provision
+# No ADSBee attached is the normal case on SDR boxes, not a failure.
+SuccessExitStatus=0 1
+
+[Install]
+WantedBy=multi-user.target

--- a/shared_files/aryaos/udev/99-aryaos-adsbee.rules
+++ b/shared_files/aryaos/udev/99-aryaos-adsbee.rules
@@ -1,0 +1,13 @@
+# AryaOS — ADSBee 1090/1090U hardware ADS-B + UAT receiver.
+#
+# The ADSBee exposes its console on the RP2040's USB CDC port, which enumerates
+# with the STOCK Raspberry Pi Pico id 2e8a:000a. That id is shared with every
+# other RP2040 board, so it CANNOT be used to claim a device: this rule
+# deliberately creates no /dev/adsbee symlink. Identification is an active
+# `AT+DEVICE_INFO?` probe in aryaos-adsbee, and the device is referenced by its
+# unique /dev/serial/by-id/ path.
+#
+# All this rule does is re-run provisioning on hotplug, so an ADSBee plugged in
+# after boot is configured and picked up without a reboot. Firing the probe at
+# some unrelated Pico is harmless: it answers nothing and is ignored.
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000a", TAG+="systemd", ENV{SYSTEMD_WANTS}="aryaos-adsbee.service", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/stages/stage-adsbcot/03-install-packages/00-packages
+++ b/stages/stage-adsbcot/03-install-packages/00-packages
@@ -3,6 +3,7 @@ dump978-fa
 git wget unzip
 git wget unzip curl build-essential python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g
 python3-websockets
+python3-serial
 librtlsdr0
 librtlsdr-dev
 rtl-sdr

--- a/stages/stage-adsbcot/04-adsbcot/00-run.sh
+++ b/stages/stage-adsbcot/04-adsbcot/00-run.sh
@@ -56,5 +56,11 @@ install -v -m 0644 "${SHARED_FILES}/adsbcot/systemd/readsb.service.d/aryaos-conf
 install -v -m 755 "${SHARED_FILES}/adsbcot/readsb-set-location.sh" "${ROOTFS_DIR}/usr/local/bin/"
 install -v -m 755 "${SHARED_FILES}/adsbcot/readsb-gain.sh" "${ROOTFS_DIR}/usr/local/bin/"
 
+# ADSBee — hardware ADS-B/UAT receiver; replaces the 1090 + 978 RTL-SDR pair.
+install -v -m 755 "${SHARED_FILES}/adsbcot/aryaos-adsbee" "${ROOTFS_DIR}/usr/local/sbin/aryaos-adsbee"
+install -v -m 644 "${SHARED_FILES}/aryaos/systemd/aryaos-adsbee.service" \
+	"${ROOTFS_DIR}/etc/systemd/system/aryaos-adsbee.service"
+install -v -m 644 "${SHARED_FILES}/aryaos/udev/99-aryaos-adsbee.rules" "${ROOTFS_DIR}/etc/udev/rules.d/"
+
 # cockpit-adsbcot installs from the snstac apt repo in 01-run-chroot.sh
 # (repo configured by stage-pytak, which runs earlier in STAGE_LIST).

--- a/stages/stage-adsbcot/04-adsbcot/01-run-chroot.sh
+++ b/stages/stage-adsbcot/04-adsbcot/01-run-chroot.sh
@@ -59,6 +59,11 @@ sed --follow-symlinks -i -E -e "s/^# (FEED_URL.*)/\1/" /etc/default/adsbcot
 grep -qxF "EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/adsbcot.service || sed --follow-symlinks -i -E -e "/\[Service\]/a EnvironmentFile=/etc/aryaos/aryaos-config.txt" /lib/systemd/system/adsbcot.service
 
 systemctl daemon-reload || true
+
+# Always on: it is a cheap oneshot that exits 1 when no ADSBee is attached, and
+# readsb needs its verdict (/run/aryaos/adsbee.env) before it picks a receiver.
+systemctl enable aryaos-adsbee.service 2>/dev/null || true
+
 if [[ "${ARYAOS_PROFILE}" == "uas" ]]; then
 	systemctl disable --now adsbcot.service readsb.service dump1090-fa.service dump978-fa.service 2>/dev/null || true
 elif [[ "${ARYAOS_ADSB_DECODER_DEFAULT}" == "dump1090_fa" ]]; then

--- a/stages/stage-adsbcot/templates/readsb-receiver-options.j2
+++ b/stages/stage-adsbcot/templates/readsb-receiver-options.j2
@@ -1,5 +1,10 @@
 {# readsb RECEIVER_OPTIONS line for /etc/default/readsb — device-type must come first. #}
-{% if readsb_device_type | string == 'soapysdr' %}
+{# With an ADSBee attached, run_readsb.sh overrides this at runtime from         #}
+{# /run/aryaos/adsbee.env unless ARYAOS_ADSB_RECEIVER pins an SDR. This line is  #}
+{# what an SDR box uses, and what an ADSBee box falls back to if it is unplugged. #}
+{% if readsb_device_type | string == 'adsbee' %}
+RECEIVER_OPTIONS="--device-type modesbeast --beast-serial {{ readsb_beast_serial }}"
+{% elif readsb_device_type | string == 'soapysdr' %}
 RECEIVER_OPTIONS="--device-type soapysdr --soapy-device {{ readsb_soapy_device }} --gain {{ readsb_gain }}"
 {% else %}
 RECEIVER_OPTIONS="--device-type rtlsdr --device {{ adsb_sdr_sn }} --gain {{ readsb_gain }} --ppm {{ readsb_ppm }}"

--- a/vars.yml
+++ b/vars.yml
@@ -28,9 +28,15 @@ adsb_sdr_sn: stx:1090:0
 # Keep in sync with ARYAOS_UAT_RTL_SERIAL in shared_files/aryaos/aryaos-config.txt unless you override only at image build.
 uat_sdr_sn: stx:978:0
 
-# readsb SDR: rtlsdr (RTL EEPROM serial in adsb_sdr_sn) or soapysdr (Airspy, etc. via readsb_soapy_device).
+# readsb receiver: rtlsdr (RTL EEPROM serial in adsb_sdr_sn), soapysdr (Airspy, etc.
+# via readsb_soapy_device), or adsbee (hardware ADSBee over Beast-on-serial).
+# Leave this at rtlsdr for a generic image: an attached ADSBee is detected at boot
+# by aryaos-adsbee and preferred automatically (ARYAOS_ADSB_RECEIVER=auto).
 readsb_device_type: rtlsdr
 readsb_soapy_device: driver=airspy
+# Fallback Beast serial path used only when readsb_device_type is pinned to adsbee
+# at build time. Runtime detection supplies the real unique by-id path instead.
+readsb_beast_serial: /dev/ttyACM0
 readsb_gain: -10
 readsb_ppm: 0
 


### PR DESCRIPTION
Bench-proved on `aryaos-584d` (Pi 5) with a real ADSBee 1090U, and verified end to end across a full reboot.

## ADSBee 1090U — one device replaces both RTL dongles

It demodulates 1090 Mode S **and** 978 UAT in its own silicon and emits Mode S Beast over USB serial. `readsb` reads that directly with `--device-type modesbeast`, so the `readsb → aircraft.json → adsbcot → CoT` chain is unchanged — no socat, no TCP hop.

**Measured: `readsb` CPU drops to ~0%** (0.07 s of CPU over four minutes), because nothing on the Pi demodulates any more. That is the power/heat win. It also frees the box's single SDR for AIS, so the adsb/ais radio contention no longer fires.

**UAT really does ride the same cable.** The ADSBee encapsulates it in Beast frame type `0xec`; readsb converts via `uat2esnt` and those aircraft appear as `type=adsr_icao`. Confirmed live alongside 1090 traffic (`adsr_icao` positions 46, `remote.modes` 179 UAT vs `local.modes` 1159 1090, 0 bad). So `dump978-fa` and the 978 dongle are dropped from the `adsb` capability while an ADSBee is in use — otherwise it just crash-loops on a missing dongle.

### Two constraints that shaped the design

- The device enumerates as a **stock `2e8a:000a` "Raspberry Pi Pico"** — the generic RP2040 CDC id — and it **ships silent**. Neither USB descriptors nor passive sniffing can identify it, so `aryaos-adsbee` probes actively with `AT+DEVICE_INFO?`. (Harmless if it hits some unrelated Pico.)
- **`/etc/default/readsb` is never rewritten.** `aryaos-adsbee` is a oneshot ordered `Before=readsb.service` that publishes `/run/aryaos/adsbee.env`; `run_readsb.sh` selects the receiver from it. SDR boxes are untouched, and pulling the ADSBee reverts to the SDR line with no edit in either direction.

## Security

**AIS-catcher was leaking to a public aggregator** (first commit, reviewable on its own). A deployed unit held an active outbound connection to `185.77.96.227:4242` — the aiscatcher.org hub — with nothing in AryaOS config to explain it. Root cause: AIS-catcher 0.68 embeds that address and enables sharing **by default**, while its own `-h` claims `(default: off)`. We passed no `-X`, so we inherited the build default. Now `-X off`, verified on hardware.

> A **bare `-X` does not disable sharing**, so this is hardcoded rather than driven from `/etc/default/ais-catcher` — systemd drops an unset `${VAR}`, which would leave a bare `-X` and silently restore the leak.

**ADSBee provisioning disables its hostile defaults** on every boot: stock firmware enables a Wi-Fi AP (`ADSBee1090-<serial>` / `yummyflowers`) and preloads four *public* aggregator feeds, dormant only while it has no network.

## Two hardware traps found the hard way

**Never send `AT+ESP32_ENABLE=0`.** It silences the device *completely* — Beast-over-USB included — even though the console has nothing to do with networking. Measured: **0 bytes in 120 s** with it off vs **63 Beast frames in the next 120 s** with it back on, same antenna, both receivers reporting `ENABLED` throughout. I hit this by disabling the ESP32 for EMCON and watching aircraft stop. Provisioning now pins `ESP32_ENABLE=1` so a mis-provisioned box heals itself, and disables each radio individually instead.

**Clearing a feed slot does not erase its hostname.** The firmware keeps the string, so a literal comparison never converges and would rewrite + re-flash the RP2040 on every boot. Comparison is now semantic (`active==0 and protocol==NONE`).

## Verification

Verified across a real reboot on `aryaos-584d`:

- `aryaos-adsbee.service` ran at boot, found the device, reported *"configuration already correct"* (idempotent — no flash write)
- `/etc/default/readsb` still says `--device-type rtlsdr`, while `readsb` runs on `--device-type modesbeast`
- `aryaos-serial-assign` logs an explicit skip for the device
- `dump978-fa` inactive, `systemctl --failed` empty
- CoT on the mesh: `<event type="a-n-A-C" uid="ICAO-A38527">`
- `readsb` at 0.0% CPU, 40.6 °C, `throttled=0x0`
- Pinning `ARYAOS_ADSB_RECEIVER=rtlsdr` correctly bypasses the ADSBee; back to `auto` restores it
- `pytest scripts/test_capability_scan.py scripts/test_beacon_caps.py` — 23 passed (extended with three ADSBee cases; the existing suite caught my change, which is what it is for)

## Not done

A **same-antenna RF A/B against an RTL box**. The power win is proven; sensitivity equivalence is not — traffic was sparse all session (1–4 aircraft), which points at the antenna rather than the receiver.

## Docs

- [ADSBee](docs/config/adsbee.md) — what it is, configuration, emissions posture, troubleshooting
- [Runbook](docs/operations/adsbee-runbook.md) — fitting one to a unit, acceptance checklist, failure modes, rollback
- `docs/agent-handoff.md` updated with the architecture invariants and both traps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM
