### PR TITLE
Detect DroneCoT TAK egress loss

### DIFF
--- a/docs/deploy/counter-uas.md
+++ b/docs/deploy/counter-uas.md
@@ -73,7 +73,7 @@ Each detector emits CoT to the Charontak hub at `udp+wo://127.0.0.1:28087`; Char
 
 An **AntSDR E200** running the [alphafox02 DJI DroneID firmware](https://github.com/alphafox02/antsdr_dji_droneid) detects DJI OcuSync DroneID and **pushes it to `dronecot` over point-to-point Ethernet** (TCP `172.31.100.1:52002`). That Ethernet link is the data path; the AntSDR's **USB-serial is its Zynq config/recovery console, not a data feed**.
 
-- **Health at a glance.** AryaOS polls the feed every 30 s (`aryaos-antsdr-health`) and, when an AntSDR is present, shows an **AntSDR (DJI DroneID)** card in Cockpit: green when the feed socket is established, amber when the SDR is reachable but silent (normal with no DJI drone in range; otherwise the firmware may have stalled). The card is hidden on boxes with no AntSDR. Check it by hand any time:
+- **Health at a glance.** AryaOS polls the feed every 30 s (`aryaos-antsdr-health`) and, when an AntSDR is present, shows an **AntSDR (DJI DroneID)** card in Cockpit: green when both the feed socket and DroneCOT's TAK WebSocket are established, amber when either side is missing. A missing feed can be normal with no DJI drone in range; `tak_established: false` means TAK egress is actually degraded even if systemd still calls DroneCOT active. The card is hidden on boxes with no AntSDR. Check it by hand any time:
 
     ```bash
     aryaos-antsdr-health --json

--- a/scripts/aryaos-test/tests/07-antsdr.sh
+++ b/scripts/aryaos-test/tests/07-antsdr.sh
@@ -66,4 +66,18 @@ else
 	warn "ANTSDR TCP session not established"
 fi
 
+if [[ -x /usr/local/sbin/aryaos-antsdr-health ]]; then
+	HEALTH_JSON="$(sudo -n /usr/local/sbin/aryaos-antsdr-health --quiet --json 2>/dev/null || true)"
+	if python3 -c '
+import json, sys
+doc = json.load(sys.stdin)
+assert "tak_established" in doc
+assert doc["tak_established"] in (True, False, None)
+' <<<"${HEALTH_JSON}" 2>/dev/null; then
+		ok "ANTSDR health reports TAK egress state"
+	else
+		fail "ANTSDR health missing valid tak_established state"
+	fi
+fi
+
 print_summary

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -267,7 +267,7 @@ require_pkg ais-catcher
 require_pkg sikw00fcot
 require_pkg gdltak
 require_pkg_version pytak 7.4.1
-require_pkg_version dronecot 2.3.3
+require_pkg_version dronecot 2.3.4
 require_unit adsbcot.service
 require_unit aiscot.service
 require_unit dronecot.service

--- a/scripts/verify-image.sh
+++ b/scripts/verify-image.sh
@@ -126,6 +126,16 @@ require_pkg() {
 		fail "package $1 not installed"
 	fi
 }
+require_pkg_version() {
+	local pkg="$1" minimum="$2" version
+	version="$(awk -v pkg="${pkg}" 'BEGIN{RS=""} $0 ~ "Package: "pkg"\n" {for (i=1;i<=NF;i++) if ($i=="Version:") {print $(i+1); exit}}' \
+		"${MNT}/var/lib/dpkg/status" 2>/dev/null)"
+	if [[ -n "${version}" ]] && dpkg --compare-versions "${version}" ge "${minimum}"; then
+		ok "package ${pkg} ${version} >= ${minimum}"
+	else
+		fail "package ${pkg} ${version:-missing} is older than ${minimum}"
+	fi
+}
 
 echo "== AryaOS image content checks: ${IMG##*/} (lab=${LAB_EXPECTED}) =="
 
@@ -256,6 +266,8 @@ require_pkg python3-gps
 require_pkg ais-catcher
 require_pkg sikw00fcot
 require_pkg gdltak
+require_pkg_version pytak 7.4.1
+require_pkg_version dronecot 2.3.3
 require_unit adsbcot.service
 require_unit aiscot.service
 require_unit dronecot.service
@@ -270,6 +282,7 @@ require_grep '303a' /etc/udev/rules.d/99-aryaos-dronescout.rules "DS101 udev sym
 require_path /usr/local/sbin/aryaos-antsdr-console
 require_path /usr/local/sbin/aryaos-antsdr-health
 require_path /etc/systemd/system/aryaos-antsdr-health.timer
+require_grep 'tak_established' /usr/local/sbin/aryaos-antsdr-health "AntSDR health reports DroneCOT TAK egress"
 require_grep '1a86' /etc/udev/rules.d/99-aryaos-antsdr-console.rules "AntSDR console udev rule present"
 require_path /usr/bin/tio
 # Wi-Fi Remote ID: opt-in dronecot instance (802.11 monitor-mode ODID capture).

--- a/shared_files/aryaos/aryaos-antsdr-health
+++ b/shared_files/aryaos/aryaos-antsdr-health
@@ -4,9 +4,10 @@
 # An AntSDR running the alphafox02 antsdr_dji_droneid firmware detects DJI
 # OcuSync DroneID and PUSHES it over point-to-point Ethernet to dronecot's DJI
 # listener (TCP, default 172.31.100.1:52002). This tool checks that path is
-# healthy — the SDR is reachable and the feed socket is ESTABLISHED — and writes
-# a small JSON status for Cockpit plus a syslog line. It is OBSERVABILITY ONLY:
-# it never restarts or reconfigures anything, so it cannot disrupt a live feed.
+# healthy — the SDR is reachable, the feed socket is ESTABLISHED, and dronecot's
+# TAK WebSocket is connected — then writes a small JSON status for Cockpit plus
+# a syslog line. It is OBSERVABILITY ONLY: it never restarts or reconfigures
+# anything, so it cannot disrupt a live feed.
 #
 # Usage:
 #   aryaos-antsdr-health            # evaluate, write /run/aryaos/antsdr-health.json, log
@@ -31,11 +32,15 @@ BIND="172.31.100.1"
 [[ -n "${DJI_TCP_PORT:-}" ]] && PORT="${DJI_TCP_PORT}"
 [[ -n "${DJI_BIND_ADDRESS:-}" ]] && BIND="${DJI_BIND_ADDRESS}"
 
-# AntSDR peer: explicit override, else the .2 host of the Pi's /24 link net.
+# AntSDR peer: explicit override, then a live feed peer, then the .2 host of the
+# Pi's point-to-point /24 link net.
 ANTSDR_IP="${ANTSDR_IP:-}"
 [[ -r /etc/default/aryaos-antsdr ]] && . <(grep -E '^ANTSDR_IP=' /etc/default/aryaos-antsdr 2>/dev/null | sed 's/^/export /') 2>/dev/null || true
 if [[ -z "${ANTSDR_IP}" ]]; then
-	ANTSDR_IP="${BIND%.*}.2"
+	peer="$(ss -tnH state established "( sport = :${PORT} )" 2>/dev/null | awk 'NR == 1 {print $4}')"
+	ANTSDR_IP="${peer%:*}"
+	ANTSDR_IP="${ANTSDR_IP#[}"; ANTSDR_IP="${ANTSDR_IP%]}"
+	[[ -n "${ANTSDR_IP}" ]] || ANTSDR_IP="${BIND%.*}.2"
 fi
 
 quiet=0; want_json=0
@@ -64,7 +69,65 @@ elif ss -tnH state established "( dport = :${PORT} )" 2>/dev/null | grep -q "${A
 	feed=true
 fi
 
-if $feed; then
+# 3) For WebSocket/tak:// output, does THIS dronecot process still own an
+#    established connection to the resolved TAK port? This catches the failure
+#    mode where WSRXWorker exits but systemd continues to report the process as
+#    active. Never copy COT_URL into output: tak:// URLs can carry enrollment
+#    credentials.
+read_env_value() {
+	local path="$1" key="$2"
+	[[ -r "${path}" ]] || return 0
+	sed -n -E "s/^[[:space:]]*${key}=//p" "${path}" 2>/dev/null | tail -1
+}
+
+COT_URL=""
+for config_path in /etc/aryaos/aryaos-config.txt /etc/default/dronecot; do
+	value="$(read_env_value "${config_path}" COT_URL)"
+	if [[ -n "${value}" ]]; then
+		value="${value#\"}"; value="${value%\"}"
+		value="${value#\'}"; value="${value%\'}"
+		COT_URL="${value}"
+	fi
+done
+
+tak_port=""
+scheme="${COT_URL%%://*}"
+case "${scheme}" in
+	tak)
+		host_param="${COT_URL#*host=}"
+		host_param="${host_param%%&*}"
+		host_param="${host_param//%3A/:}"
+		host_param="${host_param//%3a/:}"
+		if [[ "${host_param}" =~ :([0-9]+)$ ]]; then
+			tak_port="${BASH_REMATCH[1]}"
+		else
+			tak_port=8443
+		fi
+		;;
+	ws|wss)
+		authority="${COT_URL#*://}"
+		authority="${authority%%/*}"
+		authority="${authority##*@}"
+		if [[ "${authority}" =~ :([0-9]+)$ ]]; then
+			tak_port="${BASH_REMATCH[1]}"
+		else
+			tak_port=8443
+		fi
+		;;
+esac
+
+tak_established=null
+if [[ -n "${tak_port}" ]]; then
+	tak_established=false
+	main_pid="$(systemctl show dronecot.service -p MainPID --value 2>/dev/null)"
+	if [[ "${main_pid}" =~ ^[1-9][0-9]*$ ]] && \
+		ss -tnpH state established "( dport = :${tak_port} )" 2>/dev/null | \
+		grep -q "pid=${main_pid},"; then
+		tak_established=true
+	fi
+fi
+
+if $feed && [[ "${tak_established}" != false ]]; then
 	status="ok"
 elif $reachable; then
 	status="degraded"   # SDR is up but not pushing DroneID (idle if no DJI drone, or app stalled)
@@ -79,7 +142,7 @@ prev=""
 [[ -r "${STATE_FILE}" ]] && prev="$(sed -n 's/.*"status":"\([a-z]*\)".*/\1/p' "${STATE_FILE}" 2>/dev/null)"
 
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
-json="{\"status\":\"${status}\",\"antsdr_ip\":\"${ANTSDR_IP}\",\"feed_port\":${PORT},\"reachable\":${reachable},\"feed_established\":${feed},\"ts\":\"${ts}\"}"
+json="{\"status\":\"${status}\",\"antsdr_ip\":\"${ANTSDR_IP}\",\"feed_port\":${PORT},\"reachable\":${reachable},\"feed_established\":${feed},\"tak_established\":${tak_established},\"ts\":\"${ts}\"}"
 
 mkdir -p "${RUN_DIR}" 2>/dev/null
 # Best-effort state file for Cockpit. Guard the write so a NON-root invocation
@@ -93,7 +156,13 @@ fi
 if [[ "${quiet}" != 1 && "${status}" != "${prev}" ]]; then
 	case "${status}" in
 		ok)       logger -t aryaos-antsdr-health "AntSDR ${ANTSDR_IP} OK — DroneID feed established on :${PORT}" 2>/dev/null || true;;
-		degraded) logger -t aryaos-antsdr-health "AntSDR ${ANTSDR_IP} reachable but NO DroneID feed on :${PORT} (idle if no DJI drone, or firmware stalled)" 2>/dev/null || true;;
+		degraded)
+			if $feed && [[ "${tak_established}" == false ]]; then
+				logger -t aryaos-antsdr-health "AntSDR ${ANTSDR_IP} feed established but dronecot has NO TAK WebSocket connection" 2>/dev/null || true
+			else
+				logger -t aryaos-antsdr-health "AntSDR ${ANTSDR_IP} reachable but NO DroneID feed on :${PORT} (idle if no DJI drone, or firmware stalled)" 2>/dev/null || true
+			fi
+			;;
 		down)     logger -t aryaos-antsdr-health "AntSDR ${ANTSDR_IP} not present on the link (${BIND%.*}.0/24) — expected if this box has no AntSDR" 2>/dev/null || true;;
 	esac
 fi


### PR DESCRIPTION
## Summary
- extend the AntSDR health probe with a backward-compatible tak_established field tied to the DroneCoT MainPID
- discover the active AntSDR peer before falling back to the configured address
- require PyTAK 7.4.1 and corrected DroneCoT 2.3.4 in image validation
- document and test the new observability contract; the guard remains non-remediating

Depends on snstac/pytak#111, snstac/dronecot#13, and the release-packaging correction snstac/dronecot#14. Merge after 2.3.4 reaches the package repository.

## Validation
- bash syntax checks passed
- JSON health smoke test passed
- git diff --check passed
- proposed helper tested live on newave.local: feed and TAK sockets both detected, status ok
- upstream PyTAK: 213 passed, 1 skipped
- upstream DroneCoT: 96 passed, 1 skipped
- locally built 2.3.4 wheel contains dronecot/VERSION