### PR TITLE
Default aryaos.org to the light theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,35 +37,26 @@ theme:
   icon:
     repo: fontawesome/brands/github
   palette:
-    # The auto entry needs the colours spelled out too. With them omitted
-    # Material falls back to its stock indigo, which shipped in the built HTML
-    # as data-md-color-primary="indigo" for every visitor whose browser has no
-    # explicit colour-scheme preference -- the default state.
-    - media: "(prefers-color-scheme)"
-      primary: custom
-      accent: custom
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-    # `custom` tells Material to emit no palette of its own and defer to the
-    # variables set in docs/stylesheets/suite.css, which bridge the vendored
-    # design-kit tokens. This used to say `teal` — the pre-kit colour the whole
-    # fleet has now been moved off (the Cockpit plugins carried the same
-    # #35a58f). Material's teal still won anywhere our overrides did not reach.
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    # AryaOS documentation defaults to its sunlight-legible light palette,
+    # independent of the visitor's OS preference. A saved Material palette
+    # choice still wins, and the header toggle provides an explicit dark mode.
+    - scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    # `custom` tells Material to emit no palette of its own and defer to the
+    # variables set in docs/stylesheets/suite.css, which bridge the vendored
+    # design-kit tokens. This used to say `teal` — the pre-kit colour the whole
+    # fleet has now been moved off (the Cockpit plugins carried the same
+    # #35a58f). Material's teal still won anywhere our overrides did not reach.
+    - scheme: slate
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-4
-        name: Switch to system preference
+        name: Switch to light mode
   features:
     - navigation.tabs
     - navigation.tabs.sticky

--- a/scripts/test_docs_theme.py
+++ b/scripts/test_docs_theme.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Regression tests for the public AryaOS documentation theme."""
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DocsThemeTestCase(unittest.TestCase):
+    def test_light_palette_is_the_unconditional_default(self):
+        # The later Markdown extension section intentionally contains MkDocs
+        # Python object tags. Keep this configuration assertion safe and
+        # dependency-light by parsing only the ordinary YAML before `nav:`.
+        source = (ROOT / "mkdocs.yml").read_text()
+        config = yaml.safe_load(source.split("\nnav:", 1)[0])
+        palette = config["theme"]["palette"]
+
+        self.assertEqual("default", palette[0]["scheme"])
+        self.assertNotIn("media", palette[0])
+        self.assertEqual("Switch to dark mode", palette[0]["toggle"]["name"])
+
+        self.assertEqual("slate", palette[1]["scheme"])
+        self.assertNotIn("media", palette[1])
+        self.assertEqual("Switch to light mode", palette[1]["toggle"]["name"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make the sunlight-legible light palette the unconditional first-paint default on aryaos.org
- retain dark mode as an explicit header toggle and continue honoring saved Material palette choices
- add a regression covering palette order and the absence of system-preference media conditions

## Validation

- 110 Python unit tests pass
- strict MkDocs production build passes with pinned dependencies
- generated homepage body uses `data-md-color-scheme="default"`; palette index 0 is light and index 1 is dark
