### PR TITLE
Use plain language throughout AryaOS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <img src="docs/brand/logo/mark-aryaos.svg" width="160" height="160" alt="AryaOS Signal Block mark">
 
-# AryaOS — the situational awareness operating system for TAK
+# AryaOS - the situational awareness operating system for TAK
 
 AryaOS turns an inexpensive single-board computer into a turn-key sensor gateway. It listens to
-the radio traffic around it — aircraft, vessels, drones, radios — and puts what it hears onto any
+the radio traffic around it - aircraft, vessels, drones, radios - and puts what it hears onto any
 [TAK](https://www.aryaos.org/reference/glossary/#tak) device as
 [Cursor on Target](https://www.aryaos.org/reference/glossary/#cot): ATAK, WinTAK, iTAK, TAKX, or a
 TAK Server.
 
-No cloud. No subscription. No command line. Flash a card, boot the box, connect a phone —
+No cloud. No subscription. No command line. Flash a card, boot the box, connect a phone -
 everything else is configured from a touch-friendly web console.
 
-[**Get started in 15 minutes →**](https://www.aryaos.org/get-started/quickstart/)
+[**Get started in 15 minutes >**](https://www.aryaos.org/get-started/quickstart/)
 
 ## What you can build with it
 
@@ -20,29 +20,29 @@ everything else is configured from a touch-friendly web console.
 | **Aerial firefighting & wildland fire** | Puts the local ADS-B and UAT air picture in front of crews on the ground, with no dependence on connectivity. The original AirTAK use case, funded by the Colorado Center of Excellence and the USDA Forest Service. |
 | **Search & rescue** | A backpack-sized node that broadcasts its own Wi-Fi and shares aircraft, vessel, and team position with every phone in range. |
 | **Maritime domain awareness** | Live vessel traffic from an over-the-air AIS receiver or an online feed. |
-| **Counter-UAS & airspace security** | Detects drones by Remote ID (Wi-Fi and Bluetooth), DJI DroneID, and purpose-built receivers — reporting the aircraft *and* the operator's location. |
+| **Counter-UAS & airspace security** | Detects drones by Remote ID (Wi-Fi and Bluetooth), DJI DroneID, and purpose-built receivers - reporting the aircraft *and* the operator's location. |
 | **Range & site security** | A fixed multi-sensor node fusing air, maritime, and drone feeds into a single common operating picture. |
 | **CoT relay & bridging** | Moves Cursor on Target between isolated networks, radios, and a TAK Server. |
 | **Electronic flight bag** | Feeds ADS-B traffic to ForeFlight and other GDL 90 apps. |
 
 ## What it can hear
 
-Capabilities are named after the signal, not after a product — `adsb`, `ais`,
+Capabilities are named after the signal, not after a product - `adsb`, `ais`,
 `wifi-rid`, `ble-rid`, `rid`, `dji`, `sik`, `sapient`. They are exactly the names
 you type, the names the box reports, and the names on the map.
 
 Each capability is a receiver AryaOS turns into TAK tracks. The image ships with every sensor
 **switched off**; on first boot the box works out what is actually plugged in and enables what it
-finds, then reports anything it could do but did not turn on — so you always know what the hardware
+finds, then reports anything it could do but did not turn on - so you always know what the hardware
 is capable of.
 
 | Capability | Enable with | What appears on the map | Hardware needed |
 |------------|-------------|-------------------------|-----------------|
-| **ADS-B / UAT** | `adsb` | Crewed aircraft on 1090 MHz and 978 MHz | **SDR** — RTL-SDR, or any SoapySDR device |
+| **ADS-B / UAT** | `adsb` | Crewed aircraft on 1090 MHz and 978 MHz | **SDR** - RTL-SDR, or any SoapySDR device |
 | **AIS** | `ais` | Ships and vessels | dAISy NMEA receiver, or a spare **SDR** |
-| **Remote ID** — Wi-Fi | `wifi-rid` | ASTM F3411 Remote ID over 802.11, plus operator location | Monitor-mode Wi-Fi adapter (e.g. Atheros AR9271) |
-| **Remote ID** — Bluetooth | `ble-rid` | ASTM F3411 Remote ID over Bluetooth LE | **None** — the board's own radio |
-| **Remote ID** — receiver | `rid` | Remote ID via a dedicated receiver, over **MAVLink** | BlueMark DroneScout DS110 |
+| **Remote ID** - Wi-Fi | `wifi-rid` | ASTM F3411 Remote ID over 802.11, plus operator location | Monitor-mode Wi-Fi adapter (e.g. Atheros AR9271) |
+| **Remote ID** - Bluetooth | `ble-rid` | ASTM F3411 Remote ID over Bluetooth LE | **None** - the board's own radio |
+| **Remote ID** - receiver | `rid` | Remote ID via a dedicated receiver, over **MAVLink** | BlueMark DroneScout DS110 |
 | **DJI DroneID** | `dji` | DJI aircraft and the pilot's position | AntSDR E200 |
 | **MAVLink telemetry** | `sik` | Drone telemetry from a SiK radio | SiK / SiKW00F radio |
 | **SAPIENT C-UAS** | `sapient` | Counter-UAS sensors speaking BSI Flex 335 | Networked sensor |
@@ -57,7 +57,7 @@ capabilities want the same radio.
 
 ## Why teams choose it
 
-* **Works with every TAK product** — ATAK, WinTAK, iTAK, TAKX, and TAK Server, over the open
+* **Works with every TAK product** - ATAK, WinTAK, iTAK, TAKX, and TAK Server, over the open
   Cursor on Target standard.
 * **Runs offline.** Boots on a Raspberry Pi, broadcasts its own Wi-Fi, and needs no internet to put
   a picture on a phone in a backpack.
@@ -70,7 +70,7 @@ capabilities want the same radio.
   and licensed Apache 2.0.
 * **Inexpensive, low SWaP-C hardware.** Built for Arm (arm64) single-board computers such as the
   Raspberry Pi 4 and 5. Intel/amd64 support is planned
-  ([#129](https://github.com/snstac/aryaos/issues/129)) — the full gateway suite already installs on
+  ([#129](https://github.com/snstac/aryaos/issues/129)) - the full gateway suite already installs on
   any Debian host from the [signed apt repository](https://snstac.github.io/packages).
 
 ## AryaOS Software Suite
@@ -79,19 +79,19 @@ AryaOS ships with the full [Sensors & Signals](https://www.snstac.com) open-sour
 
 | Project | What it does |
 |---------|--------------|
-| [PyTAK — Python Team Awareness Kit (TAK) library](https://github.com/snstac/pytak) | Python framework for building TAK & Cursor on Target (CoT) integrations. ([PyTAK documentation](https://pytak.readthedocs.io/)) |
-| [ADSBCOT — ADS-B to TAK gateway](https://github.com/snstac/adsbcot) | Displays live aircraft from ADS-B receivers in ATAK, WinTAK & iTAK. ([ADSBCOT documentation](https://adsbcot.readthedocs.io/)) |
-| [AISCOT — AIS to TAK gateway](https://github.com/snstac/aiscot) | Displays ships & maritime vessel traffic from AIS in TAK. ([AISCOT documentation](https://aiscot.readthedocs.io/)) |
-| [DroneCOT — Drone Remote ID to TAK gateway](https://github.com/snstac/dronecot) | Detects & tracks drones (Remote ID / Open Drone ID) in TAK for counter-UAS awareness. |
-| [AIRCOT — aircraft classification for TAK](https://github.com/snstac/aircot) | Classifies aircraft into TAK/CoT types from ADS-B & Mode S data. ([AIRCOT documentation](https://aircot.readthedocs.io/)) |
-| [DJICOT — DJI drone detection for TAK](https://github.com/snstac/djicot) | Detects & tracks DJI drones (DroneID) in TAK. ([DJICOT documentation](https://djicot.readthedocs.io/)) |
-| [GPSTAK — network GPS for TAK](https://github.com/snstac/gpstak) | Streams gpsd position data to TAK as CoT, with NMEA fan-out for WinTAK. |
-| [LINCOT — Linux GPS to TAK gateway](https://github.com/snstac/lincot) | Sends Linux device position (GPS) to TAK. |
-| [APRSCOT — APRS to TAK gateway](https://github.com/snstac/aprscot) | Displays amateur radio APRS stations in TAK. ([APRSCOT documentation](https://aprscot.readthedocs.io/)) |
-| [INRCOT — Garmin inReach to TAK gateway](https://github.com/snstac/inrcot) | Displays Garmin inReach satellite tracker positions in TAK. |
-| [SiKW00FCOT — MAVLink drone telemetry to TAK](https://github.com/snstac/sikw00fcot) | Converts SiK-radio MAVLink drone telemetry to Cursor on Target. |
-| [CharonTAK — Cursor on Target ferryman](https://github.com/snstac/charontak) | Bridges & relays CoT between networks and TAK servers. |
-| [QRTAK — TAK onboarding with QR codes](https://github.com/snstac/qrtak) | Onboard devices to TAK Server by scanning a QR code. |
+| [PyTAK - Python Team Awareness Kit (TAK) library](https://github.com/snstac/pytak) | Python framework for building TAK & Cursor on Target (CoT) integrations. ([PyTAK documentation](https://pytak.readthedocs.io/)) |
+| [ADSBCOT - ADS-B to TAK gateway](https://github.com/snstac/adsbcot) | Displays live aircraft from ADS-B receivers in ATAK, WinTAK & iTAK. ([ADSBCOT documentation](https://adsbcot.readthedocs.io/)) |
+| [AISCOT - AIS to TAK gateway](https://github.com/snstac/aiscot) | Displays ships & maritime vessel traffic from AIS in TAK. ([AISCOT documentation](https://aiscot.readthedocs.io/)) |
+| [DroneCOT - Drone Remote ID to TAK gateway](https://github.com/snstac/dronecot) | Detects & tracks drones (Remote ID / Open Drone ID) in TAK for counter-UAS awareness. |
+| [AIRCOT - aircraft classification for TAK](https://github.com/snstac/aircot) | Classifies aircraft into TAK/CoT types from ADS-B & Mode S data. ([AIRCOT documentation](https://aircot.readthedocs.io/)) |
+| [DJICOT - DJI drone detection for TAK](https://github.com/snstac/djicot) | Detects & tracks DJI drones (DroneID) in TAK. ([DJICOT documentation](https://djicot.readthedocs.io/)) |
+| [GPSTAK - network GPS for TAK](https://github.com/snstac/gpstak) | Streams gpsd position data to TAK as CoT, with NMEA fan-out for WinTAK. |
+| [LINCOT - Linux GPS to TAK gateway](https://github.com/snstac/lincot) | Sends Linux device position (GPS) to TAK. |
+| [APRSCOT - APRS to TAK gateway](https://github.com/snstac/aprscot) | Displays amateur radio APRS stations in TAK. ([APRSCOT documentation](https://aprscot.readthedocs.io/)) |
+| [INRCOT - Garmin inReach to TAK gateway](https://github.com/snstac/inrcot) | Displays Garmin inReach satellite tracker positions in TAK. |
+| [SiKW00FCOT - MAVLink drone telemetry to TAK](https://github.com/snstac/sikw00fcot) | Converts SiK-radio MAVLink drone telemetry to Cursor on Target. |
+| [CharonTAK - Cursor on Target ferryman](https://github.com/snstac/charontak) | Bridges & relays CoT between networks and TAK servers. |
+| [QRTAK - TAK onboarding with QR codes](https://github.com/snstac/qrtak) | Onboard devices to TAK Server by scanning a QR code. |
 
 Every gateway on AryaOS is managed from a touch-friendly browser UI built on [Cockpit](https://cockpit-project.org/), including [cockpit-aryaos](https://github.com/snstac/cockpit-aryaos), [cockpit-adsbcot](https://github.com/snstac/cockpit-adsbcot), [cockpit-aiscot](https://github.com/snstac/cockpit-aiscot), [cockpit-dronecot](https://github.com/snstac/cockpit-dronecot), [cockpit-gpstak](https://github.com/snstac/cockpit-gpstak) & [cockpit-lincot](https://github.com/snstac/cockpit-lincot).
 

--- a/docs/admin/aryaos-site.md
+++ b/docs/admin/aryaos-site.md
@@ -1,11 +1,11 @@
 # AryaOS Site page
 
-The **AryaOS Site** page is the single most important admin surface on the device. It edits the site-wide settings in `/etc/aryaos/aryaos-config.txt` — the file inherited by every PyTAK sensor gateway — plus onboarding, radios, updates, VPN, and support tooling. Open it from Cockpit's menu, or directly at `https://aryaos-xxxx.local/admin/` → **AryaOS Site**.
+The **AryaOS Site** page is the single most important admin surface on the device. It edits the site-wide settings in `/etc/aryaos/aryaos-config.txt` - the file inherited by every PyTAK sensor gateway - plus onboarding, radios, updates, VPN, and support tooling. Open it from Cockpit's menu, or directly at `https://aryaos-xxxx.local/admin/` > **AryaOS Site**.
 
-![The AryaOS Site page in Cockpit — TAK destination, device role, radios, TLS, sensor services, updates, backup, and decommission cards](../media/screenshots/aryaos-site-cockpit.png)
+![The AryaOS Site page in Cockpit - TAK destination, device role, radios, TLS, sensor services, updates, backup, and decommission cards](../media/screenshots/aryaos-site-cockpit.png)
 
 !!! info "How saving works"
-    The page edits known keys **in place** and preserves everything else in the file, including comments. Most cards apply immediately, but the **TAK destination** and TLS fields at the top only take effect when you press **Save & restart sensors** (or **Save only**) at the bottom of the page — see [Save & restart](#save-restart). Cards with their own buttons (role, hotspot, radios, updates, VPN, support, Node-RED) act on their own.
+    The page edits known keys **in place** and preserves everything else in the file, including comments. Most cards apply immediately, but the **TAK destination** and TLS fields at the top only take effect when you press **Save & restart sensors** (or **Save only**) at the bottom of the page - see [Save & restart](#save-restart). Cards with their own buttons (role, hotspot, radios, updates, VPN, support, Node-RED) act on their own.
 
 The cards appear in the order below.
 
@@ -24,12 +24,12 @@ The cards appear in the order below.
 The default **Site COT_URL** feeds the local **Charontak hub** on `udp+wo://127.0.0.1:28087`. Charontak then forwards that stream to Mesh SA and/or a TAK Server through its own lanes.
 
 !!! tip "Keep the default unless you know why"
-    For almost every deployment you should leave `COT_URL` pointed at the Charontak hub and configure your actual upstream (Mesh SA, TAK Server) in the [Charontak lane editor](./charontak-lanes.md). Only change `COT_URL` when you are deliberately bypassing Charontak — for example, to send every feeder directly to `tls://takserver.example.com:8089` or `udp+wo://239.2.3.1:6969`. This is the CoT routing invariant: **feeders → charontak → Mesh SA / TAK Server**.
+    For almost every deployment you should leave `COT_URL` pointed at the Charontak hub and configure your actual upstream (Mesh SA, TAK Server) in the [Charontak lane editor](./charontak-lanes.md). Only change `COT_URL` when you are deliberately bypassing Charontak - for example, to send every feeder directly to `tls://takserver.example.com:8089` or `udp+wo://239.2.3.1:6969`. This is the CoT routing invariant: **feeders > charontak > Mesh SA / TAK Server**.
 
 The **ADS-B decoder** drop-down offers `readsb` (RTL-SDR / SoapySDR / HackRF) and `dump1090-fa` (FlightAware). Only one 1090 MHz decoder runs at a time.
 
 !!! warning "Changing the decoder needs a service switch too"
-    Setting `ARYAOS_ADSB_DECODER` records *which* decoder should be enabled, but it does not by itself start or stop systemd units. Re-apply the [device role](./aryaos-site.md#device-role) after changing the decoder — the role logic enables the selected decoder and disables the other. See [Radios & SDRs](../config/radios-sdr.md) for the full switch procedure.
+    Setting `ARYAOS_ADSB_DECODER` records *which* decoder should be enabled, but it does not by itself start or stop systemd units. Re-apply the [device role](./aryaos-site.md#device-role) after changing the decoder - the role logic enables the selected decoder and disables the other. See [Radios & SDRs](../config/radios-sdr.md) for the full switch procedure.
 
 The **UAT serial** must differ from the 1090 MHz serial. See [Radios (RTL-SDR)](#radios-rtl-sdr) below and [Radios & SDRs](../config/radios-sdr.md).
 
@@ -37,7 +37,7 @@ The **UAT serial** must differ from the 1090 MHz serial. See [Radios (RTL-SDR)](
 
 ## Device role
 
-**What it does.** Chooses which sensor pipelines run on this unit. The **CoT core** — Charontak, LINCOT, GPSTAK, and gpsd — always runs; the role enables its sensor services at boot and stops the rest.
+**What it does.** Chooses which sensor pipelines run on this unit. The **CoT core** - Charontak, LINCOT, GPSTAK, and gpsd - always runs; the role enables its sensor services at boot and stops the rest.
 
 | Role | Pipelines |
 |------|-----------|
@@ -47,7 +47,7 @@ The **UAT serial** must differ from the 1090 MHz serial. See [Radios (RTL-SDR)](
 | C-UAS | Drone detection |
 | Relay | CoT routing only (no sensors) |
 
-The card lists the exact sensor services the selected role will enable ("Sensor services for this role: …"). Press **Apply role**; you will be asked to confirm, because services outside the chosen role are **stopped and disabled at boot**.
+The card lists the exact sensor services the selected role will enable ("Sensor services for this role: ..."). Press **Apply role**; you will be asked to confirm, because services outside the chosen role are **stopped and disabled at boot**.
 
 **Config key:** the choice is persisted as `ARYAOS_ROLE` in the site config and applied by the `aryaos-role set` helper. Full unit-by-unit detail is in [Device roles](../config/device-roles.md).
 
@@ -60,9 +60,9 @@ The card lists the exact sensor services the selected role will enable ("Sensor 
 
 **What it does.** Sets (or removes) the WPA2 password on the device's onboarding Wi-Fi hotspot.
 
-When no known Wi-Fi is in range, AryaOS broadcasts its onboarding hotspot (`AryaOS-xxxx`) via Comitup. **By default the hotspot is open.** Enter a password of **8–63 characters** and press **Save hotspot password** to protect it; press **Remove password (open AP)** to return to an open hotspot.
+When no known Wi-Fi is in range, AryaOS broadcasts its onboarding hotspot (`AryaOS-xxxx`) via Comitup. **By default the hotspot is open.** Enter a password of **8-63 characters** and press **Save hotspot password** to protect it; press **Remove password (open AP)** to return to an open hotspot.
 
-**File touched:** `/etc/comitup.conf` — the card writes the `ap_password:` setting (commenting it out re-opens the AP), then restarts `comitup`.
+**File touched:** `/etc/comitup.conf` - the card writes the `ap_password:` setting (commenting it out re-opens the AP), then restarts `comitup`.
 
 !!! warning "Applies to the next hotspot"
     A password change applies the **next** time the hotspot comes up. Reboot the device to force it. If you are currently connected over the hotspot, changing it will drop your connection. See [Wi-Fi & onboarding hotspot](../networking/wifi-hotspot.md).
@@ -75,10 +75,10 @@ When no known Wi-Fi is in range, AryaOS broadcasts its onboarding hotspot (`Arya
 
 AryaOS selects dongles by EEPROM serial:
 
-- `stx:1090:0` — ADS-B 1090 MHz (readsb / dump1090-fa)
-- `stx:978:0` — UAT 978 MHz (dump978-fa), matching the **UAT serial** in [TAK destination](#tak-destination)
+- `stx:1090:0` - ADS-B 1090 MHz (readsb / dump1090-fa)
+- `stx:978:0` - UAT 978 MHz (dump978-fa), matching the **UAT serial** in [TAK destination](#tak-destination)
 
-The table shows each detected dongle's index, device string, and current serial, plus a **New serial** field and a **Write** button. Use the refresh icon to rescan. Serials must be 1–32 characters from the set `A-Z a-z 0-9 : . _ -`.
+The table shows each detected dongle's index, device string, and current serial, plus a **New serial** field and a **Write** button. Use the refresh icon to rescan. Serials must be 1-32 characters from the set `A-Z a-z 0-9 : . _ -`.
 
 **Backend:** the `aryaos-sdr` helper (`list` and `set-serial`).
 
@@ -112,7 +112,7 @@ The **Don't verify server certificate** checkbox sets `PYTAK_TLS_DONT_VERIFY=1`.
     openssl pkcs12 -in bundle.p12 -out client.pem -clcerts -nokeys
     openssl pkcs12 -in bundle.p12 -out client.key -nocerts -nodes
     ```
-    Certificates apply after you press **Save & restart sensors**. In most cases the **TAK connection** card below is easier — it installs certs from a data package or enrollment URL automatically.
+    Certificates apply after you press **Save & restart sensors**. In most cases the **TAK connection** card below is easier - it installs certs from a data package or enrollment URL automatically.
 
 ---
 
@@ -122,17 +122,17 @@ The **Don't verify server certificate** checkbox sets `PYTAK_TLS_DONT_VERIFY=1`.
 
 The status table at the top of the card reports:
 
-- **Enrollment** — configured or not
-- **Import service** — ready or not
-- **TAK target** — the resulting `COT_URL`
-- **TLS material** — whether cert, key, and CA are present
+- **Enrollment** - configured or not
+- **Import service** - ready or not
+- **TAK target** - the resulting `COT_URL`
+- **TLS material** - whether cert, key, and CA are present
 - **Last updated** / **Detail** when available
 
-**To enroll with a URL:** paste the one-time `tak://com.atakmap.app/enroll?host=…&username=…&token=…` string into **One-time enrollment URL** and press **Enroll**.
+**To enroll with a URL:** paste the one-time `tak://com.atakmap.app/enroll?host=...&username=...&token=...` string into **One-time enrollment URL** and press **Enroll**.
 
 **To import a package:** choose a `.zip` or `.dpk` connection package under **Connection package** and press **Import package**. Use **Refresh status** to re-read state.
 
-On success the card reports the TAK target and that **Charontak forwarding was updated** — so this card configures the upstream lane for you.
+On success the card reports the TAK target and that **Charontak forwarding was updated** - so this card configures the upstream lane for you.
 
 !!! tip "Preferred way to connect to a TAK Server"
     This card is the easiest path to a working TAK Server connection. It handles TLS material and the Charontak lane together. For the manual lane approach, see [Connect to a TAK Server](../deploy/connect-tak-server.md) and the [Charontak lane editor](./charontak-lanes.md).
@@ -143,7 +143,7 @@ On success the card reports the TAK target and that **Charontak forwarding was u
 
 **What it does.** Shows the live systemd state (active / inactive / failed / not installed) of the site's sensor units, with a status dot per service.
 
-The set of services is `charontak adsbcot aiscot dronecot lincot readsb ais-catcher` by default, or whatever you set as `AOS_SERVICES` in the site config. This is a **read-only status list** — start, stop, enable, and restart individual services from each gateway's own [Cockpit page](./gateways.md), or restart them all with **Save & restart sensors**.
+The set of services is `charontak adsbcot aiscot dronecot lincot readsb ais-catcher` by default, or whatever you set as `AOS_SERVICES` in the site config. This is a **read-only status list** - start, stop, enable, and restart individual services from each gateway's own [Cockpit page](./gateways.md), or restart them all with **Save & restart sensors**.
 
 ---
 
@@ -151,13 +151,13 @@ The set of services is `charontak adsbcot aiscot dronecot lincot readsb ais-catc
 
 **What it does.** Checks for and installs updates from the signed Sensors & Signals package repository, plus Debian security fixes.
 
-- **Check for updates** refreshes package lists and lists what is upgradable (name, current → candidate version), any held-back packages, and when the check ran.
+- **Check for updates** refreshes package lists and lists what is upgradable (name, current > candidate version), any held-back packages, and when the check ran.
 - **Install all updates** applies them. The card shows the AryaOS version and a live log.
 
 **Backend:** the `aryaos-update` helper running under `aryaos-update.service`.
 
 !!! tip "Safe to leave the page"
-    Because the upgrade runs in its own systemd unit, **it survives a closed browser** — you can navigate away and the install continues. Sensor services may restart briefly while updates apply, and a reboot may be required to finish some updates (the summary will say so). Debian security fixes are applied automatically every day. For per-package operations, use Cockpit's **Software Updates (PackageKit)** page. See [Updates](../operations/updates.md).
+    Because the upgrade runs in its own systemd unit, **it survives a closed browser** - you can navigate away and the install continues. Sensor services may restart briefly while updates apply, and a reboot may be required to finish some updates (the summary will say so). Debian security fixes are applied automatically every day. For per-package operations, use Cockpit's **Software Updates (PackageKit)** page. See [Updates](../operations/updates.md).
 
 !!! note "readsb is held"
     `readsb` is `apt-mark hold` on the image so decoder updates do not silently change your ADS-B pipeline.
@@ -198,11 +198,11 @@ Enter and confirm a password of **at least 8 characters** and press **Set Node-R
 
 The card shows the current state (Connected / Not logged in / Logged in but disconnected / daemon not running) and offers:
 
-- **Start Tailscale service** — appears when the daemon is not running; enables and starts `tailscaled`.
-- **Connect (get login link)** — runs `tailscale up` and shows a one-time `https://login.tailscale.com/…` link. Open it on any signed-in device to authorize this node.
-- **Cancel login** — abort a pending login.
-- **Disconnect** — `tailscale down` (stays logged in).
-- **Log out of tailnet** — `tailscale logout`; the node needs a new login link to rejoin.
+- **Start Tailscale service** - appears when the daemon is not running; enables and starts `tailscaled`.
+- **Connect (get login link)** - runs `tailscale up` and shows a one-time `https://login.tailscale.com/...` link. Open it on any signed-in device to authorize this node.
+- **Cancel login** - abort a pending login.
+- **Disconnect** - `tailscale down` (stays logged in).
+- **Log out of tailnet** - `tailscale logout`; the node needs a new login link to rejoin.
 
 When connected, the card shows the node's tailnet DNS name and IPs.
 
@@ -233,8 +233,8 @@ This is a **read-only** discovery view; use the **Open** link to jump to a neigh
 
 At the bottom of the page:
 
-- **Save & restart sensors** — writes the site config and runs `systemctl try-restart` on the sensor units (`AOS_SERVICES`, or the default set) so changes to `COT_URL`, the ADS-B decoder, the UAT serial, and the TLS fields take effect.
-- **Save only** — writes the file without restarting anything.
+- **Save & restart sensors** - writes the site config and runs `systemctl try-restart` on the sensor units (`AOS_SERVICES`, or the default set) so changes to `COT_URL`, the ADS-B decoder, the UAT serial, and the TLS fields take effect.
+- **Save only** - writes the file without restarting anything.
 
 ![Save & restart sensors button](../media/save_restart.png)
 
@@ -247,7 +247,7 @@ At the bottom of the page:
 
 At the very bottom, an expandable **Raw site config** section exposes the full `/etc/aryaos/aryaos-config.txt` in a text area for direct editing.
 
-Saving the form updates known keys in place and **preserves everything else, including comments** — so an edit here to a key the form does not manage (for example the Bluetooth PAN block, `PYTAK_MULTICAST_LOCAL_ADDR`, or `COT_HOST_ID`) is kept. Use this escape hatch for keys not surfaced as fields. The full key list is in [Site configuration](../config/site-config.md).
+Saving the form updates known keys in place and **preserves everything else, including comments** - so an edit here to a key the form does not manage (for example the Bluetooth PAN block, `PYTAK_MULTICAST_LOCAL_ADDR`, or `COT_HOST_ID`) is kept. Use this escape hatch for keys not surfaced as fields. The full key list is in [Site configuration](../config/site-config.md).
 
 !!! warning "Do not edit device identity keys"
     `DEVICE_SUFFIX` and `COT_HOST_ID` are set on first boot and should not be changed by hand. See [Site configuration](../config/site-config.md).

--- a/docs/admin/charontak-lanes.md
+++ b/docs/admin/charontak-lanes.md
@@ -1,10 +1,10 @@
 # Charontak lane editor
 
-**Charontak** is the CoT hub at the center of AryaOS. Every local sensor gateway sends its [Cursor on Target (CoT)](../reference/glossary.md) to Charontak, and Charontak fans that single stream out to wherever it needs to go — the local Mesh SA multicast group, one or more TAK Servers, or other tools. The **Charontak** Cockpit plugin edits `/etc/charontak.ini` through a structured **lane editor** so you rarely have to touch the INI by hand.
+**Charontak** is the CoT hub at the center of AryaOS. Every local sensor gateway sends its [Cursor on Target (CoT)](../reference/glossary.md) to Charontak, and Charontak fans that single stream out to wherever it needs to go - the local Mesh SA multicast group, one or more TAK Servers, or other tools. The **Charontak** Cockpit plugin edits `/etc/charontak.ini` through a structured **lane editor** so you rarely have to touch the INI by hand.
 
-Open it from Cockpit → **Charontak**.
+Open it from Cockpit > **Charontak**.
 
-![The Charontak lane editor — service controls and two bridge lanes (feeders → Mesh SA, and Mesh SA → TAK Server), each with its ingress and egress CoT URLs](../media/screenshots/charontak-lane-editor.png)
+![The Charontak lane editor - service controls and two bridge lanes (feeders > Mesh SA, and Mesh SA > TAK Server), each with its ingress and egress CoT URLs](../media/screenshots/charontak-lane-editor.png)
 
 ## Concept: one hub, many lanes
 
@@ -16,7 +16,7 @@ flowchart LR
     a[adsbcot]
     b[aiscot]
     c[dronecot]
-    d[lincot / gpstak / …]
+    d[lincot / gpstak / ...]
   end
   feeders -->|udp+wo://127.0.0.1:28087| hub[(Charontak hub)]
   hub -->|lane: local-to-mesh| mesh[Mesh SA<br/>udp+wo://239.2.3.1:6969]
@@ -32,15 +32,15 @@ The image ships two lanes:
 
 | Lane | Default state | Flow |
 |------|--------------|------|
-| `local-to-mesh` | **enabled** | `udp+ro://127.0.0.1:28087` → `udp+wo://239.2.3.1:6969` |
-| `local-to-takserver` | disabled (template) | `udp+ro://127.0.0.1:28087` → `tls://takserver.example.com:8089` |
+| `local-to-mesh` | **enabled** | `udp+ro://127.0.0.1:28087` > `udp+wo://239.2.3.1:6969` |
+| `local-to-takserver` | disabled (template) | `udp+ro://127.0.0.1:28087` > `tls://takserver.example.com:8089` |
 
 !!! warning "Charontak needs at least one lane"
     If no lanes are configured, Charontak exits at startup. The editor warns you when the lane list is empty.
 
 ## The lane list
 
-The **Bridge lanes** card lists every lane with a status dot (on/off), its name, mode, and a one-line flow summary (`ingress → egress`). Each lane has **Edit**, **Enable / Disable**, and **Delete** buttons.
+The **Bridge lanes** card lists every lane with a status dot (on/off), its name, mode, and a one-line flow summary (`ingress > egress`). Each lane has **Edit**, **Enable / Disable**, and **Delete** buttons.
 
 - **Enable / Disable** flips the lane's `enabled` flag and saves immediately.
 - **Delete** removes the lane's section from the file (with a confirmation).
@@ -62,11 +62,11 @@ Press **Add lane** (or **Edit** on an existing lane) to open the editor.
 | TAK protocol | `TAK_PROTO` | Payload framing; inherited unless set |
 | *TLS fields* | `PYTAK_TLS_*` | Appear when a TLS scheme is used (below) |
 
-A new lane pre-fills the ingress with the AryaOS hub address `udp+ro://127.0.0.1:28087` and enables **Suppress hello event** — the sensible defaults for a bridge.
+A new lane pre-fills the ingress with the AryaOS hub address `udp+ro://127.0.0.1:28087` and enables **Suppress hello event** - the sensible defaults for a bridge.
 
 !!! note "Ingress vs egress"
     - **Ingress** is the *local* side: where the lane reads CoT from. On AryaOS that is normally the hub, `udp+ro://127.0.0.1:28087`, where feeders publish.
-    - **Egress** is the *remote* side: where the lane writes CoT to — Mesh SA (`udp+wo://239.2.3.1:6969`), a TAK Server (`tls://host:8089`), or a `tak://` enrollment URL.
+    - **Egress** is the *remote* side: where the lane writes CoT to - Mesh SA (`udp+wo://239.2.3.1:6969`), a TAK Server (`tls://host:8089`), or a `tak://` enrollment URL.
 
     Both are required. Empty keys are removed so the lane falls back to the `[charontak]` global defaults.
 
@@ -76,8 +76,8 @@ The **Mode** selector controls which direction CoT flows between the two URLs:
 
 | Mode | Direction | Flow shown |
 |------|-----------|-----------|
-| `forward` | ingress → egress | `ingress → egress` |
-| `reverse` | egress → ingress | `egress → ingress` |
+| `forward` | ingress > egress | `ingress > egress` |
+| `reverse` | egress > ingress | `egress > ingress` |
 | `duplex` | both directions | `ingress ⇄ egress` |
 
 Most AryaOS lanes are **forward**: read from the local hub, write to the remote destination.
@@ -90,15 +90,15 @@ Enable this on bridge lanes so Charontak does **not** inject its own presence "h
 
 Sets the payload framing for the lane. Leave as **inherited / default** unless the peer requires a specific value:
 
-- `0` — XML
-- `1` — Mesh protobuf
-- `2` — Stream protobuf
+- `0` - XML
+- `1` - Mesh protobuf
+- `2` - Stream protobuf
 
 The default for all lanes can be set in the collapsible **Global defaults ([charontak] section)** card, which also holds `DEBUG`, `CONNECT_RETRY_SLEEP`, `MAX_IN_QUEUE`, and `MAX_OUT_QUEUE`. Values there are inherited by every lane unless the lane overrides them.
 
 ## Per-lane TLS
 
-When either the ingress or egress URL uses a TLS scheme (`tls://`, `ssl://`, `tak://`) — or when any TLS field is already set — the editor reveals a **TLS client identity** fieldset:
+When either the ingress or egress URL uses a TLS scheme (`tls://`, `ssl://`, `tak://`) - or when any TLS field is already set - the editor reveals a **TLS client identity** fieldset:
 
 | Field | INI key |
 |-------|---------|
@@ -119,7 +119,7 @@ These are **per-lane**, so one Charontak instance can hold different client iden
 
 ## Validation
 
-The editor validates lanes in the browser using the **same rules Charontak applies at startup**, so it rejects exactly what the daemon would reject — you find out before you save, not after the service fails.
+The editor validates lanes in the browser using the **same rules Charontak applies at startup**, so it rejects exactly what the daemon would reject - you find out before you save, not after the service fails.
 
 ### Supported CoT URL schemes
 
@@ -128,22 +128,22 @@ The ingress and egress URLs must use a scheme PyTAK understands:
 | Scheme | Use |
 |--------|-----|
 | `tcp://` | Outbound TCP client (e.g. `tcp://host:8087`) |
-| `udp://`, `udp+wo://`, `udp+ro://`, `udp+broadcast://` | UDP — write-only (`+wo`), read-only listen (`+ro`), or broadcast |
+| `udp://`, `udp+wo://`, `udp+ro://`, `udp+broadcast://` | UDP - write-only (`+wo`), read-only listen (`+ro`), or broadcast |
 | `tls://`, `ssl://`, `tak://` | TLS / TAK Server / enrollment |
 | `log://`, `file://` | Logging / file output |
 
 An unsupported scheme is rejected with a message pointing at the [PyTAK configuration docs](https://pytak.rtfd.io/en/stable/configuration/). Note in particular:
 
 !!! warning "No TCP listen"
-    PyTAK does not support inbound `tcp+…://` listen schemes — only outbound `tcp://` (client). If you need local feeders to reach a listener, point them at a `udp+ro://` mesh instead.
+    PyTAK does not support inbound `tcp+...://` listen schemes - only outbound `tcp://` (client). If you need local feeders to reach a listener, point them at a `udp+ro://` mesh instead.
 
 ### Loopback UDP must be directional
 
-A bidirectional `udp://` on loopback is ambiguous. To listen for local CoT senders on a loopback port, use `udp+ro://127.0.0.1:<port>` (or `udp+ro://:<port>`) — the editor flags a bare `udp://127.0.0.1:<port>` and tells you the fix. A bare all-interfaces `udp://:<port>` is auto-normalized to `udp+ro://`.
+A bidirectional `udp://` on loopback is ambiguous. To listen for local CoT senders on a loopback port, use `udp+ro://127.0.0.1:<port>` (or `udp+ro://:<port>`) - the editor flags a bare `udp://127.0.0.1:<port>` and tells you the fix. A bare all-interfaces `udp://:<port>` is auto-normalized to `udp+ro://`.
 
 ### UDP bind-conflict checks
 
-Two enabled lanes cannot both **bind** the same UDP endpoint (host + port). When you save, the editor computes the bind endpoints of every enabled lane — the ingress of `forward`/`duplex` lanes and the egress of `reverse`/`duplex` lanes — and refuses the save if any two collide, naming the conflicting lanes and sides. Give each lane a distinct UDP ingress/egress bind, or disable the extra lane.
+Two enabled lanes cannot both **bind** the same UDP endpoint (host + port). When you save, the editor computes the bind endpoints of every enabled lane - the ingress of `forward`/`duplex` lanes and the egress of `reverse`/`duplex` lanes - and refuses the save if any two collide, naming the conflicting lanes and sides. Give each lane a distinct UDP ingress/egress bind, or disable the extra lane.
 
 ## Raw INI escape hatch
 
@@ -159,7 +159,7 @@ sudo systemctl restart charontak
 
 ## See also
 
-- [Connect to a TAK Server](../deploy/connect-tak-server.md) — end-to-end TAK Server setup
-- [Relay & routing](../deploy/relay-routing.md) — routing patterns and courses of action
-- [Site configuration](../config/site-config.md) — the feeder-side `COT_URL`
-- [AryaOS Site page](./aryaos-site.md) — one-click TAK connection
+- [Connect to a TAK Server](../deploy/connect-tak-server.md) - end-to-end TAK Server setup
+- [Relay & routing](../deploy/relay-routing.md) - routing patterns and courses of action
+- [Site configuration](../config/site-config.md) - the feeder-side `COT_URL`
+- [AryaOS Site page](./aryaos-site.md) - one-click TAK connection

--- a/docs/admin/gateways.md
+++ b/docs/admin/gateways.md
@@ -8,13 +8,13 @@ Open any of them from Cockpit's left menu.
 
 | Cockpit plugin | Service | Config file | Feeds |
 |----------------|---------|-------------|-------|
-| adsbcot | `adsbcot` | `/etc/default/adsbcot` | ADS-B aircraft → CoT |
-| aiscot | `aiscot` | `/etc/default/aiscot` | AIS vessels → CoT |
-| dronecot | `dronecot` | `/etc/default/dronecot` | Remote ID drones → CoT |
-| aprscot | `aprscot` | `/etc/default/aprscot` | APRS (KISS TNC / APRS-IS) → CoT |
-| sapientcot | `sapientcot` | `/etc/default/sapientcot` | SAPIENT (BSI Flex 335) C-UAS / ISR → CoT |
-| lincot | `lincot` | `/etc/default/lincot` | This host's position/beacon → CoT |
-| gps | *(gpsd)* | — | On-board GNSS receiver |
+| adsbcot | `adsbcot` | `/etc/default/adsbcot` | ADS-B aircraft > CoT |
+| aiscot | `aiscot` | `/etc/default/aiscot` | AIS vessels > CoT |
+| dronecot | `dronecot` | `/etc/default/dronecot` | Remote ID drones > CoT |
+| aprscot | `aprscot` | `/etc/default/aprscot` | APRS (KISS TNC / APRS-IS) > CoT |
+| sapientcot | `sapientcot` | `/etc/default/sapientcot` | SAPIENT (BSI Flex 335) C-UAS / ISR > CoT |
+| lincot | `lincot` | `/etc/default/lincot` | This host's position/beacon > CoT |
+| gps | *(gpsd)* | - | On-board GNSS receiver |
 | gpstak | `gpstak` | `/etc/default/gpstak` | Network GPS to ATAK/WinTAK |
 | aiscatcher | `ais-catcher` | `/etc/default/ais-catcher` | Over-the-air AIS receiver |
 
@@ -25,7 +25,7 @@ The AIS receiver (`ais-catcher`) demodulates RF AIS and hands messages to `aisco
 
 ## The common layout
 
-![The aiscot gateway page in Cockpit — service controls, TLS certificates, iconset, and the configuration form over /etc/default/aiscot](../media/screenshots/gateway-aiscot.png)
+![The aiscot gateway page in Cockpit - service controls, TLS certificates, iconset, and the configuration form over /etc/default/aiscot](../media/screenshots/gateway-aiscot.png)
 
 Every gateway plugin (using **aiscot** as the representative example) shows the same cards, top to bottom:
 
@@ -42,7 +42,7 @@ A **TLS upload** card installs PEM client credentials for *this* service. For ai
 
 ### Configuration card
 
-The **Configuration** card is a form generated from the gateway's environment-variable definitions. Each row shows the variable name, a description, its default, and an input appropriate to its type (text, number, boolean drop-down, or enum drop-down). Required fields are marked. Values are validated as you type — for example `COT_URL` must match a supported scheme, ports must be in range, and enums must be one of the listed options — and invalid fields block the save.
+The **Configuration** card is a form generated from the gateway's environment-variable definitions. Each row shows the variable name, a description, its default, and an input appropriate to its type (text, number, boolean drop-down, or enum drop-down). Required fields are marked. Values are validated as you type - for example `COT_URL` must match a supported scheme, ports must be in range, and enums must be one of the listed options - and invalid fields block the save.
 
 Tick **Restart *service* after save** and press **Validate & Save** to write `/etc/default/<svc>` and (optionally) restart the service.
 
@@ -78,16 +78,16 @@ This is the key to how AryaOS gateways are configured:
 Because the per-service file is read second, **anything you set on a gateway page overrides the site default** for that one service. Anything you leave unset falls through to the site value.
 
 !!! example "How the default CoT route works"
-    The site config sets `COT_URL=udp+wo://127.0.0.1:28087` (the Charontak hub). Each gateway inherits that, so out of the box **every** feeder sends CoT to Charontak — you did not set `COT_URL` on the gateway page. If you *do* set `COT_URL` on, say, the aiscot page, only aiscot changes; the rest keep going through the hub.
+    The site config sets `COT_URL=udp+wo://127.0.0.1:28087` (the Charontak hub). Each gateway inherits that value, so **every** feeder sends CoT to Charontak without a gateway-specific `COT_URL`. Setting `COT_URL` on the aiscot page changes only aiscot; the other gateways keep using the hub.
 
-This is why the CoT routing invariant holds without per-service configuration: **feeders → charontak → Mesh SA / TAK Server**. Leave each feeder's `COT_URL` unset (inheriting the hub) and control the upstream in the [Charontak lane editor](./charontak-lanes.md).
+This is why the CoT routing invariant holds without per-service configuration: **feeders > charontak > Mesh SA / TAK Server**. Leave each feeder's `COT_URL` unset (inheriting the hub) and control the upstream in the [Charontak lane editor](./charontak-lanes.md).
 
 !!! warning "Setting COT_URL per gateway bypasses Charontak"
     Overriding `COT_URL` on a gateway page routes *that* feeder around the hub. That is occasionally useful for debugging, but it means the feeder no longer benefits from Charontak's fan-out to Mesh SA and TAK Servers. Prefer configuring destinations as Charontak lanes.
 
 ## See also
 
-- [Configuration model](../config/index.md) — the full inheritance picture
-- [Site configuration](../config/site-config.md) — the keys every gateway inherits
-- [Charontak lane editor](./charontak-lanes.md) — where upstream destinations live
-- [Software suite](../reference/software-suite.md) — every gateway and what it does
+- [Configuration model](../config/index.md) - the full inheritance picture
+- [Site configuration](../config/site-config.md) - the keys every gateway inherits
+- [Charontak lane editor](./charontak-lanes.md) - where upstream destinations live
+- [Software suite](../reference/software-suite.md) - every gateway and what it does

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -1,6 +1,6 @@
 # The web console
 
-AryaOS is administered entirely from a web browser. There is no need to open an SSH session for normal setup and operation: everything a field operator or TAK admin needs — TAK destinations, sensor roles, radios, updates, VPN, and support bundles — lives in a point-and-click console served by the device itself.
+AryaOS is administered entirely from a web browser. There is no need to open an SSH session for normal setup and operation: everything a field operator or TAK admin needs - TAK destinations, sensor roles, radios, updates, VPN, and support bundles - lives in a point-and-click console served by the device itself.
 
 !!! tip "No SSH required"
     AryaOS follows a **no-SSH philosophy**: the console covers day-to-day administration so you can field, configure, and troubleshoot a unit from a phone or laptop without a terminal. SSH remains available on the image for advanced recovery, but you should not need it for anything on the pages that follow.
@@ -12,10 +12,10 @@ Every AryaOS device runs [Cockpit](https://cockpit-project.org/), a web-based sy
 | Address | Serves | Notes |
 |---------|--------|-------|
 | `https://aryaos-xxxx.local:9090/` | Cockpit directly | Cockpit's own port |
-| `https://aryaos-xxxx.local/admin/` | Cockpit via lighttpd | `lighttpd` on `:443` proxies `/admin` → Cockpit |
+| `https://aryaos-xxxx.local/admin/` | Cockpit via lighttpd | `lighttpd` on `:443` proxies `/admin` > Cockpit |
 | `https://aryaos-xxxx.local/` | Landing portal | Read-only live status page |
 
-Replace `xxxx` with your device's four-character suffix — the same hex characters that appear in the hostname `aryaos-xxxx` and the onboarding Wi-Fi SSID `AryaOS-xxxx`. Before first-boot personalization the factory hostname is simply `aryaos` (`https://aryaos.local/`).
+Replace `xxxx` with your device's four-character suffix. The same hex characters appear in the hostname `aryaos-xxxx` and the onboarding Wi-Fi SSID `AryaOS-xxxx`. Before first-boot personalization, the factory hostname is `aryaos` (`https://aryaos.local/`).
 
 === "On the onboarding hotspot"
     When no known Wi-Fi is in range, the device broadcasts its `AryaOS-xxxx` hotspot. Join it, then browse to `https://aryaos-xxxx.local/admin/`. See [Wi-Fi & onboarding hotspot](../networking/wifi-hotspot.md).
@@ -34,21 +34,21 @@ Replace `xxxx` with your device's four-character suffix — the same hex charact
 Log in as the **`pi`** user with the device password.
 
 !!! danger "The default password expires at first login"
-    Release images ship with a well-known default `pi` password that is **expired at first login** — you will be forced to set a new one. Choose a strong password and record it: there is no password-recovery feature. See [Security posture](../security.md).
+    Release images ship with a well-known default `pi` password that is **expired at first login** - you will be forced to set a new one. Choose a strong password and record it: there is no password-recovery feature. See [Security posture](../security.md).
 
 ## The landing portal
 
-Browsing to `https://aryaos-xxxx.local/` (no `/admin`) shows the **landing portal** — a lightweight, read-only status page served by `lighttpd`, independent of Cockpit and Node-RED. It is the fastest way to confirm a unit is healthy before you dig into administration.
+Browsing to `https://aryaos-xxxx.local/` (no `/admin`) shows the **landing portal** - a lightweight, read-only status page served by `lighttpd`, independent of Cockpit and Node-RED. It is the fastest way to confirm a unit is healthy before you dig into administration.
 
-![The AryaOS landing portal — TAK gateway status, connection and GNSS panels, radios, nearby nodes, and links to the on-device docs](../media/screenshots/portal-landing.png)
+![The AryaOS landing portal - TAK gateway status, connection and GNSS panels, radios, nearby nodes, and links to the on-device docs](../media/screenshots/portal-landing.png)
 
 The portal polls a JSON status endpoint (`/cgi-bin/aryaos-portal-status`) every 8 seconds and shows:
 
-- **TAK gateway strip** — live up/down/degraded state of `charontak`, `adsbcot`, `aiscot`, `lincot`, `dronecot`, and `sikw00fcot`.
-- **System health** — CPU temperature, load average, memory, and Raspberry Pi power/throttle state.
-- **Connection & status** — hostname, FQDN, primary IP, the full IPv4 address block, and uptime.
-- **GNSS** — the gpsd position fix: latitude/longitude, MSL and HAE altitude, CE/LE accuracy, Maidenhead grid, and satellites in view/used.
-- **Radios / RF** — an inventory of Wi-Fi, Bluetooth, and USB SDR hardware plus decoder service state.
+- **TAK gateway strip** - live up/down/degraded state of `charontak`, `adsbcot`, `aiscot`, `lincot`, `dronecot`, and `sikw00fcot`.
+- **System health** - CPU temperature, load average, memory, and Raspberry Pi power/throttle state.
+- **Connection & status** - hostname, FQDN, primary IP, the full IPv4 address block, and uptime.
+- **GNSS** - the gpsd position fix: latitude/longitude, MSL and HAE altitude, CE/LE accuracy, Maidenhead grid, and satellites in view/used.
+- **Radios / RF** - an inventory of Wi-Fi, Bluetooth, and USB SDR hardware plus decoder service state.
 
 The portal is for reading; all **writes** happen in Cockpit (and, for Wi-Fi onboarding, Comitup). See [HTTPS landing portal](../portal.md) for the full status schema.
 
@@ -58,13 +58,13 @@ Cockpit's left-hand menu lists standard system pages (Overview, Logs, Storage, N
 
 <div class="grid cards" markdown>
 
-- :material-tune-vertical: **AryaOS Site** — The flagship page. TAK destination, site-wide TLS, TAK Server enrollment, device role, radios, updates, VPN, support bundles, and more, all writing the shared [site configuration](../config/site-config.md). [Open the reference](./aryaos-site.md)
+- :material-tune-vertical: **AryaOS Site** - The flagship page. TAK destination, site-wide TLS, TAK Server enrollment, device role, radios, updates, VPN, support bundles, and more, all writing the shared [site configuration](../config/site-config.md). [Open the reference](./aryaos-site.md)
 
-- :material-transit-connection-variant: **Charontak lane editor** — The CoT router. Define the ingress/egress lanes that carry Cursor on Target (CoT) from local feeders out to Mesh SA and TAK Servers. [Edit lanes](./charontak-lanes.md)
+- :material-transit-connection-variant: **Charontak lane editor** - The CoT router. Define the ingress/egress lanes that carry Cursor on Target (CoT) from local feeders out to Mesh SA and TAK Servers. [Edit lanes](./charontak-lanes.md)
 
-- :material-cog-transfer: **Gateway pages** — One Cockpit plugin per sensor gateway (adsbcot, aiscot, dronecot, lincot, gps, gpstak, aiscatcher). Per-service tuning, service controls, TLS, and logs. [See the pattern](./gateways.md)
+- :material-cog-transfer: **Gateway pages** - One Cockpit plugin per sensor gateway (adsbcot, aiscot, dronecot, lincot, gps, gpstak, aiscatcher). Per-service tuning, service controls, TLS, and logs. [See the pattern](./gateways.md)
 
-- :material-map-marker-radius: **Node-RED dashboard** — Maps, TFR injection, and optional recording. Deprecated for configuration. [Node-RED](../node-red.md)
+- :material-map-marker-radius: **Node-RED dashboard** - Maps, TFR injection, and optional recording. Deprecated for configuration. [Node-RED](../node-red.md)
 
 </div>
 
@@ -74,11 +74,11 @@ If you are not sure which surface owns a setting, start with the [configuration 
 
 <div class="grid cards" markdown>
 
-- :material-file-cog: **Site configuration** — The keys in `/etc/aryaos/aryaos-config.txt` inherited by every gateway. [Reference](../config/site-config.md)
+- :material-file-cog: **Site configuration** - The keys in `/etc/aryaos/aryaos-config.txt` inherited by every gateway. [Reference](../config/site-config.md)
 
-- :material-account-switch: **Device roles** — Which sensor pipelines run on this unit. [Roles](../config/device-roles.md)
+- :material-account-switch: **Device roles** - Which sensor pipelines run on this unit. [Roles](../config/device-roles.md)
 
-- :material-radio-tower: **Radios & SDRs** — RTL-SDR serial conventions and decoder selection. [Radios](../config/radios-sdr.md)
+- :material-radio-tower: **Radios & SDRs** - RTL-SDR serial conventions and decoder selection. [Radios](../config/radios-sdr.md)
 
 </div>
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -1,4 +1,4 @@
-# Agent handoff — state as of 2026-07-21
+# Agent handoff - state as of 2026-07-21
 
 Working notes for agents (and humans) picking up AryaOS and the snstac fleet.
 Supersedes the 2026-05-16 handoff in [portal.md](portal.md).
@@ -7,19 +7,19 @@ Supersedes the 2026-05-16 handoff in [portal.md](portal.md).
     Outstanding work and follow-ups live in **[Roadmap & next steps](roadmap.md)**.
     This handoff covers the running build/merge state and architecture invariants.
 
-## 2026-07-19→21 sweep — HIL hardening + landing-page features (SHIPPED)
+## 2026-07-19 to 21 sweep - HIL hardening + landing-page features (SHIPPED)
 
 Two arcs, both merged and in a green image: **`v2026.07.21.211313-4e5923568c11-dev`**
-(`verify-image`: 135 ok, 0 failed). User is flashing it now for HIL testing —
+(`verify-image`: 135 ok, 0 failed). User is flashing it now for HIL testing -
 **resume by testing this release on the box.**
 
-### Arc 1 — HIL security hardening (radios / EMCON / isolation)
+### Arc 1 - HIL security hardening (radios / EMCON / isolation)
 Hardware-in-the-loop pentest of the appliance. Landed (aryaos, all asserted in
 `verify-image.sh`):
 - **Wi-Fi/AP isolation**: `public.xml` dropped `<forward/>` so the onboarding AP/PAN
   can't gateway to wired ethernet; new **`aryaos-hotspot` firewalld zone** withholds
   ssh/node-red/mesh from onboarding clients; NM owns the zone via `connection.zone`
-  (`comitup-callback.sh` uses `nmcli connection modify … + device reapply`, NOT
+  (`comitup-callback.sh` uses `nmcli connection modify ... + device reapply`, NOT
   `firewall-cmd --change-interface`, which NM reverts). `pan0` statically bound.
 - **EMCON / radio silence** (`aryaos-radio`): `ap {on|off}`, `silence {on|off}` does
   `nmcli radio wifi off` + `rfkill block wifi bluetooth`; `--boot` re-applies from
@@ -27,15 +27,15 @@ Hardware-in-the-loop pentest of the appliance. Landed (aryaos, all asserted in
   `ConditionPathExists=!/etc/aryaos/emcon` drop-ins. Ethernet + SDR RX unaffected.
 - **Node-RED unauth-root closed**: drop-in runs it `User=node-red` (was root); default
   publicly-known password (`aryaos415`) rotated on first boot; cockpit-aryaos card to reset.
-- **XXE/billion-laughs guards** + systemd sandboxing on `aryaos-neighbord` (score 9→3),
+- **XXE/billion-laughs guards** + systemd sandboxing on `aryaos-neighbord` (score reduced from 9 to 3),
   socket `0600`; TAK data-package import moved off CGI to a root CLI over an AF_UNIX
   socket with SSRF host-blocking. **Zeroize stays best-effort sanitize (usable box), NOT
   scorched-earth.** SSH password auth intentionally STAYS ON (don't lock users out).
 - **chrony NTP server** (`local stratum 10`, gpsd SHM refclock, `allow`) served on the LAN zone.
 
-### Arc 2 — landing-page features + style fix (cockpit-aryaos v1.5.0 + plugin patches)
+### Arc 2 - landing-page features + style fix (cockpit-aryaos v1.5.0 + plugin patches)
 - **Unstyled plugins fixed**: React/esbuild plugins bundle SCSS to `dist/index.css` but
-  `index.html` never linked it → completely unstyled in Cockpit. Added
+  `index.html` never linked it > completely unstyled in Cockpit. Added
   `<link rel="stylesheet" href="index.css">` + shared `branding.css` (matching
   cockpit-gps/aiscatcher) to **cockpit-charontak/adsbcot/dronecot/aiscot/sdrconnect**.
 - **Landing-page location chip** (cockpit-aryaos): offline **North America** base map +
@@ -49,58 +49,58 @@ Hardware-in-the-loop pentest of the appliance. Landed (aryaos, all asserted in
 
 ### Build/release gotchas learned this sweep (IMPORTANT)
 - **image-commit stamp**: pi-gen runs inside a **Docker container** (`usimd/pi-gen-action`).
-  `GITHUB_ENV` vars do NOT cross into it — `ARYAOS_BUILD_SHA` must be passed via
+  `GITHUB_ENV` vars do NOT cross into it - `ARYAOS_BUILD_SHA` must be passed via
   `docker-opts: -e` (fixed #164). A prior "fix" using GITHUB_ENV silently left the stamp
   `unknown` and failed the gate. Same rule for any new build-time env a stage needs.
 - **Plugin debs publish on TAGS ONLY** (`build.yml` steps are `if: startsWith(github.ref,
-  'refs/tags/')`). Merging a plugin PR to `main` only runs validation — it does NOT
+  'refs/tags/')`). Merging a plugin PR to `main` only runs validation - it does NOT
   produce a new deb. To ship a plugin change: **push a `vX.Y.Z` git tag** (git push, not
-  `gh release create` — the workflow triggers on `push: tags`, not the `release` event) →
-  build.yml packages the deb + creates the release → then publish the apt repo.
+  `gh release create` - the workflow triggers on `push: tags`, not the `release` event) >
+  build.yml packages the deb + creates the release > then publish the apt repo.
 - **apt repo path** is `https://snstac.github.io/packages/apt` (note the `/apt` subpath),
-  suite `stable`, component `main`, index at `…/apt/dists/stable/main/binary-arm64/Packages`.
+  suite `stable`, component `main`, index at `.../apt/dists/stable/main/binary-arm64/Packages`.
   Ingest new debs by dispatching **`snstac/packages` `publish.yml`** (`gh workflow run
-  publish.yml --repo snstac/packages`; also runs daily 06:17 UTC) — it pulls each product's
+  publish.yml --repo snstac/packages`; also runs daily 06:17 UTC) - it pulls each product's
   *latest* GitHub Release assets. THEN rebuild the aryaos image so apt pulls the new versions.
-- Correct order to land a plugin change in an image: merge PR → tag release → publish.yml →
+- Correct order to land a plugin change in an image: merge PR > tag release > publish.yml >
   image build. Skipping any step ships the old deb (and `verify-image` now catches the
   cockpit-aryaos case: `card-location` + `aryaos-basemap.js`).
 
 This sweep's plugin releases: cockpit-aryaos **v1.5.0**, cockpit-charontak **v1.2.1**,
 cockpit-aiscot **v1.2.2**, cockpit-dronecot **v1.1.2**, cockpit-adsbcot **v1.2.2**.
-(cockpit-sdrconnect CSS fix merged but unreleased — not in the image manifest / apt index.)
+(cockpit-sdrconnect CSS fix merged but unreleased - not in the image manifest / apt index.)
 
-## 2026-07-15/17 sweep — "never SSH" + fleet dedup (SHIPPED)
+## 2026-07-15/17 sweep - "never SSH" + fleet dedup (SHIPPED)
 
 Full review + implementation sweep. **All 11 PRs merged and released** (2026-07-17,
-in dependency order: packages → aryaos → cockpit-aryaos → plugins). What landed:
+in dependency order: packages > aryaos > cockpit-aryaos > plugins). What landed:
 
 - **aryaos overlay helpers** (all driven by cockpit-aryaos cards, no SSH):
   `aryaos-support-bundle` (redacted diagnostics tarball, `/var/lib/aryaos/support/`),
-  `aryaos-set-nodered-password` (rotates the publicly-known default; `settings.js`
-  → `root:node-red 0640`), `aryaos-sdr` (RTL-SDR enumerate + EEPROM re-serial; this
-  added the `rtl-sdr` package — only `librtlsdr0` shipped before), `aryaos-role`
+  `aryaos-set-nodered-password` (rotates the publicly-known default and sets
+  `settings.js` to `root:node-red 0640`), `aryaos-sdr` (RTL-SDR enumerate + EEPROM re-serial; this
+  added the `rtl-sdr` package - only `librtlsdr0` shipped before), `aryaos-role`
   (runtime device roles **multi/air/maritime/cuas/relay**; CoT core charontak/lincot/
   gpstak/gpsd never touched; ADS-B decoder follows `ARYAOS_ADSB_DECODER`). Installed
   via overlay deb + chroot stage + Ansible; asserted in `verify-image.sh`; all four
-  now in the CI shellcheck list (they have **no `.sh` suffix** — the globs missed them,
+  now in the CI shellcheck list (they have **no `.sh` suffix** - the globs missed them,
   don't re-break that).
-- **SBOMs** — `scripts/generate-sbom.sh` + pinned syft, every image build emits
+- **SBOMs** - `scripts/generate-sbom.sh` + pinned syft, every image build emits
   SPDX + CycloneDX attached to the release. The step runs **before the tag push** on
   purpose (an SBOM failure must not strand a tag). CAUTION: it runs syft under `sudo`,
-  so it chowns `deploy/` back to the runner afterward — a prior version stranded a tag
+  so it chowns `deploy/` back to the runner afterward - a prior version stranded a tag
   by leaving `deploy/` root-owned (fixed in #131).
-- **cockpit-aryaos v1.3.0** — six new cards: support bundle, Node-RED password,
+- **cockpit-aryaos v1.3.0** - six new cards: support bundle, Node-RED password,
   Radios (RTL-SDR), Device role, comitup hotspot password, Tailscale join. The four
   helper-backed cards need aryaos-overlay ≥ the 2026-07 helpers; on older images they
   show a clear error toast.
-- **cockpit-charontak v1.2.0** — React/TS rewrite + **structured lane editor**.
+- **cockpit-charontak v1.2.0** - React/TS rewrite + **structured lane editor**.
   `src/cotUrl.ts` is a differentially-tested port of `charontak/src/charontak/config.py`
-  — **keep the two in sync** if lane/URL validation changes.
-- **gdltak** (new repo, v1.0.0) — CoT → GDL90 UDP broadcast so ForeFlight/EFBs display
+  - **keep the two in sync** if lane/URL validation changes.
+- **gdltak** (new repo, v1.0.0) - CoT > GDL90 UDP broadcast so ForeFlight/EFBs display
   the TAK air picture. In the sensor manifest + air/multi roles; egress-only (no
   inbound firewall service). 48 tests incl. the GDL90-spec CRC known-answer.
-- **@snstac/cockpit-shared** (new repo, v1.1.0) — shared `serviceCard`/`tlsCard`/
+- **@snstac/cockpit-shared** (new repo, v1.1.0) - shared `serviceCard`/`tlsCard`/
   `envDefaultFile`/`types`. **Source-shipping model**: consumers depend on
   `github:snstac/cockpit-shared#vX.Y.Z` and esbuild bundles the `.ts/.tsx` directly
   (no npm registry, no build step); `cockpit` resolves from each consumer's `pkg/lib`.
@@ -108,10 +108,10 @@ in dependency order: packages → aryaos → cockpit-aryaos → plugins). What l
   though the lockfile `resolved` says `git+ssh`). **All five family-B plugins consume
   it** (aiscot v1.2.1, adsbcot v1.2.1, dronecot v1.1.1, lincot v1.1.1, charontak v1.2.0).
   Bumping the shared package = bump its tag, then bump the `#vX.Y.Z` ref in each consumer.
-- **README** amd64 claim softened (arm64 today, amd64 planned) — tracking #129
+- **README** amd64 claim softened (arm64 today, amd64 planned) - tracking #129
   (installer-script path first: the apt repo + overlay deb already run on any Debian host).
 
-Issue tracker triaged **42 → 11 open** (each closure commented with what superseded it).
+Issue tracker triaged **42 > 11 open** (each closure commented with what superseded it).
 
 **Next hardware session**: flash the milestone image below and exercise all six
 cockpit-aryaos cards + verify the Cockpit expired-password first-login flow (the
@@ -121,7 +121,7 @@ plugins still on vanilla-JS could adopt cockpit-shared patterns.
 
 ## Current known-good build
 
-- Latest successful dev image: `v2026.07.17.165541-5fa79a7bfae5-dev` — **the milestone
+- Latest successful dev image: `v2026.07.17.165541-5fa79a7bfae5-dev` - **the milestone
   build**: first image with gdltak, the four field-support helpers, device roles, and
   working SBOM attachment.
 - Release: https://github.com/snstac/aryaos/releases/tag/v2026.07.17.165541-5fa79a7bfae5-dev
@@ -130,7 +130,7 @@ plugins still on vanilla-JS could adopt cockpit-shared patterns.
 - Notes: **dev/lab image** (`aryaos-dev-lab` SSH key, passwordless `pi` sudo, no
   first-boot password expiry). Do not field it. For a release image, dispatch the
   Pi-gen workflow with the `release` input checked.
-- Watch: the apt index refreshes on the packages repo's daily/push publish — the new
+- Watch: the apt index refreshes on the packages repo's daily/push publish - the new
   plugin deb versions (cockpit-aryaos 1.3.0 etc.) reach deployed units via one-click
   updates once that runs.
 
@@ -153,18 +153,18 @@ Recent build blockers fixed:
 
 AryaOS is the **master consumer of the PyTAK stack**. Three pillars landed in June 2026:
 
-1. **Everything installs from the signed apt repo** — https://snstac.github.io/packages,
+1. **Everything installs from the signed apt repo** - https://snstac.github.io/packages,
    built by [snstac/packages](https://github.com/snstac/packages) from each product's
    *latest GitHub release* (repos listed in its `products.txt`). No vendored sensor
    binaries remain in this repo; the only vendored artifacts are trust anchors
    (`shared_files/aryaos/snstac-packages/`, FlightAware repo deb).
-2. **Cockpit is the single admin surface** — nine standalone `cockpit-*` plugin
+2. **Cockpit is the single admin surface** - nine standalone `cockpit-*` plugin
    repos/debs (adsbcot, aiscot, aiscatcher, dronecot, lincot, gps, charontak, gpstak,
    aryaos). `cockpit-aryaos` ("AryaOS Site") manages the site-wide layer:
    `/etc/aryaos/aryaos-config.txt` (site `COT_URL` etc.) and one-shot TAK TLS cert
    upload to `/etc/aryaos/tls` (key `0640 root:tak-certs`; group reconciled by
    `aryaos-firstboot.sh` every boot). Per-tool plugins edit `/etc/default/<svc>`.
-3. **CI builds dev images by default** — every push to `main` produces a
+3. **CI builds dev images by default** - every push to `main` produces a
    `v<ts>-<sha>-dev` **prerelease** with lab access baked (dev SSH key, pi NOPASSWD,
    no password expiry) for burn-and-test. Hardened release images require dispatching
    the Pi-gen workflow with the **`release`** input checked. `scripts/verify-image.sh`
@@ -175,7 +175,7 @@ AryaOS is the **master consumer of the PyTAK stack**. Three pillars landed in Ju
 
 - **Site-config inheritance**: every gateway unit loads
   `EnvironmentFile=-/etc/aryaos/aryaos-config.txt` *before* its own
-  `/etc/default/<svc>` — site sets defaults, per-service values override. The
+  `/etc/default/<svc>` - site sets defaults, per-service values override. The
   injection happens in each stage's chroot script (sed after `[Service]`); drop-in
   files would invert the precedence (drop-ins parse *after* the unit file).
 - **CoT routing hub**: `adsbcot`, `aiscot`, `dronecot`, `lincot`, and other local
@@ -185,13 +185,13 @@ AryaOS is the **master consumer of the PyTAK stack**. Three pillars landed in Ju
   feeder independently at the same TAK Server except for deliberate legacy/debug bypass.
 - **apt pinning**: `install-sensor-debs.sh` pins `release o=snstac` at **995** because
   stage-adsbcot pins trixie at 990 and Debian ships an SDR-less readsb that must never
-  win. readsb is also `apt-mark hold` (status `hold ok installed` — verify-image
+  win. readsb is also `apt-mark hold` (status `hold ok installed` - verify-image
   accepts both hold and install).
 - **Exactly one `EXPORT_IMAGE`** stage, last in every `STAGE_LIST` (PR validation
-  enforces). `ARYAOS_CI_TRIM_WORK=1` (CI only) deletes stale stage rootfs trees —
+  enforces). `ARYAOS_CI_TRIM_WORK=1` (CI only) deletes stale stage rootfs trees -
   pi-gen full-copies per stage and 72 GB arm64 runners can't hold ~15 copies
   (the fleet has 72 GB *and* 145 GB VMs; never rely on runner luck).
-  `increase-runner-disk-size` is broken on arm64 runners — keep it false.
+  `increase-runner-disk-size` is broken on arm64 runners - keep it false.
 - **Release publication on immutable-release repos**: use `gh release create` for
   releases with image assets. Do not go back to `softprops/action-gh-release` unless
   it is configured to keep the release draft until after asset upload.
@@ -230,8 +230,8 @@ See [security.md](security.md) for the full posture. Summary of what landed:
 
 - **firewalld** enabled with an explicit allowlist in the default zone
   (`shared_files/aryaos/firewalld/`); AntSDR link pinned to the trusted zone
-  via `zone=trusted` in `aryaos-antsdr.nmconnection`. Operators use Cockpit →
-  Networking → Firewall. If a new service opens a port, add a firewalld
+  via `zone=trusted` in `aryaos-antsdr.nmconnection`. Operators use Cockpit >
+  Networking > Firewall. If a new service opens a port, add a firewalld
   service XML + zone entry + verify-image assert, or it will be unreachable.
 - **fail2ban** (sshd jail), **sshd drop-in** (`50-aryaos.conf`, password auth
   deliberately stays on), **sysctl** hardening, **unattended-upgrades**
@@ -239,7 +239,7 @@ See [security.md](security.md) for the full posture. Summary of what landed:
 - **Per-device web TLS**: `aryaos-firstboot.sh` regenerates the snakeoil key
   and `/etc/lighttpd/ssl/snakeoil-combined.pem` once per device (marker
   `/etc/aryaos/.web-tls-regenerated`). Firstboot also stopped `chown -R
-  node-red /etc/aryaos` — Node-RED now owns only the config file, and
+  node-red /etc/aryaos` - Node-RED now owns only the config file, and
   `/etc/aryaos/tls` is `root:tak-certs 0750` with the key `0640`.
 - **One-click updates**: `/usr/local/sbin/aryaos-update {check|apply|status}`
   + `aryaos-update.service` (oneshot, survives browser close), driven by the
@@ -248,17 +248,17 @@ See [security.md](security.md) for the full posture. Summary of what landed:
   `/var/lib/aryaos/update-*.json`.
 - **aryaos-overlay 2.1** is built by CI and attached to releases as a deb
   asset, so units can upgrade the overlay itself once `snstac/aryaos` is in
-  the packages repo `products.txt` (see open items — sequencing matters).
+  the packages repo `products.txt` (see open items - sequencing matters).
 - New verify-image asserts cover all of the above; runtime checks are in
   `scripts/aryaos-test/tests/09-security.sh`.
 
 ## GPSTAK (new, 2026-06-12)
 
-`gpstak` package → `/usr/bin/gpstak`: feeds onboard GNSS to TAK
-devices per https://ampledata.org/network_gps.html — CoT position events to `COT_URL`
+`gpstak` package > `/usr/bin/gpstak`: feeds onboard GNSS to TAK
+devices per https://ampledata.org/network_gps.html - CoT position events to `COT_URL`
 (default `udp+broadcast://255.255.255.255:4349`, ATAK's *External or Network GPS*) and
 raw-NMEA passthrough for WinTAK (`NMEA_TARGETS`). Reads gpsd's JSON socket; pytak for
-transport (so `PYTAK_TLS_*` applies). Ships **disabled**; managed in Cockpit → GPSTAK
+transport (so `PYTAK_TLS_*` applies). Ships **disabled**; managed in Cockpit > GPSTAK
 ([cockpit-gpstak](https://github.com/snstac/cockpit-gpstak)). Verified live on the dev
 Pi. Source and Debian/RPM release packaging live in https://github.com/snstac/gpstak.
 
@@ -273,7 +273,7 @@ Pi. Source and Debian/RPM release packaging live in https://github.com/snstac/gp
 | readsb | 3.16.15-2 | synced to wiedehopf dev; build debs in `debian:trixie` containers because Ubuntu builds depend on `librtlsdr2`, uninstallable on Debian |
 | AIS-catcher fork | 0.68 | release workflow runs upstream `build-debian.sh` as root; upstream CI workflows disabled on the fork |
 | windtak 1.0.0, takline 0.1.1 | Jun 2026 | |
-| cockpit-* ×9 | 1.0.0+ | Cockpit plugins use the dark AryaOS/GPSTAK visual style; watch for regressions to white-on-white UI |
+| cockpit-* x9 | 1.0.0+ | Cockpit plugins use the dark AryaOS/GPSTAK visual style; watch for regressions to white-on-white UI |
 
 ## LINCOT / Host Beacon
 
@@ -290,16 +290,16 @@ for `/cgi-bin/aryaos-neighbors` and the landing-page neighbor table.
 
 ## Recurring gotchas (each cost a build this month)
 
-- `gh release upload` fails on fresh tags — `gh release view || gh release create` first.
+- `gh release upload` fails on fresh tags - `gh release view || gh release create` first.
 - Immutable GitHub releases reject assets uploaded after publication. Use
   `gh release create <tag> <asset> ...`, not a create-then-upload flow that publishes
   first.
-- `dpkg-deb -c | grep | head` → SIGPIPE kills dpkg-deb under `set -e`.
+- `dpkg-deb -c | grep | head` > SIGPIPE kills dpkg-deb under `set -e`.
 - `dh_install` treats destinations as directories (`foo.conf` becomes a *dir*).
 - stdeb deb names default to `python3-<name>` without `stdeb.cfg` `Package3:`.
 - A single private/release-less repo in `products.txt` kills the whole publish
   ("release not found"); publishes racing a just-pushed tag fail the same way.
-- This repo has `core.fileMode=false` — `git update-index --chmod=+x` for scripts.
+- This repo has `core.fileMode=false` - `git update-index --chmod=+x` for scripts.
 - GitHub GraphQL intermittently 401s here; use REST (`gh api`) with retries.
 
 ## Dev lab
@@ -331,10 +331,10 @@ After flashing the latest dev image, first checks should include:
 0. **Hardening burn-in (2026-07-02)**: flash the first post-hardening dev
    image and run the integration suite (esp. `09-security.sh`). Watch for
    firewalld regressions: comitup hotspot onboarding, Bluetooth PAN DHCP,
-   Mesh SA neighbor discovery, AntSDR → dronecot, Docker-published CloudTAK
+   Mesh SA neighbor discovery, AntSDR > dronecot, Docker-published CloudTAK
    ports, Node-RED/AIS-catcher dashboards. Then, **after the first release
    with the `aryaos-overlay_*_all.deb` asset exists**, add `snstac/aryaos` to
-   packages `products.txt` (adding it earlier breaks the whole publish —
+   packages `products.txt` (adding it earlier breaks the whole publish -
    `gh release download` fails on a release with no deb assets).
 1. **Flash and test the latest dev image**: burn
    `v2026.06.23.212757-abe8e41bf5e2-dev`, then run the integration suite against the
@@ -350,7 +350,7 @@ After flashing the latest dev image, first checks should include:
 4. **Release hygiene**: for dev builds, verify published prereleases have the image
    asset attached. Delete empty prereleases immediately if publish fails after tag
    creation.
-5. **takline + windtak are private** — the packages publish token can't read them;
+5. **takline + windtak are private** - the packages publish token can't read them;
    flip public (`gh repo edit snstac/<r> --visibility public
    --accept-visibility-change-consequences`), then add to `products.txt`.
 6. **Archive** `spotcot` (pre-pytak-5, dormant since 2022) and `cockpit-sdrconnect`
@@ -358,7 +358,7 @@ After flashing the latest dev image, first checks should include:
 7. **Delete** stray fork `snstac/AIS-catcher-1` (accidental duplicate).
 8. adsbcot PyPI job needs a **trusted publisher** configured on PyPI (release works
    regardless; the job just reads red).
-9. Possible next plugins: charontak *lane editor* (structured `charontak.ini` UI —
+9. Possible next plugins: charontak *lane editor* (structured `charontak.ini` UI -
    current plugin is a raw editor), windtak/aprscot pages; backport SIGPIPE
    fixes everywhere `dpkg-deb -c | head` survives.
 10. Node-RED runtime check after the worldmap 5.x / tfr2cot 2.0 major bumps

--- a/docs/brand/VENDORED.md
+++ b/docs/brand/VENDORED.md
@@ -4,7 +4,7 @@ Source: **`snstac/design-system`** (private)
 Pinned revision: **`f8bdd10028f55f75c83f438d34e6ed29527d6d75`**
 Vendored: 2026-07-29
 
-The design-system consumption model is explicit — pin a reviewed commit, copy
+The design-system consumption model is explicit - pin a reviewed commit, copy
 the files in, and record the revision here. Do **not** hotlink that repository
 at request time: a public site must not depend on GitHub availability or on a
 private repo.
@@ -22,10 +22,10 @@ private repo.
 ## Local adjustments
 
 Both are sanctioned by the upstream README, which describes `implementation/`
-as *copyable CSS … adjusted for the consumer's public asset path*.
+as *copyable CSS ... adjusted for the consumer's public asset path*.
 
-1. **Asset paths.** `../../runtime/fonts/` → `../fonts/`, and the token import
-   → `../tokens/suite-tokens.css`, to match this flat layout.
+1. **Asset paths.** `../../runtime/fonts/` becomes `../fonts/`, and the token
+   import becomes `../tokens/suite-tokens.css`, to match this flat layout.
 
 2. **Arya-family surfaces.** The shared `.sns-surface-paper` /
    `.sns-surface-console` are defined against the **&kit** palette
@@ -47,7 +47,7 @@ and was set from use. Documentation is a *read* surface and follows the kit at
 
 Copy the table above from a newer reviewed commit, re-apply the two local
 adjustments, update the revision here, then run this repository's own
-validation — `mkdocs build --strict` — as the upstream RUNBOOK requires of a
+validation - `mkdocs build --strict` - as the upstream RUNBOOK requires of a
 consumer.
 
 ## How this consumer applies the tokens

--- a/docs/build.md
+++ b/docs/build.md
@@ -14,7 +14,7 @@ For flash instructions, see [Installing AryaOS](get-started/flash-the-image.md).
 
 ## Manual build checklist (local Raspberry Pi image)
 
-Use this checklist when building an **arm64** Raspberry Pi OS–based image on your own machine. Automation-focused notes live in [AGENTS.md](https://github.com/snstac/aryaos/blob/main/AGENTS.md) at the repo root.
+Use this checklist when building an **arm64** Raspberry Pi OS-based image on your own machine. Automation-focused notes live in [AGENTS.md](https://github.com/snstac/aryaos/blob/main/AGENTS.md) at the repo root.
 
 ### Prerequisites
 
@@ -26,15 +26,15 @@ Use this checklist when building an **arm64** Raspberry Pi OS–based image on y
 ### Steps
 
 1. Clone this repository.
-2. **`make pi-gen`** — clones upstream [pi-gen](https://github.com/RPi-Distro/pi-gen) **`arm64`** into `./pi-gen/` (gitignored).
+2. **`make pi-gen`** - clones upstream [pi-gen](https://github.com/RPi-Distro/pi-gen) **`arm64`** into `./pi-gen/` (gitignored).
 3. Choose one build path:
-   - **Docker (preferred):** `make build-docker` — runs `./pi-gen/build-docker.sh -c <repo>/config.docker`, repo mounted read-only at `/aryaos`. Outputs land under **`.aryaos-pigen-deploy/`** at the repo root (and may also appear under `pi-gen/deploy/`).
-   - **Native:** `make build` — runs `sudo ./build.sh`, which invokes pi-gen with **`config`** (expects `./pi-gen`).
-4. After a successful base exists, use **`make skip`** / **`make unskip`** to skip or restore pi-gen **`stage0`–`stage2`** while iterating on AryaOS-only stages (see Makefile).
+   - **Docker (preferred):** `make build-docker` - runs `./pi-gen/build-docker.sh -c <repo>/config.docker`, repo mounted read-only at `/aryaos`. Outputs land under **`.aryaos-pigen-deploy/`** at the repo root (and may also appear under `pi-gen/deploy/`).
+   - **Native:** `make build` - runs `sudo ./build.sh`, which invokes pi-gen with **`config`** (expects `./pi-gen`).
+4. After a successful base exists, use **`make skip`** / **`make unskip`** to skip or restore pi-gen **`stage0`-`stage2`** while iterating on AryaOS-only stages (see Makefile).
 5. Optional **apt cache for Docker builds:** `make apt-cacher-up`, then `ARYAOS_APT_CACHE=1 make build-docker` (see Makefile targets **`apt-cacher-*`**; compose file **`docker-compose.apt-cacher.yml`** at repo root).
 6. Optional **logged Docker build:** `./scripts/agent-build-docker.sh` mirrors output to `build-YYYYMMDD-HHMMSS.log`.
 7. **Lab vs release builds:** by default images carry **no lab access** and **expire the default `pi` password at first login**. For a lab image (aryaos-dev-lab SSH key + passwordless sudo for `pi`, no password expiry) build with **`ARYAOS_LAB_ACCESS=1 make build-docker`** (or `sudo ARYAOS_LAB_ACCESS=1 ./build.sh` native). See `shared_files/aryaos/ssh/README.md`.
-8. **Verify a built image:** `sudo scripts/verify-image.sh [--lab] <image>.img|.img.xz|.zip` loop-mounts the image and asserts key files, packages, units — and that release images ship no lab access. CI runs this on every `main` build before publishing a release.
+8. **Verify a built image:** `sudo scripts/verify-image.sh [--lab] <image>.img|.img.xz|.zip` loop-mounts the image and asserts key files, packages, units - and that release images ship no lab access. CI runs this on every `main` build before publishing a release.
 9. **Build the AryaOS overlay package only:** `make package-overlay` writes `deploy/debs/aryaos-overlay_<version>_all.deb`, containing the portal, Cockpit proxy integration, TAK data package/enrollment helpers, first-boot identity scripts, gpsd defaults, dispatcher hooks, and related systemd/lighttpd configuration.
 10. Lightweight validation without an image: **`make ansible-syntax`** (requires Ansible / `ansible-galaxy` per Makefile).
 
@@ -72,7 +72,7 @@ Docker alternative (no host `sudo` for debootstrap): `make build-docker` runs `.
 To iterate on AryaOS-only stages without rebuilding the base OS:
 
 1. Sync the repo.
-2. Run `make skip` to add `SKIP` markers for `stage0`–`stage2`.
+2. Run `make skip` to add `SKIP` markers for `stage0`-`stage2`.
 3. Run `make build` again.
 
 The `make build` step invokes `sudo` and may prompt for a password.
@@ -83,8 +83,8 @@ To refresh the embedded pi-gen clone after `make pi-gen`, run `cd pi-gen && git 
 
 The workflow `.github/workflows/pi-gen.yml`:
 
-1. **Pull requests** — Runs Ansible collection install, `ansible-playbook --syntax-check`, checks that key paths (`config`, `manifests/aryaos-sensor-packages.yml`, custom stages) exist, validates that exactly **one stage carries `EXPORT_IMAGE`** and is **last in every `STAGE_LIST`**, and HEAD-checks pinned download URLs (catches upstream release renames before they break a 6-hour `main` build). No image is built (GitHub-hosted `ubuntu-latest`).
-2. **Push to `main` or `workflow_dispatch`** — Builds a **dev image by default** (`ARYAOS_LAB_ACCESS=1`: aryaos-dev-lab SSH key + passwordless sudo for `pi`, no first-boot password expiry) tagged `v<ts>-<sha>-dev` and published as a **prerelease** — grab it from Releases, burn, and test. For a **release image** (no lab access, password expiry enforced) run the workflow manually with the **`release`** input checked; it tags without the `-dev` suffix as a normal release. `verify-image.sh` checks whichever flavor was built (`--lab` for dev). Builds the full pi-gen image on GitHub’s hosted **`ubuntu-24.04-arm`** runner (native **aarch64**) via [usimd/pi-gen-action](https://github.com/usimd/pi-gen-action) (`compression: xz`). No QEMU/`binfmt_misc` emulation step — debootstrap/chroot run natively. Before **`pi-gen-action`**, the workflow frees disk (`dotnet`, Android NDK, hosted toolcache, etc.) because default runner images are tight on space. After a successful build, the workflow uploads the image as a **workflow artifact** (30-day retention), then runs **`scripts/verify-image.sh`** (loop-mounts the image; asserts key files/packages/units and that no lab access ships) — a verification failure keeps the artifact but **blocks the release**. On success it creates an annotated tag `v<UTC-datetime>-<12-char-sha>`, pushes it, and publishes a **GitHub Release** with the image attached (`generate_release_notes`). Builds for the same repo are serialized (`concurrency`, no cancel-in-progress).
+1. **Pull requests** - Runs Ansible collection install, `ansible-playbook --syntax-check`, checks that key paths (`config`, `manifests/aryaos-sensor-packages.yml`, custom stages) exist, validates that exactly **one stage carries `EXPORT_IMAGE`** and is **last in every `STAGE_LIST`**, and HEAD-checks pinned download URLs (catches upstream release renames before they break a 6-hour `main` build). No image is built (GitHub-hosted `ubuntu-latest`).
+2. **Push to `main` or `workflow_dispatch`** - Builds a **dev image by default** (`ARYAOS_LAB_ACCESS=1`: aryaos-dev-lab SSH key + passwordless sudo for `pi`, no first-boot password expiry) tagged `v<ts>-<sha>-dev` and published as a **prerelease** - grab it from Releases, burn, and test. For a **release image** (no lab access, password expiry enforced) run the workflow manually with the **`release`** input checked; it tags without the `-dev` suffix as a normal release. `verify-image.sh` checks whichever flavor was built (`--lab` for dev). Builds the full pi-gen image on GitHub's hosted **`ubuntu-24.04-arm`** runner (native **aarch64**) via [usimd/pi-gen-action](https://github.com/usimd/pi-gen-action) (`compression: xz`). No QEMU/`binfmt_misc` emulation step - debootstrap/chroot run natively. Before **`pi-gen-action`**, the workflow frees disk (`dotnet`, Android NDK, hosted toolcache, etc.) because default runner images are tight on space. After a successful build, the workflow uploads the image as a **workflow artifact** (30-day retention), then runs **`scripts/verify-image.sh`** (loop-mounts the image; asserts key files/packages/units and that no lab access ships) - a verification failure keeps the artifact but **blocks the release**. On success it creates an annotated tag `v<UTC-datetime>-<12-char-sha>`, pushes it, and publishes a **GitHub Release** with the image attached (`generate_release_notes`). Builds for the same repo are serialized (`concurrency`, no cancel-in-progress).
 
 **Hosted arm64 notes**
 
@@ -98,7 +98,7 @@ Every image build also produces a **Software Bill of Materials** in both
 SPDX 2.3 and CycloneDX JSON (`aryaos-<tag>.spdx.json` / `.cdx.json`), attached
 to the GitHub Release beside the image and kept as a 90-day workflow artifact.
 The generator is `scripts/generate-sbom.sh` (loop-mounts the image, runs a
-pinned [syft](https://github.com/anchore/syft) over the rootfs — covers dpkg,
+pinned [syft](https://github.com/anchore/syft) over the rootfs - covers dpkg,
 Python site-packages, and the Node-RED npm tree). Run it locally with:
 
 ```bash
@@ -117,7 +117,7 @@ The workflow no longer triggers on `push` of version tags (that avoided rebuildi
 ### Faster local builds (beefy machine)
 
 - Prefer upstream **`pi-gen/build-docker.sh`** with **bind mounts or named volumes** for `work/` and `deploy/` so repeated runs reuse downloads where pi-gen allows.
-- **Apt cache (Docker builds):** run `make apt-cacher-up` once (starts **`apt-cacher-ng`** via `docker-compose.apt-cacher.yml` at the repo root; cache lives in the Docker volume `aryaos_apt_cacher_cache`). Then build with **`ARYAOS_APT_CACHE=1 make build-docker`**. The Makefile passes **`APT_PROXY`** into the pi-gen container (`Acquire::http::Proxy`, same as upstream pi-gen) using **`host.docker.internal`** + Docker’s **`host-gateway`**. Check the cache with **`make apt-cacher-ping`**; tail logs with **`make apt-cacher-logs`**. Stop with **`make apt-cacher-down`** (volume is kept until you remove it with `docker volume rm`).
+- **Apt cache (Docker builds):** run `make apt-cacher-up` once (starts **`apt-cacher-ng`** via `docker-compose.apt-cacher.yml` at the repo root; cache lives in the Docker volume `aryaos_apt_cacher_cache`). Then build with **`ARYAOS_APT_CACHE=1 make build-docker`**. The Makefile passes **`APT_PROXY`** into the pi-gen container (`Acquire::http::Proxy`, same as upstream pi-gen) using **`host.docker.internal`** + Docker's **`host-gateway`**. Check the cache with **`make apt-cacher-ping`**; tail logs with **`make apt-cacher-logs`**. Stop with **`make apt-cacher-down`** (volume is kept until you remove it with `docker volume rm`).
 - **Native `make build`:** set **`APT_PROXY`** in [`config`](config/index.md) (commented example) to your proxy URL, e.g. `http://127.0.0.1:3142` when `apt-cacher-ng` publishes that port on the host.
 - Export **`NUM_CORES`** to match your CPU so pi-gen can parallelize package operations.
 - Use **`make skip`** / **`make unskip`** when iterating only on AryaOS stages after a full base image exists.
@@ -126,8 +126,8 @@ The workflow no longer triggers on `push` of version tags (that avoided rebuildi
 
 When Actions hit timeouts, disk limits, or the 2 GiB release cap:
 
-1. Launch **Ubuntu 22.04/24.04** on **EC2 Spot** (e.g. compute-optimized 4xlarge class) with a large **gp3** volume (256–512 GB) for Docker and pi-gen work dirs.
-2. Install Docker, clone this repo, `make pi-gen`, then `sudo ./build.sh` or run `pi-gen`’s Docker build script from the `pi-gen` tree.
+1. Launch **Ubuntu 22.04/24.04** on **EC2 Spot** (e.g. compute-optimized 4xlarge class) with a large **gp3** volume (256-512 GB) for Docker and pi-gen work dirs.
+2. Install Docker, clone this repo, `make pi-gen`, then `sudo ./build.sh` or run `pi-gen`'s Docker build script from the `pi-gen` tree.
 3. Copy the artifact from `pi-gen/deploy/` to **S3** (`aws s3 cp ...`; add a lifecycle rule to expire old objects). Optionally front it with **CloudFront** if download traffic grows.
 4. For GitHub distribution, either upload a file **smaller than 2 GiB** with **`gh release upload`** using a token on the instance, or publish an **S3 HTTPS URL** / `latest.json` pointer in the release notes.
 
@@ -175,7 +175,7 @@ When you need something close to AryaOS (e.g. **Cockpit + cockpit-adsbcot + adsb
 
 ### Incremental image builds (reminder)
 
-Reuse **`.aryaos-pigen-work`** / **`.aryaos-pigen-deploy`**, **`make skip`** after the base exists, **`ARYAOS_APT_CACHE=1`**, and **`NUM_CORES`** — see [AGENTS.md](https://github.com/snstac/aryaos/blob/main/AGENTS.md) and the **Manual build checklist** above. Avoid **`make build-docker-clean`** unless you need a cold rebuild.
+Reuse **`.aryaos-pigen-work`** / **`.aryaos-pigen-deploy`**, **`make skip`** after the base exists, **`ARYAOS_APT_CACHE=1`**, and **`NUM_CORES`** - see [AGENTS.md](https://github.com/snstac/aryaos/blob/main/AGENTS.md) and the **Manual build checklist** above. Avoid **`make build-docker-clean`** unless you need a cold rebuild.
 
 ### Ansible against a running Debian/arm64 host
 
@@ -191,7 +191,7 @@ ansible-playbook -i inventory.yml site.yml \
 ```
 
 - Add **`aryaos`** (or other tags from [`site.yml`](https://github.com/snstac/aryaos/blob/main/site.yml)) when you need portal/lighttpd/Cockpit proxy behaviour (e.g. **`UrlRoot=/admin`**).
-- **`stage-adsbcot`** may assume **Pi-oriented `.deb` artifacts** (e.g. vendored **arm64** readsb) or hardware; an **amd64** laptop often needs different packages or vars — prefer **arm64** for parity with shipped images.
+- **`stage-adsbcot`** may assume **Pi-oriented `.deb` artifacts** (e.g. vendored **arm64** readsb) or hardware; an **amd64** laptop often needs different packages or vars - prefer **arm64** for parity with shipped images.
 - **readsb SDR backends:** pi-gen rebuilds readsb with **RTL-SDR**, **SoapySDR** (Airspy), and **HackRF** via [`shared_files/adsbcot/readsb-install.sh`](https://github.com/snstac/aryaos/blob/main/shared_files/adsbcot/readsb-install.sh); `04-adsbcot/01-run-chroot.sh` fails the stage if `readsb --help` lacks any of those. See [Radios & SDRs](config/radios-sdr.md#choosing-the-1090-mhz-decoder).
 
 See commented **`dev_arm64`** stubs in [`inventory.yml`](https://github.com/snstac/aryaos/blob/main/inventory.yml).
@@ -230,4 +230,4 @@ Boot a generic **Debian arm64** cloud image or your produced image under **QEMU*
 
 ### cockpit-adsbcot UI-only iteration
 
-Upstream [**cockpit-adsbcot**](https://github.com/snstac/cockpit-adsbcot) documents **`make devel-install`**, which symlinks the built bundle into **`~/.local/share/cockpit/`** on a machine that already runs Cockpit — fastest for **frontend** changes. It does **not** reproduce AryaOS **lighttpd** termination or **`UrlRoot=/admin`** by itself; validate that stack via Ansible or a real image.
+Upstream [**cockpit-adsbcot**](https://github.com/snstac/cockpit-adsbcot) documents **`make devel-install`**, which symlinks the built bundle into **`~/.local/share/cockpit/`** on a machine that already runs Cockpit - fastest for **frontend** changes. It does **not** reproduce AryaOS **lighttpd** termination or **`UrlRoot=/admin`** by itself; validate that stack via Ansible or a real image.

--- a/docs/config/device-roles.md
+++ b/docs/config/device-roles.md
@@ -1,15 +1,15 @@
 # Device roles
 
-A **device role** selects which sensor pipelines run on an AryaOS unit — aircraft, vessels, drones, all of them, or none. Roles are runtime-selectable and persisted, so you can repurpose a box in the field without re-flashing. Set the role from the [Device role](../admin/aryaos-site.md#device-role) card or with the `aryaos-role` CLI helper.
+A **device role** selects which sensor pipelines run on an AryaOS unit - aircraft, vessels, drones, all of them, or none. Roles are runtime-selectable and persisted, so you can repurpose a box in the field without re-flashing. Set the role from the [Device role](../admin/aryaos-site.md#device-role) card or with the `aryaos-role` CLI helper.
 
 ## The CoT core is always on
 
 Whatever role you choose, the **CoT core never stops**:
 
-- `charontak` — the CoT hub / router
-- `lincot` — this host's own beacon
-- `gpstak` — network GPS to TAK clients
-- `gpsd` — the GNSS receiver
+- `charontak` - the CoT hub / router
+- `lincot` - this host's own beacon
+- `gpstak` - network GPS to TAK clients
+- `gpsd` - the GNSS receiver
 
 Roles only toggle the **sensor** units on top of that core. This means a unit always beacons its position and routes CoT, even in the sensor-free `relay` role.
 
@@ -34,12 +34,12 @@ The exact unit sets, from `aryaos-role`:
 | Drones / C-UAS (`cuas`, `multi`) | `dronecot`, `sikw00fcot`, `sapientcot` |
 
 !!! note "Units missing from your image are skipped"
-    Applying a role enables the role's units and disables all other managed units. Optional units that are not installed on your image (for example a decoder you did not build) are simply skipped — not errors. The full managed set the helper touches is: `readsb`, `dump1090-fa`, `dump978-fa`, `adsbcot`, `gdltak`, `ais-catcher`, `aiscot`, `dronecot`, `sikw00fcot`, `sapientcot`.
+    Applying a role enables the role's units and disables all other managed units. Missing optional units are skipped without error. The full managed set is: `readsb`, `dump1090-fa`, `dump978-fa`, `adsbcot`, `gdltak`, `ais-catcher`, `aiscot`, `dronecot`, `sikw00fcot`, `sapientcot`.
 
-    `sapientcot` bridges a [SAPIENT (BSI Flex 335)](https://github.com/snstac/sapientcot) C-UAS sensor/fusion network into TAK. Point `SAPIENT_HOST`/`SAPIENT_PORT` in `/etc/default/sapientcot` at your SAPIENT node; with no reachable node it simply retries.
+    `sapientcot` bridges a [SAPIENT (BSI Flex 335)](https://github.com/snstac/sapientcot) C-UAS sensor/fusion network into TAK. Point `SAPIENT_HOST`/`SAPIENT_PORT` in `/etc/default/sapientcot` at your SAPIENT node. It retries while the node is unreachable.
 
 !!! tip "The unused ADS-B decoder is always disabled"
-    Applying a role also disables whichever 1090 MHz decoder you are *not* using. That is why re-applying the role is the way to make a decoder change in the site config take effect — see [Radios & SDRs](./radios-sdr.md).
+    Applying a role also disables whichever 1090 MHz decoder you are *not* using. That is why re-applying the role is the way to make a decoder change in the site config take effect - see [Radios & SDRs](./radios-sdr.md).
 
 ## How switching works
 
@@ -52,7 +52,7 @@ Applying a role does three things, in order:
 Because the units are *disabled*, the role sticks across reboots.
 
 === "Web console"
-    On the [AryaOS Site page](../admin/aryaos-site.md#device-role), choose a role from the **Role** drop-down. The card previews the exact units that will be enabled ("Sensor services for this role: …"). Press **Apply role** and confirm — services outside the role are stopped and disabled.
+    On the [AryaOS Site page](../admin/aryaos-site.md#device-role), choose a role from the **Role** drop-down. The card previews the exact units that will be enabled ("Sensor services for this role: ..."). Press **Apply role** and confirm - services outside the role are stopped and disabled.
 
 === "CLI"
     ```bash
@@ -65,7 +65,7 @@ Because the units are *disabled*, the role sticks across reboots.
     The helper prints each `enable`/`disable` action it takes. See [CLI helpers](../reference/cli-helpers.md).
 
 !!! warning "Applying a role disables other sensors"
-    Switching to `air` stops and disables the AIS and drone units; switching to `relay` stops **all** sensor units. This is intentional — pick the role that matches the mission. The CoT core keeps running regardless.
+    Switching to `air` stops and disables the AIS and drone units; switching to `relay` stops **all** sensor units. This is intentional - pick the role that matches the mission. The CoT core keeps running regardless.
 
 ## Capability discovery
 
@@ -86,7 +86,7 @@ Detected hardware capabilities: adsb
                        * shares a radio with 'adsb'; enable manually with
                          `aryaos-role caps ais` (or add a second receiver)
   wifi-rid  no         no external Wi-Fi adapter
-  sapient   manual     network sensor — configure deliberately, never auto-detected
+  sapient   manual     network sensor - configure deliberately, never auto-detected
 ```
 
 **This runs automatically once, at first boot.** The image ships every sensor
@@ -102,7 +102,7 @@ worse than enabling nothing:
 - **Contended radios.** One SDR cannot serve ADS-B *and* AIS at once, so only
   the higher-priority capability (`adsb`) is auto-enabled; the other is reported
   as available with the reason it was held back.
-- **DS110 vs SiKW00F.** Both are ESP32-S3 (`303a:1001`) — the USB id cannot tell
+- **DS110 vs SiKW00F.** Both are ESP32-S3 (`303a:1001`) - the USB id cannot tell
   them apart. The scanner probes the port for MAVLink framing (a DS110 speaks
   it); if the port is silent or in use it reports `AMBIGUOUS` rather than
   guessing.
@@ -119,11 +119,11 @@ off, or a service running that nobody declared.
 ## Persistence and precedence
 
 - The current role lives in `ARYAOS_ROLE` in the site config. When unset, the effective role is `multi`.
-- Editing `ARYAOS_ROLE` by hand does **not** change which units run — the enable/disable actions happen when you *apply* a role. Always apply through the card or `aryaos-role set` so systemd state and the config key stay in sync.
+- Editing `ARYAOS_ROLE` by hand does **not** change which units run - the enable/disable actions happen when you *apply* a role. Always apply through the card or `aryaos-role set` so systemd state and the config key stay in sync.
 
 ## See also
 
-- [Multi-sensor COP](../deploy/multi-sensor.md) — running all pipelines at once
-- [Relay & routing](../deploy/relay-routing.md) — the `relay` role in practice
-- [Site configuration](./site-config.md) — `ARYAOS_ROLE` and the decoder key
-- [Radios & SDRs](./radios-sdr.md) — decoder selection
+- [Multi-sensor COP](../deploy/multi-sensor.md) - running all pipelines at once
+- [Relay & routing](../deploy/relay-routing.md) - the `relay` role in practice
+- [Site configuration](./site-config.md) - `ARYAOS_ROLE` and the decoder key
+- [Radios & SDRs](./radios-sdr.md) - decoder selection

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -9,7 +9,7 @@ flowchart TD
   site["/etc/aryaos/aryaos-config.txt<br/>(site config)"]
   svc1["/etc/default/adsbcot"]
   svc2["/etc/default/aiscot"]
-  svc3["/etc/default/…"]
+  svc3["/etc/default/..."]
   ct["/etc/charontak.ini<br/>(lanes)"]
   site -->|EnvironmentFile, read first| svc1
   site -->|EnvironmentFile, read first| svc2
@@ -22,7 +22,7 @@ flowchart TD
 Each gateway's systemd unit loads the **site config first**, then its own **`/etc/default/<svc>`** file. Because the per-service file is read second, **a value set per-service wins**; anything left unset falls through to the site default.
 
 !!! example "One place sets the CoT hub for everyone"
-    The site config sets `COT_URL=udp+wo://127.0.0.1:28087`. Every feeder inherits it, so out of the box they all send [Cursor on Target (CoT)](../reference/glossary.md) to the Charontak hub — no per-service configuration needed. This is the AryaOS routing invariant: **feeders → charontak → Mesh SA / TAK Server**.
+    The site config sets `COT_URL=udp+wo://127.0.0.1:28087`. Every feeder inherits it and sends [Cursor on Target (CoT)](../reference/glossary.md) to the Charontak hub without per-service configuration. This is the AryaOS routing invariant: **feeders > charontak > Mesh SA / TAK Server**.
 
 ## Where each thing lives
 
@@ -36,22 +36,22 @@ Each gateway's systemd unit loads the **site config first**, then its own **`/et
 
 ## Edit in the UI, not the files
 
-Everything above can be edited in the web console — you should not need SSH or a text editor for normal configuration. As a rule:
+Everything above can be edited in the web console - you should not need SSH or a text editor for normal configuration. As a rule:
 
-- **Site-wide behavior** (TAK destination, decoder, role, radios, TLS) → [AryaOS Site page](../admin/aryaos-site.md).
-- **Where CoT goes upstream** (mesh, TAK Server, fan-out) → [Charontak lane editor](../admin/charontak-lanes.md).
-- **One service's own knobs** → that [gateway's page](../admin/gateways.md).
+- **Site-wide behavior** (TAK destination, decoder, role, radios, TLS) > [AryaOS Site page](../admin/aryaos-site.md).
+- **Where CoT goes upstream** (mesh, TAK Server, fan-out) > [Charontak lane editor](../admin/charontak-lanes.md).
+- **One service's own knobs** > that [gateway's page](../admin/gateways.md).
 
-Each editor writes the underlying file for you, preserving comments and any keys it does not manage. If you *do* edit a file directly (over SSH or with Cockpit's file editor), restart the affected units afterward — for example `sudo systemctl restart charontak adsbcot aiscot lincot`.
+Each editor writes the underlying file for you, preserving comments and any keys it does not manage. If you *do* edit a file directly (over SSH or with Cockpit's file editor), restart the affected units afterward - for example `sudo systemctl restart charontak adsbcot aiscot lincot`.
 
 ## The three configuration references
 
 <div class="grid cards" markdown>
 
-- :material-file-cog: **Site configuration** — Every key in `/etc/aryaos/aryaos-config.txt`: the TAK/CoT destination, ADS-B decoder, network binding, Bluetooth PAN, role, and device identity. [Reference](./site-config.md)
+- :material-file-cog: **Site configuration** - Every key in `/etc/aryaos/aryaos-config.txt`: the TAK/CoT destination, ADS-B decoder, network binding, Bluetooth PAN, role, and device identity. [Reference](./site-config.md)
 
-- :material-account-switch: **Device roles** — The five roles, exactly which sensor units each enables, and how the CoT core always stays up. [Roles](./device-roles.md)
+- :material-account-switch: **Device roles** - The five roles, exactly which sensor units each enables, and how the CoT core always stays up. [Roles](./device-roles.md)
 
-- :material-radio-tower: **Radios & SDRs** — The `stx:1090:0` / `stx:978:0` serial convention, re-serializing dongles, decoder selection, and multi-SDR setups. [Radios](./radios-sdr.md)
+- :material-radio-tower: **Radios & SDRs** - The `stx:1090:0` / `stx:978:0` serial convention, re-serializing dongles, decoder selection, and multi-SDR setups. [Radios](./radios-sdr.md)
 
 </div>

--- a/docs/config/network-sdr.md
+++ b/docs/config/network-sdr.md
@@ -2,14 +2,14 @@
 
 AryaOS can serve an onboard SDR **raw over the network** so a remote operator can
 tune and demodulate it from a desktop client (SDR++, SDRangel, GQRX, SDR#,
-`dump1090`, …) instead of decoding it on the box. A dongle can only do one job at
+`dump1090`, ...) instead of decoding it on the box. A dongle can only do one job at
 a time, so sharing a dongle **stops its decoder** first.
 
-!!! danger "Raw SDR sharing is unauthenticated — opt-in only"
+!!! danger "Raw SDR sharing is unauthenticated - opt-in only"
     Both servers below give any client that can reach the port **full control of
     the dongle** (tuning + raw IQ). They are **off by default**, and the firewall
     does **not** open their ports on any zone. Enable a share only on a **trusted
-    or VPN** network — open the firewall service deliberately, or bind the server
+    or VPN** network - open the firewall service deliberately, or bind the server
     to your [VPN](../networking/vpn-tailscale.md) address (`AOS_RTLTCP_BIND` /
     `AOS_SOAPY_BIND` / `AOS_SPYSERVER_BIND`). Turn it back off when you're done.
 
@@ -17,15 +17,15 @@ a time, so sharing a dongle **stops its decoder** first.
 
 | Server | Devices | Client connects as | Port |
 |---|---|---|---|
-| **rtl_tcp** | RTL-SDR only (per dongle) | `rtl_tcp` host:port (SDR#, GQRX, dump1090…) | `1234 + index` |
+| **rtl_tcp** | RTL-SDR only (per dongle) | `rtl_tcp` host:port (SDR#, GQRX, dump1090...) | `1234 + index` |
 | **SoapyRemote** | any SoapySDR device (RTL / LimeSDR / Airspy / HackRF) | `driver=remote,remote=<host>` (SDR++, SDRangel) | `55132` |
 | **SpyServer** | RTL-SDR (per dongle) | `spyserver://<host>:<port>` (SDR#, SDRangel, SDR++) | `5555 + index` |
 
 !!! note "SpyServer is an optional proprietary component"
     The Airspy `spyserver` binary is not in Debian; AryaOS fetches it at **build
     time** from airspy.com. If the builder was offline the mode is unavailable and
-    `aryaos-sdr share N spyserver` reports so (check `share-status` →
-    `"spyserver_available"`). SpyServer streams a *compressed, decimated* slice —
+    `aryaos-sdr share N spyserver` reports so (check `share-status` >
+    `"spyserver_available"`). SpyServer streams a *compressed, decimated* slice -
     lighter on the network than `rtl_tcp`'s raw IQ, and it never advertises the box
     in the public SpyServer directory (`list_in_directory = 0`).
 
@@ -51,7 +51,7 @@ The share ports are closed by default. To reach a share, either **bind to the VP
 sudo systemctl edit aryaos-rtltcp@0     # add: [Service]\nEnvironment=AOS_RTLTCP_BIND=100.x.y.z
 ```
 
-…or **open the firewall service on a trusted zone** (the definitions ship but are
+...or **open the firewall service on a trusted zone** (the definitions ship but are
 attached to no zone):
 
 ```bash
@@ -62,6 +62,6 @@ sudo firewall-cmd --permanent --zone=public --add-service=aryaos-rtltcp
 
 ## See also
 
-- [Radios & SDRs](radios-sdr.md) — SDR serials and decoder assignment
-- [SIGINT / wideband (LimeSDR)](../deploy/sigint-limesdr.md) — the dragonegg laydown
-- [VPN (Tailscale)](../networking/vpn-tailscale.md) — the recommended path for remote SDR access
+- [Radios & SDRs](radios-sdr.md) - SDR serials and decoder assignment
+- [SIGINT / wideband (LimeSDR)](../deploy/sigint-limesdr.md) - the dragonegg laydown
+- [VPN (Tailscale)](../networking/vpn-tailscale.md) - the recommended path for remote SDR access

--- a/docs/config/radios-sdr.md
+++ b/docs/config/radios-sdr.md
@@ -23,7 +23,7 @@ You can list dongles and write new serials from the web console or the CLI.
 === "Radios card (recommended)"
     On the [AryaOS Site page](../admin/aryaos-site.md#radios-rtl-sdr), the **Radios (RTL-SDR)** card lists each detected dongle with its index, device string, and current serial. Type a new serial into the **New serial** field for a dongle and press **Write**; confirm the prompt. Use the refresh (↻) icon to rescan.
 
-    Serials must be **1–32 characters** from `A-Z a-z 0-9 : . _ -`.
+    Serials must be **1-32 characters** from `A-Z a-z 0-9 : . _ -`.
 
 === "CLI"
     ```bash
@@ -42,15 +42,15 @@ You can list dongles and write new serials from the web console or the CLI.
 
 AryaOS runs exactly **one** 1090 MHz decoder at a time:
 
-- **readsb** (image default) — rebuilt with RTL-SDR, SoapySDR (Airspy and other Soapy devices), and native HackRF support.
-- **dump1090-fa** (FlightAware) — RTL-SDR.
+- **readsb** (image default) - rebuilt with RTL-SDR, SoapySDR (Airspy and other Soapy devices), and native HackRF support.
+- **dump1090-fa** (FlightAware) - RTL-SDR.
 
 Both decoders write the same unified JSON feed at `/run/adsb/aircraft.json` (directory set by `ARYAOS_ADSB_JSON_DIR`), and `adsbcot` always reads that path. **You never change `adsbcot`'s feed when switching decoders.**
 
 Selecting the decoder is a two-part operation today:
 
 1. **Record the choice.** Set the **ADS-B decoder** drop-down on the [AryaOS Site page](../admin/aryaos-site.md#tak-destination) (writes `ARYAOS_ADSB_DECODER` = `readsb` or `dump1090_fa`).
-2. **Switch the services.** Setting the key alone does not start or stop systemd units. **Re-apply the [device role](./device-roles.md)** — the role logic enables the selected decoder and disables the other.
+2. **Switch the services.** Setting the key alone does not start or stop systemd units. **Re-apply the [device role](./device-roles.md)** - the role logic enables the selected decoder and disables the other.
 
 === "Via role re-apply (recommended)"
     After changing the decoder drop-down, open the [Device role](../admin/aryaos-site.md#device-role) card and press **Apply role** again. The role enables the chosen decoder and disables the unused one.
@@ -66,7 +66,7 @@ Selecting the decoder is a two-part operation today:
 
 ## Multi-SDR setups
 
-A common AryaOS build carries two dongles — one at `stx:1090:0` for ADS-B and one at `stx:978:0` for UAT — plus optionally an AIS receiver. The serial pairing is what lets `readsb`/`dump1090-fa` and `dump978-fa` each claim the correct hardware regardless of USB order. When you add or swap a dongle:
+A common AryaOS build carries two dongles - one at `stx:1090:0` for ADS-B and one at `stx:978:0` for UAT - plus optionally an AIS receiver. The serial pairing is what lets `readsb`/`dump1090-fa` and `dump978-fa` each claim the correct hardware regardless of USB order. When you add or swap a dongle:
 
 1. `aryaos-sdr list` (or the Radios card) to find its current serial and index.
 2. Write the band-appropriate serial (`stx:1090:0` or `stx:978:0`), keeping the two bands distinct.
@@ -76,11 +76,11 @@ The [landing portal](../portal.md) and the portal's **Radios / RF** panel show a
 
 ## Gain, PPM, and other tuning
 
-Fine-tuning such as gain and frequency correction (PPM) is **not** exposed in the Radios card today — that card manages serials only. These live in the decoder's own config file:
+Fine-tuning such as gain and frequency correction (PPM) is **not** exposed in the Radios card today - that card manages serials only. These live in the decoder's own config file:
 
-- **readsb** — `/etc/default/readsb` (`RECEIVER_OPTIONS`, `DECODER_OPTIONS`)
-- **dump1090-fa** — `/etc/default/dump1090-fa`
-- **dump978-fa** — `/etc/default/dump978-fa`
+- **readsb** - `/etc/default/readsb` (`RECEIVER_OPTIONS`, `DECODER_OPTIONS`)
+- **dump1090-fa** - `/etc/default/dump1090-fa`
+- **dump978-fa** - `/etc/default/dump978-fa`
 
 Edit them with Cockpit's file editor or over SSH, then `sudo systemctl restart <decoder>`. Because `readsb` is `apt-mark hold` on the image, updates will not silently overwrite a tuned decoder.
 
@@ -89,17 +89,17 @@ Edit them with Cockpit's file editor or over SSH, then `sudo systemctl restart <
 
 ## See also
 
-- [Site configuration](./site-config.md) — `ARYAOS_ADSB_DECODER`, `ARYAOS_UAT_RTL_SERIAL`, `ARYAOS_ADSB_JSON_DIR`
-## Serial (NMEA) receivers — GPS and AIS
+- [Site configuration](./site-config.md) - `ARYAOS_ADSB_DECODER`, `ARYAOS_UAT_RTL_SERIAL`, `ARYAOS_ADSB_JSON_DIR`
+## Serial (NMEA) receivers - GPS and AIS
 
-USB-serial receivers — a **GPS puck** and a **dAISy** (or equivalent serial AIS receiver) — are
+USB-serial receivers - a **GPS puck** and a **dAISy** (or equivalent serial AIS receiver) - are
 assigned the same way in spirit, but by the **NMEA they emit** rather than an EEPROM serial,
-since serial adapters (CP210x, CH340, FTDI, Prolific…) have no consistent identity.
+since serial adapters (CP210x, CH340, FTDI, Prolific...) have no consistent identity.
 
 At boot, **`aryaos-serial-assign`** probes each USB-serial device and classifies it:
 
-- **GPS** if it emits `$GPxxx`/`$GNxxx` → written to `gpsd` (`/etc/default/gpsd` `DEVICES`).
-- **AIS** if it emits `!AIVDM`/`!AIVDO` → written to `ais-catcher` (`SERIAL_PORT`).
+- **GPS** if it emits `$GPxxx`/`$GNxxx` > written to `gpsd` (`/etc/default/gpsd` `DEVICES`).
+- **AIS** if it emits `!AIVDM`/`!AIVDO` > written to `ais-catcher` (`SERIAL_PORT`).
 - A **dAISy with no vessels in range is silent**; when AIS is intended and it's the only
   non-GPS serial left, it's assigned by **elimination** at 38400 baud.
 
@@ -110,7 +110,7 @@ yourself and disable `aryaos-serial-assign.service`.
 
 ## Re-tasking an SDR
 
-An SDR is just a wideband receiver — the same radio can decode ADS-B, UAT, AIS,
+An SDR is just a wideband receiver - the same radio can decode ADS-B, UAT, AIS,
 or APRS depending on how it's tuned. **Re-task** it to a different job on the fly,
 without a re-serialize or replug:
 
@@ -124,25 +124,25 @@ sudo aryaos-sdr task 1 off          # idle the SDR
 ```
 
 !!! info "Any SDR, not just RTL-SDR (DragonEgg)"
-    `aryaos-sdr` enumerates and tasks **any SoapySDR device** — RTL-SDR, **Airspy**,
-    HackRF, LimeSDR — via `SoapySDRUtil`, not only RTL dongles. `list` reports each
+    `aryaos-sdr` enumerates and tasks **any SoapySDR device** - RTL-SDR, **Airspy**,
+    HackRF, LimeSDR - via `SoapySDRUtil`, not only RTL dongles. `list` reports each
     device's **driver** and **serial**; tasking builds the right decoder invocation
     (native `rtlsdr`, or `--device-type soapysdr driver=<drv>` for the rest).
     Current coverage: **ADS-B** and **AIS** work on any SDR; **UAT** and **APRS**
-    are RTL-SDR only for now (UAT needs `dump978-fa`; APRS needs an FM demod —
+    are RTL-SDR only for now (UAT needs `dump978-fa`; APRS needs an FM demod -
     `rx_tools` for non-RTL is a roadmap item).
 
 - **`ais`** runs `ais-catcher` on the tasked SDR (`aryaos-ais-sdr` for any device;
-  the serial dAISy path is untouched) and feeds the same `aiscot → charontak → TAK`
+  the serial dAISy path is untouched) and feeds the same `aiscot > charontak > TAK`
   chain. It needs a **VHF marine antenna** to hear vessels.
 - **`aprs`** decodes 1200-baud packet **APRS on 144.39 MHz** (North America):
-  `rtl_fm` → **Dire Wolf** (`aryaos-direwolf@N`, KISS TNC on `:8001`, receive-only)
-  → **aprscot** (KISS input, ≥ 8.2.0) → `charontak → TAK`. Fully **offline** — no
+  `rtl_fm` > **Dire Wolf** (`aryaos-direwolf@N`, KISS TNC on `:8001`, receive-only)
+  then **aprscot** (KISS input, ≥ 8.2.0), followed by `charontak` and TAK. Fully **offline** - no
   APRS-IS internet. Needs a **2 m (VHF) antenna**. Single dongle at a time (one
   APRS channel).
 - The job is **persisted** (`/etc/aryaos/sdr-tasks`) and re-applied at boot,
   mapping the dongle by serial so it survives enumeration changes.
-- A **role apply** (`aryaos-role set …`) is authoritative and **clears** per-dongle
+- A **role apply** (`aryaos-role set ...`) is authoritative and **clears** per-dongle
   re-tasks.
 
 To hand the dongle to a remote operator instead of decoding locally, see
@@ -150,8 +150,8 @@ To hand the dongle to a remote operator instead of decoding locally, see
 
 ## See also
 
-- [Device roles](./device-roles.md) — how a role apply switches decoders
-- [Aircraft (ADS-B)](../deploy/air-adsb.md) — deploying the aircraft pipeline
-- [Maritime vessels (AIS)](../deploy/maritime-ais.md) — the AIS pipeline
-- [Network SDR sharing](network-sdr.md) — serve a dongle over the net
-- [CLI helpers](../reference/cli-helpers.md) — `aryaos-sdr`
+- [Device roles](./device-roles.md) - how a role apply switches decoders
+- [Aircraft (ADS-B)](../deploy/air-adsb.md) - deploying the aircraft pipeline
+- [Maritime vessels (AIS)](../deploy/maritime-ais.md) - the AIS pipeline
+- [Network SDR sharing](network-sdr.md) - serve a dongle over the net
+- [CLI helpers](../reference/cli-helpers.md) - `aryaos-sdr`

--- a/docs/config/site-config.md
+++ b/docs/config/site-config.md
@@ -1,22 +1,22 @@
 # Site configuration
 
-`/etc/aryaos/aryaos-config.txt` is the **site configuration** file: the site-wide defaults inherited by every PyTAK sensor gateway on the device. This page is the complete key reference. Edit it through the [AryaOS Site page](../admin/aryaos-site.md) — the form updates known keys in place and preserves comments and everything else — or, for keys the form does not surface, through that page's **Raw site config** editor.
+`/etc/aryaos/aryaos-config.txt` is the **site configuration** file: the site-wide defaults inherited by every PyTAK sensor gateway on the device. This page is the complete key reference. Edit it through the [AryaOS Site page](../admin/aryaos-site.md) - the form updates known keys in place and preserves comments and everything else - or, for keys the form does not surface, through that page's **Raw site config** editor.
 
 !!! info "How it is applied"
     Each gateway's systemd unit loads this file via `EnvironmentFile=` **before** its own `/etc/default/<svc>`, so these are *defaults*: a per-service value overrides the site value. See the [configuration model](./index.md).
 
 ## The CoT routing invariant
 
-The single most important thing this file sets is where local feeders send CoT — and the AryaOS default keeps them all flowing through one hub:
+The single most important thing this file sets is where local feeders send CoT - and the AryaOS default keeps them all flowing through one hub:
 
 ```mermaid
 flowchart LR
-  feeders[Feeders<br/>adsbcot, aiscot, dronecot, lincot, gpstak, …] -->|COT_URL<br/>udp+wo://127.0.0.1:28087| charontak[(Charontak hub)]
+  feeders[Feeders<br/>adsbcot, aiscot, dronecot, lincot, gpstak, ...] -->|COT_URL<br/>udp+wo://127.0.0.1:28087| charontak[(Charontak hub)]
   charontak -->|lane| mesh[Mesh SA<br/>239.2.3.1:6969]
   charontak -.->|lane| tak[TAK Server]
 ```
 
-**Feeders → Charontak → Mesh SA (and/or TAK Server).** Keep `COT_URL` pointed at the Charontak hub and configure upstream destinations as [Charontak lanes](../admin/charontak-lanes.md). Only change `COT_URL` when you are deliberately bypassing the hub.
+**Feeders > Charontak > Mesh SA (and/or TAK Server).** Keep `COT_URL` pointed at the Charontak hub and configure upstream destinations as [Charontak lanes](../admin/charontak-lanes.md). Only change `COT_URL` when you are deliberately bypassing the hub.
 
 ## TAK / CoT
 
@@ -31,7 +31,7 @@ TLS material for TAK Server connections is written to this file by the [Site-wid
 
 | Key | Default | Meaning |
 |-----|---------|---------|
-| `ARYAOS_ADSB_DECODER` | `readsb` | 1090 MHz decoder: `readsb` or `dump1090_fa` (only one may run). Must match the image build. Changing this alone does not reconfigure systemd — re-apply the [device role](./device-roles.md). |
+| `ARYAOS_ADSB_DECODER` | `readsb` | 1090 MHz decoder: `readsb` or `dump1090_fa` (only one may run). Must match the image build. Changing this alone does not reconfigure systemd - re-apply the [device role](./device-roles.md). |
 | `ARYAOS_ADSB_JSON_DIR` | `/run/adsb` | Directory where the decoder writes `aircraft.json`; `adsbcot` reads `aircraft.json` from here. |
 | `ARYAOS_UAT_RTL_SERIAL` | `stx:978:0` | RTL-SDR EEPROM serial for `dump978-fa` (UAT / 978 MHz). Must differ from the 1090 MHz serial. Restart `dump978-fa` after changing. |
 
@@ -87,7 +87,7 @@ For the normal case, leave `COT_URL` alone and edit lanes:
     Point upstream destinations at the [Charontak lane editor](../admin/charontak-lanes.md). Feeders keep `COT_URL=udp+wo://127.0.0.1:28087`; Charontak forwards to Mesh SA and/or a TAK Server. For TAK Servers, the [TAK connection](../admin/aryaos-site.md#tak-connection) card wires the lane and certs automatically.
 
 === "Bypass Charontak (advanced)"
-    Set `COT_URL` directly on the Site page (or per-gateway) to route feeders around the hub — for example `tls://takserver.example.com:8089` or `udp+wo://239.2.3.1:6969`. This forgoes Charontak's fan-out and is normally used only for debugging.
+    Set `COT_URL` directly on the Site page (or per-gateway) to route feeders around the hub - for example `tls://takserver.example.com:8089` or `udp+wo://239.2.3.1:6969`. This forgoes Charontak's fan-out and is normally used only for debugging.
 
 ## Editing over SSH
 

--- a/docs/deploy/air-adsb.md
+++ b/docs/deploy/air-adsb.md
@@ -4,8 +4,8 @@ Turn AryaOS into a standalone airspace picture: attach an SDR and antenna, selec
 
 Aircraft broadcast their position on two frequencies:
 
-- **1090 MHz — ADS-B (Mode S Extended Squitter).** The global standard; airliners and most turbine aircraft.
-- **978 MHz — UAT (Universal Access Transceiver).** A US-only band used by many general-aviation aircraft below 18,000 ft.
+- **1090 MHz - ADS-B (Mode S Extended Squitter).** The global standard; airliners and most turbine aircraft.
+- **978 MHz - UAT (Universal Access Transceiver).** A US-only band used by many general-aviation aircraft below 18,000 ft.
 
 AryaOS decodes both and feeds them to your COP through `adsbcot`.
 
@@ -25,8 +25,8 @@ AryaOS decodes both and feeds them to your COP through `adsbcot`.
 
 === "Web console"
 
-    1. Open **Cockpit → AryaOS Site** (browse to `https://<host>/admin/` or `https://aryaos.local`).
-    2. In the **Device role** card, choose **Air — ADS-B 1090/978 aircraft**.
+    1. Open **Cockpit > AryaOS Site** (browse to `https://<host>/admin/` or `https://aryaos.local`).
+    2. In the **Device role** card, choose **Air - ADS-B 1090/978 aircraft**.
     3. Click **Apply role**.
 
     AryaOS enables the ADS-B decoder, `dump978-fa`, `adsbcot`, and `gdltak`, and stops the maritime and drone pipelines.
@@ -67,7 +67,7 @@ AryaOS selects dongles by their **EEPROM serial** so the right SDR handles the r
 The 978 MHz serial is configurable from the **UAT (978 MHz) RTL-SDR serial** field on the **TAK destination** card, or via `ARYAOS_UAT_RTL_SERIAL` in the site config (default `stx:978:0`, which matches the Nooelec NESDR Nano 3 "978" EEPROM preset).
 
 !!! danger "Never share a serial between bands"
-    The 978 MHz SDR must not use the same serial as the 1090 MHz path, or the decoders will fight over the same dongle. If your dongles ship blank or duplicated, re-serial them from the **Radios** card or with `aryaos-sdr set-serial IDX SERIAL`. Writing a serial briefly stops SDR services — **replug the dongle (or reboot)** before the new serial is visible.
+    The 978 MHz SDR must not use the same serial as the 1090 MHz path, or the decoders will fight over the same dongle. If your dongles ship blank or duplicated, re-serial them from the **Radios** card or with `aryaos-sdr set-serial IDX SERIAL`. Writing a serial briefly stops SDR services - **replug the dongle (or reboot)** before the new serial is visible.
 
 For SDR discovery, EEPROM re-serialing, and antenna wiring, see the [Radios](../config/radios-sdr.md) page.
 
@@ -92,7 +92,7 @@ flowchart LR
 ## Verify tracks
 
 1. Connect your EUD to the AryaOS Wi-Fi hotspot (`AryaOS-xxxx`) or the same network.
-2. Open ATAK/WinTAK/iTAK — with Mesh SA enabled, aircraft appear automatically.
+2. Open ATAK/WinTAK/iTAK - with Mesh SA enabled, aircraft appear automatically.
 3. On the box, confirm the pipeline:
 
     ```bash
@@ -107,7 +107,7 @@ flowchart LR
 
 ## Related
 
-- [Multi-sensor](./multi-sensor.md) — run air alongside maritime and drone.
-- [ForeFlight / GDL90](./foreflight-gdl90.md) — the `air` role also serves the picture to EFB apps.
-- [Connect a TAK Server](./connect-tak-server.md) — forward the air picture upstream.
+- [Multi-sensor](./multi-sensor.md) - run air alongside maritime and drone.
+- [ForeFlight / GDL90](./foreflight-gdl90.md) - the `air` role also serves the picture to EFB apps.
+- [Connect a TAK Server](./connect-tak-server.md) - forward the air picture upstream.
 - [Device roles](../config/device-roles.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/connect-tak-server.md
+++ b/docs/deploy/connect-tak-server.md
@@ -1,18 +1,18 @@
 # Connect a TAK Server
 
-Forward the AryaOS picture upstream. Import an ATAK connection **data package** or paste a **`tak://` enrollment URL** in the web console, and AryaOS provisions the certificates and turns on a Charontak lane to your TAK Server — no shell required.
+Forward the AryaOS picture upstream. Import an ATAK connection **data package** or paste a **`tak://` enrollment URL** in the web console, and AryaOS provisions the certificates and turns on a Charontak lane to your TAK Server - no shell required.
 
 By default AryaOS multicasts to **Mesh SA** (`udp+wo://239.2.3.1:6969`), which nearby EUDs pick up automatically. Connecting a TAK Server adds a **second** egress so the same picture reaches your server-side COP over the network.
 
 ## Two ways to connect
 
-Both live on the **TAK connection** card in **Cockpit → AryaOS Site**. AryaOS installs the resulting certs under **`/etc/aryaos/tls`** and enables Charontak forwarding to the TAK Server.
+Both live on the **TAK connection** card in **Cockpit > AryaOS Site**. AryaOS installs the resulting certs under **`/etc/aryaos/tls`** and enables Charontak forwarding to the TAK Server.
 
 === "Import a data package"
 
     Use the same `.zip` / `.dpk` connection package you'd load into ATAK/iTAK.
 
-    1. Open **Cockpit → AryaOS Site** → **TAK connection**.
+    1. Open **Cockpit > AryaOS Site** > **TAK connection**.
     2. Under **Connection package (.zip / .dpk)**, choose your package file.
     3. Click **Import package**.
 
@@ -22,7 +22,7 @@ Both live on the **TAK connection** card in **Cockpit → AryaOS Site**. AryaOS 
 
     Use a one-time TAK Server enrollment URL (soft-cert enrollment).
 
-    1. Open **Cockpit → AryaOS Site** → **TAK connection**.
+    1. Open **Cockpit > AryaOS Site** > **TAK connection**.
     2. Paste the URL into **One-time enrollment URL**. It must start with `tak://`, e.g.
 
         ```text
@@ -60,11 +60,11 @@ egress_cot_url = tls://takserver.example.com:8089
 PYTAK_NO_HELLO = true
 ```
 
-Keep every local feeder's `COT_URL` pointed at the Charontak hub (`udp+wo://127.0.0.1:28087`) — you route to the TAK Server **from Charontak**, not from each feeder.
+Keep every local feeder's `COT_URL` pointed at the Charontak hub (`udp+wo://127.0.0.1:28087`) - you route to the TAK Server **from Charontak**, not from each feeder.
 
 ## Manual TLS lane (lane editor)
 
-If you already have a `combined.pem` (client cert + unencrypted key) or want full control, configure the lane by hand in **Cockpit → Charontak**:
+If you already have a `combined.pem` (client cert + unencrypted key) or want full control, configure the lane by hand in **Cockpit > Charontak**:
 
 1. Combine a PEM client cert and unencrypted key into one file:
 
@@ -75,7 +75,7 @@ If you already have a `combined.pem` (client cert + unencrypted key) or want ful
     ```
 
 2. Copy `combined.pem` to the box (e.g. `/etc/aryaos/tls/combined.pem`).
-3. In **Cockpit → Charontak**, open the `local-to-takserver` lane, set `egress_cot_url` to `tls://takserver.example.com:8089`, point the TLS paths at your PEM, and **Save Changes & Restart**.
+3. In **Cockpit > Charontak**, open the `local-to-takserver` lane, set `egress_cot_url` to `tls://takserver.example.com:8089`, point the TLS paths at your PEM, and **Save Changes & Restart**.
 
 !!! danger "Convert .p12 first"
     The console TLS uploads expect PEM. If you have a `.p12`/PFX, convert it with `openssl pkcs12` before importing. TLS private keys are never included in support bundles.
@@ -92,10 +92,10 @@ See [Charontak lanes](../admin/charontak-lanes.md) for the complete lane editor 
 | Auth | None | Client certificate |
 | Use when | Local team, disconnected ops | Enterprise COP, wide-area sharing |
 
-The two are **not** exclusive — AryaOS commonly runs the Mesh SA lane **and** a TAK Server lane at the same time, so local EUDs and the server both get the picture.
+The two are **not** exclusive - AryaOS commonly runs the Mesh SA lane **and** a TAK Server lane at the same time, so local EUDs and the server both get the picture.
 
 ## Related
 
-- [Relay & routing](./relay-routing.md) — a box dedicated to forwarding CoT.
+- [Relay & routing](./relay-routing.md) - a box dedicated to forwarding CoT.
 - [Charontak lanes](../admin/charontak-lanes.md) · [AryaOS Site](../admin/aryaos-site.md)
 - [Offline backpack](./offline-backpack.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/counter-uas.md
+++ b/docs/deploy/counter-uas.md
@@ -1,31 +1,31 @@
 # Drones (Counter-UAS)
 
-Detect and track drones for counter-UAS (C-UAS) awareness. Select the **`cuas`** role, attach a Remote ID receiver and/or a DJI DroneID SDR, and drones appear in ATAK/WinTAK/iTAK as native Cursor on Target (CoT) tracks — often complete with the operator's location.
+Detect and track drones for counter-UAS (C-UAS) awareness. Select the **`cuas`** role, attach a Remote ID receiver and/or a DJI DroneID SDR, and drones appear in ATAK/WinTAK/iTAK as native Cursor on Target (CoT) tracks - often complete with the operator's location.
 
 ![AryaOS UAS screenshot](../media/uas_screenshot.png){ width="640" }
 
 AryaOS builds a C-UAS picture from two complementary detection sources:
 
-- **Remote ID / Open Drone ID** — the FAA-mandated broadcast that compliant drones emit over Wi-Fi/Bluetooth. Decoded by **`dronecot`** (on-board Wi-Fi/BLE, or a dedicated receiver — see below).
-- **DJI DroneID** — DJI's proprietary telemetry, received over the air with an SDR (for example an **AntSDR**) and decoded by **DJICOT**.
+- **Remote ID / Open Drone ID** - the FAA-mandated broadcast that compliant drones emit over Wi-Fi/Bluetooth. Decoded by **`dronecot`** (on-board Wi-Fi/BLE, or a dedicated receiver - see below).
+- **DJI DroneID** - DJI's proprietary telemetry, received over the air with an SDR (for example an **AntSDR**) and decoded by **DJICOT**.
 
 `sikw00fcot` additionally converts SiK-radio MAVLink drone telemetry to CoT when you have that link.
 
 !!! info "Dedicated Remote ID receiver: DroneScout DS110"
-    A **BlueMark DroneScout DS110 / DroneBeacon** — a standards-based Remote ID receiver — plugs in over USB-serial and emits detected Remote ID as **MAVLink** (`OPEN_DRONE_ID_MESSAGE_PACK` or `ADSB_VEHICLE`). It is an **ESP32-S3** device; AryaOS pins it to a stable `/dev/dronescout` symlink (its per-unit serial path is not portable) and ships a second, opt-in dronecot instance, **`dronecot-dronescout`**, that reads it and feeds the same Charontak hub. Enable it on a DS110 box with `sudo systemctl enable --now dronecot-dronescout` (requires `dronecot` ≥ 2.2.3). It runs alongside the AntSDR/DJI source for a multi-source Remote ID picture. *(Live-verified against a DroneBeacon DB120.)*
+    A **BlueMark DroneScout DS110 / DroneBeacon** - a standards-based Remote ID receiver - plugs in over USB-serial and emits detected Remote ID as **MAVLink** (`OPEN_DRONE_ID_MESSAGE_PACK` or `ADSB_VEHICLE`). It is an **ESP32-S3** device; AryaOS pins it to a stable `/dev/dronescout` symlink (its per-unit serial path is not portable) and ships a second, opt-in dronecot instance, **`dronecot-dronescout`**, that reads it and feeds the same Charontak hub. Enable it on a DS110 box with `sudo systemctl enable --now dronecot-dronescout` (requires `dronecot` ≥ 2.2.3). It runs alongside the AntSDR/DJI source for a multi-source Remote ID picture. *(Live-verified against a DroneBeacon DB120.)*
 
 !!! info "Wi-Fi Remote ID: monitor-mode adapter"
-    dronecot decodes Open Drone ID **directly off the air over Wi-Fi** (ASTM F3411 Beacon vendor IE *and* Wi-Fi Alliance NAN) using a **monitor-mode** USB adapter — an Atheros **AR9271 (`ath9k_htc`)** or Realtek **8821CU** works well. AryaOS ships an opt-in instance, **`dronecot-wifi`** (`FEED_URL=wifi://wlan1`, channel-hopping 1/6/11); enable it on a box with an external adapter: `sudo systemctl enable --now dronecot-wifi`. Use `wireless://wlan1` to run Wi-Fi + BLE together. *(Live-verified 2026-07-24: an AR9271 decoded a BlueMark DroneBeacon Wi-Fi squawk — the same aircraft the DS110 decoded over serial.)* `wlan0` is the on-board AP radio — always use the external adapter.
+    dronecot decodes Open Drone ID **directly off the air over Wi-Fi** (ASTM F3411 Beacon vendor IE *and* Wi-Fi Alliance NAN) using a **monitor-mode** USB adapter - an Atheros **AR9271 (`ath9k_htc`)** or Realtek **8821CU** works well. AryaOS ships an opt-in instance, **`dronecot-wifi`** (`FEED_URL=wifi://wlan1`, channel-hopping 1/6/11); enable it on a box with an external adapter: `sudo systemctl enable --now dronecot-wifi`. Use `wireless://wlan1` to run Wi-Fi + BLE together. *(Live-verified 2026-07-24: an AR9271 decoded a BlueMark DroneBeacon Wi-Fi squawk - the same aircraft the DS110 decoded over serial.)* `wlan0` is the on-board AP radio - always use the external adapter.
 
-!!! tip "Plug & play by design"
-    AirTAK C-UAS is designed to work out of the box: power the device, connect a TAK EUD (ATAK, WinTAK, iTAK) to its Wi-Fi hotspot, and drone tracks flow with no extra configuration. *When in doubt, reboot.*
+!!! tip "Default standalone setup"
+    Power the device and connect a TAK EUD (ATAK, WinTAK, or iTAK) to its Wi-Fi hotspot. Drone tracks require no additional configuration. Reboot the gateway if the receiver was attached after startup.
 
 ## Turn on the C-UAS role
 
 === "Web console"
 
-    1. Open **Cockpit → AryaOS Site** (`https://<host>/admin/` or `https://aryaos.local`).
-    2. In the **Device role** card, choose **C-UAS — drone detection**.
+    1. Open **Cockpit > AryaOS Site** (`https://<host>/admin/` or `https://aryaos.local`).
+    2. In the **Device role** card, choose **C-UAS - drone detection**.
     3. Click **Apply role**.
 
     AryaOS enables `dronecot` and `sikw00fcot`, and stops the air and maritime pipelines.
@@ -50,7 +50,7 @@ An AirTAK C-UAS can run in one of three connectivity modes:
 
 1. Connect USB power. On kitted units, match the color-coded connectors (yellow to yellow, black to black).
 2. After about two minutes, a Wi-Fi network named `AryaOS-XXXX` appears. Join it.
-3. Open ATAK, WinTAK, or iTAK — drone tracks arrive over Mesh SA automatically.
+3. Open ATAK, WinTAK, or iTAK - drone tracks arrive over Mesh SA automatically.
 
 ### Joining an existing network
 
@@ -73,7 +73,7 @@ Each detector emits CoT to the Charontak hub at `udp+wo://127.0.0.1:28087`; Char
 
 An **AntSDR E200** running the [alphafox02 DJI DroneID firmware](https://github.com/alphafox02/antsdr_dji_droneid) detects DJI OcuSync DroneID and **pushes it to `dronecot` over point-to-point Ethernet** (TCP `172.31.100.1:52002`). That Ethernet link is the data path; the AntSDR's **USB-serial is its Zynq config/recovery console, not a data feed**.
 
-- **Health at a glance.** AryaOS polls the feed every 30 s (`aryaos-antsdr-health`) and, when an AntSDR is present, shows an **AntSDR (DJI DroneID)** card in Cockpit: green when both the feed socket and DroneCOT's TAK WebSocket are established, amber when either side is missing. A missing feed can be normal with no DJI drone in range; `tak_established: false` means TAK egress is actually degraded even if systemd still calls DroneCOT active. The card is hidden on boxes with no AntSDR. Check it by hand any time:
+- **Health status.** AryaOS polls the feed every 30 s (`aryaos-antsdr-health`) and, when an AntSDR is present, shows an **AntSDR (DJI DroneID)** card in Cockpit: green when both the feed socket and DroneCOT's TAK WebSocket are established, amber when either side is missing. A missing feed can be normal with no DJI drone in range; `tak_established: false` means TAK egress is degraded even if systemd still calls DroneCOT active. The card is hidden on boxes with no AntSDR. Check it manually with:
 
     ```bash
     aryaos-antsdr-health --json
@@ -82,7 +82,7 @@ An **AntSDR E200** running the [alphafox02 DJI DroneID firmware](https://github.
 - **Console access.** To configure the SDR (e.g. `fw_setenv` to change its IP) or recover a wedged unit without a second computer, open its console from the Pi:
 
     ```bash
-    aryaos-antsdr-console          # login: root / analog — quit tio with Ctrl-t q
+    aryaos-antsdr-console          # login: root / analog - quit tio with Ctrl-t q
     ```
 
     On an AntSDR box, pin a stable `/dev/antsdr-console` first with `sudo touch /etc/aryaos/antsdr-console.enabled && sudo udevadm trigger` (the console adapter is a generic CH340, so this symlink is opt-in to avoid clashing with a CH340-based GPS).
@@ -96,17 +96,17 @@ An **AntSDR E200** running the [alphafox02 DJI DroneID firmware](https://github.
     systemctl status dronecot sikw00fcot
     ```
 
-3. Fly a Remote ID-compliant drone (or a known DJI aircraft) nearby and confirm the track — including, where broadcast, the operator/pilot position.
+3. Fly a Remote ID-compliant drone (or a known DJI aircraft) nearby and confirm the track - including, where broadcast, the operator/pilot position.
 
-!!! note "What you'll see"
+!!! note "Remote ID track fields"
     Remote ID broadcasts typically include the drone's position, altitude, and the operator's ground location, letting you map both the aircraft and its pilot. DJI DroneID similarly carries home/operator coordinates.
 
 ## Connecting an EUD
 
-AirTAK C-UAS is tested with all TAK products (iTAK, WinTAK, ATAK). Out of the box, local feeders send to Charontak on the gateway, which multicasts CoT to the Mesh SA group `239.2.3.1:6969`. Upstream TAK Server destinations are added as Charontak lanes — see [Connect a TAK Server](./connect-tak-server.md).
+AirTAK C-UAS is tested with iTAK, WinTAK, and ATAK. By default, local feeders send to Charontak on the gateway, which multicasts CoT to the Mesh SA group `239.2.3.1:6969`. Add upstream TAK Server destinations as Charontak lanes. See [Connect a TAK Server](./connect-tak-server.md).
 
 ## Related
 
-- [Multi-sensor](./multi-sensor.md) — combine drone detection with air and maritime.
+- [Multi-sensor](./multi-sensor.md) - combine drone detection with air and maritime.
 - [Connect a TAK Server](./connect-tak-server.md) · [Offline backpack](./offline-backpack.md)
 - [Device roles](../config/device-roles.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/foreflight-gdl90.md
+++ b/docs/deploy/foreflight-gdl90.md
@@ -2,17 +2,17 @@
 
 See the TAK air picture in your Electronic Flight Bag (EFB). AryaOS runs **GDLTAK**, which rebroadcasts Cursor on Target (CoT) tracks as **GDL90** over UDP, so **ForeFlight**, **FlyQ EFB**, and **Garmin Pilot** display the same traffic TAK sees.
 
-GDLTAK is the reverse of `adsbcot`: **CoT in, GDL90 out**. It subscribes to the CoT air picture, keeps a table of tracks, and once a second emits GDL90 Heartbeat, Ownship, and Traffic Report datagrams — exactly as a stratux or GDL 90 receiver would. Any traffic on your TAK network shows up in the cockpit: ADS-B via `adsbcot`, drone Remote ID via `dronecot`, even tracks from a TAK Server.
+GDLTAK is the reverse of `adsbcot`: **CoT in, GDL90 out**. It subscribes to the CoT air picture, keeps a table of tracks, and once a second emits GDL90 Heartbeat, Ownship, and Traffic Report datagrams - exactly as a stratux or GDL 90 receiver would. Any traffic on your TAK network shows up in the cockpit: ADS-B via `adsbcot`, drone Remote ID via `dronecot`, even tracks from a TAK Server.
 
 !!! info "Enabled by the air and multi roles"
-    `gdltak` is part of the `air` and `multi` role unit sets, so selecting either role in **Cockpit → AryaOS Site** turns it on automatically. See [Air — ADS-B & UAT](./air-adsb.md) and [Device roles](../config/device-roles.md).
+    `gdltak` is part of the `air` and `multi` role unit sets, so selecting either role in **Cockpit > AryaOS Site** turns it on automatically. See [Air - ADS-B & UAT](./air-adsb.md) and [Device roles](../config/device-roles.md).
 
 ## ForeFlight setup
 
 === "ForeFlight"
 
-    1. Put the iPad/iPhone on the **same Wi-Fi network** as the AryaOS box — join the `AryaOS-xxxx` hotspot.
-    2. That's it. ForeFlight auto-detects GDL90 traffic on **UDP port 4000** and lists the source under **More → Devices**.
+    1. Put the iPad/iPhone on the **same Wi-Fi network** as the AryaOS box - join the `AryaOS-xxxx` hotspot.
+    2. ForeFlight auto-detects GDL90 traffic on **UDP port 4000** and lists the source under **More > Devices**.
 
 === "FlyQ EFB / Garmin Pilot"
 
@@ -40,8 +40,8 @@ GDLTAK is PyTAK-style, configured via `/etc/default/gdltak` (systemd `Environmen
 | `GDL90_URL` | `udp+broadcast://255.255.255.255:4000` | GDL90 egress. Broadcast is the stratux/ForeFlight convention; unicast `udp://host:port` also works. |
 | `STALE_SECS` | `60` | Drop tracks not updated within this many seconds. |
 | `UPDATE_HZ` | `1` | GDL90 update rate (heartbeat convention is 1 Hz). |
-| `OWNSHIP_UID` | — | CoT UID whose track becomes the Ownship Report (e.g. this device's GPSTAK/LINCOT UID). |
-| `OWNSHIP_LAT` / `OWNSHIP_LON` / `OWNSHIP_ALT_FT` | — | Static ownship position fallback. |
+| `OWNSHIP_UID` | - | CoT UID whose track becomes the Ownship Report (e.g. this device's GPSTAK/LINCOT UID). |
+| `OWNSHIP_LAT` / `OWNSHIP_LON` / `OWNSHIP_ALT_FT` | - | Static ownship position fallback. |
 | `CALLSIGN` | `GDLTAK` | Ownship callsign shown in the EFB. |
 
 ### Ownship
@@ -62,10 +62,10 @@ If no ownship is configured, GDLTAK sends heartbeat + traffic only.
 systemctl status gdltak
 ```
 
-Then open ForeFlight and confirm traffic appears under **More → Devices** and on the map. If nothing shows, confirm the EFB device is on the AryaOS hotspot (same subnet) and that traffic exists on the TAK side.
+Then open ForeFlight and confirm traffic appears under **More > Devices** and on the map. If nothing shows, confirm the EFB device is on the AryaOS hotspot (same subnet) and that traffic exists on the TAK side.
 
 ## Related
 
-- [Air — ADS-B & UAT](./air-adsb.md) — feed the aircraft that GDLTAK rebroadcasts.
-- [Own position / GPS](./own-position-gps.md) — supply GDLTAK's ownship.
+- [Air - ADS-B & UAT](./air-adsb.md) - feed the aircraft that GDLTAK rebroadcasts.
+- [Own position / GPS](./own-position-gps.md) - supply GDLTAK's ownship.
 - [Multi-sensor](./multi-sensor.md) · [Device roles](../config/device-roles.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -1,15 +1,15 @@
 # Choose a deployment
 
-One AryaOS image runs every mission. You pick a **device role** in the web console, and AryaOS turns on exactly the sensor pipelines that role needs — no reflashing, no reconfiguring.
+One AryaOS image runs every mission. You pick a **device role** in the web console, and AryaOS turns on exactly the sensor pipelines that role needs - no reflashing, no reconfiguring.
 
 ## The mission-based model
 
 AryaOS is an all-in-one situational-awareness gateway: it decodes sensors at the edge and delivers a single Common Operating Picture (COP) to any TAK client (ATAK, WinTAK, iTAK) over Cursor on Target (CoT). Rather than shipping a different image per mission, every AryaOS device runs the **same** software and you select what it does at runtime.
 
-The core CoT plumbing — the Charontak hub, LINCOT host beacon, GPSTAK network GPS, and `gpsd` — always runs. The **role** you choose toggles which *sensor* pipelines run on top of it. Change your mind in the field and switch roles in seconds.
+The core CoT plumbing - the Charontak hub, LINCOT host beacon, GPSTAK network GPS, and `gpsd` - always runs. The **role** you choose toggles which *sensor* pipelines run on top of it. Change your mind in the field and switch roles in seconds.
 
 !!! info "Where the role lives"
-    The role is stored as `ARYAOS_ROLE` in the site config (`/etc/aryaos/aryaos-config.txt`) and applied by the `aryaos-role` helper. You set it from the **Device role** card in **Cockpit → AryaOS Site**. See [Device roles](../config/device-roles.md) for the full reference.
+    The role is stored as `ARYAOS_ROLE` in the site config (`/etc/aryaos/aryaos-config.txt`) and applied by the `aryaos-role` helper. You set it from the **Device role** card in **Cockpit > AryaOS Site**. See [Device roles](../config/device-roles.md) for the full reference.
 
 ## Pick your scenario
 
@@ -19,13 +19,13 @@ The core CoT plumbing — the Charontak hub, LINCOT host beacon, GPSTAK network 
 
     Track crewed aircraft on 1090 MHz and 978 MHz with an SDR and antenna.
 
-    [Air — ADS-B & UAT](./air-adsb.md)
+    [Air - ADS-B & UAT](./air-adsb.md)
 
 -   :material-ferry: **Vessels (AIS)**
 
     Put ships and boats on the map from marine AIS, over the air or from an online feed.
 
-    [Maritime — AIS](./maritime-ais.md)
+    [Maritime - AIS](./maritime-ais.md)
 
 -   :material-quadcopter: **Drones (Counter-UAS)**
 
@@ -71,20 +71,20 @@ The core CoT plumbing — the Charontak hub, LINCOT host beacon, GPSTAK network 
 
 </div>
 
-## Roles at a glance
+## Role summary
 
 Each role maps to a set of sensor units, which in turn dictate the hardware you attach.
 
 | Role | Sensor pipelines enabled | Typical hardware |
 |------|--------------------------|------------------|
-| `multi` | ADS-B + UAT, AIS, and drone detection — all pipelines | 2× RTL-SDR (1090 + 978), AIS SDR, drone-detection SDR/receiver, GPS |
+| `multi` | ADS-B + UAT, AIS, and drone detection - all pipelines | 2x RTL-SDR (1090 + 978), AIS SDR, drone-detection SDR/receiver, GPS |
 | `air` | ADS-B decoder (`readsb`/`dump1090-fa`), `dump978-fa`, `adsbcot`, `gdltak` | RTL-SDR + 1090 MHz antenna; optional 2nd SDR + 978 MHz antenna |
 | `maritime` | `ais-catcher`, `aiscot` | RTL-SDR + marine VHF antenna (or an online AIS feed, no SDR) |
 | `cuas` | `dronecot`, `sikw00fcot` | Remote ID receiver and/or DJI DroneID SDR (e.g. AntSDR) |
-| `relay` | none — CoT routing only | No sensors; just network (Wi-Fi/Ethernet/MANET) |
+| `relay` | none - CoT routing only | No sensors; just network (Wi-Fi/Ethernet/MANET) |
 
 !!! note "The core always runs"
-    Regardless of role, `charontak`, `lincot`, `gpstak`, and `gpsd` stay running — so a `relay` box still beacons its own position and forwards CoT, and every role can share GPS with a connected EUD.
+    Regardless of role, `charontak`, `lincot`, `gpstak`, and `gpsd` stay running - so a `relay` box still beacons its own position and forwards CoT, and every role can share GPS with a connected EUD.
 
 The `air` role also enables `gdltak`, which lets [ForeFlight and other EFB apps](./foreflight-gdl90.md) display the air picture over GDL90.
 

--- a/docs/deploy/maritime-ais.md
+++ b/docs/deploy/maritime-ais.md
@@ -8,7 +8,7 @@ Vessels broadcast **AIS (Automatic Identification System)** on two marine VHF ch
 
 === "Over the air (SDR)"
 
-    AIS-catcher decodes AIS directly from RF with an RTL-SDR and a marine VHF antenna — no internet required. This is the standalone, disconnected mode.
+    AIS-catcher decodes AIS directly from RF with an RTL-SDR and a marine VHF antenna - no internet required. This is the standalone, disconnected mode.
 
     | Part | Notes |
     |------|-------|
@@ -17,18 +17,18 @@ Vessels broadcast **AIS (Automatic Identification System)** on two marine VHF ch
     | Coax / mount | Height and a clear view of the water drive range. |
 
     !!! tip "VHF antenna matters"
-        AIS is line-of-sight at VHF. Reception is dominated by antenna height and quality — an elevated marine VHF antenna is the single biggest range improvement. Keep the AIS antenna separated from 1090/978 MHz antennas on multi-sensor boxes to limit desense.
+        AIS is line-of-sight at VHF. Reception is dominated by antenna height and quality - an elevated marine VHF antenna is the single biggest range improvement. Keep the AIS antenna separated from 1090/978 MHz antennas on multi-sensor boxes to limit desense.
 
 === "Online feed"
 
-    If the box has internet, AIS-catcher can pull from an online AIS source instead of (or in addition to) local RF — useful when you have no antenna or want wide-area coverage. No SDR is required in this mode. Configure the AIS-catcher input from the AIS-catcher plugin in Cockpit.
+    If the box has internet, AIS-catcher can pull from an online AIS source instead of (or in addition to) local RF - useful when you have no antenna or want wide-area coverage. No SDR is required in this mode. Configure the AIS-catcher input from the AIS-catcher plugin in Cockpit.
 
 ## Turn on the maritime role
 
 === "Web console"
 
-    1. Open **Cockpit → AryaOS Site** (`https://<host>/admin/` or `https://aryaos.local`).
-    2. In the **Device role** card, choose **Maritime — AIS vessels**.
+    1. Open **Cockpit > AryaOS Site** (`https://<host>/admin/` or `https://aryaos.local`).
+    2. In the **Device role** card, choose **Maritime - AIS vessels**.
     3. Click **Apply role**.
 
     AryaOS enables `ais-catcher` and `aiscot`, and stops the air and drone pipelines.
@@ -69,7 +69,7 @@ AIS-catcher exposes a local web UI and JSON on **port 8100** (allowed through th
 
 ## Related
 
-- [Multi-sensor](./multi-sensor.md) — run maritime alongside air and drone.
-- [Air — ADS-B & UAT](./air-adsb.md) · [Counter-UAS](./counter-uas.md)
-- [Connect a TAK Server](./connect-tak-server.md) — forward the maritime picture upstream.
+- [Multi-sensor](./multi-sensor.md) - run maritime alongside air and drone.
+- [Air - ADS-B & UAT](./air-adsb.md) · [Counter-UAS](./counter-uas.md)
+- [Connect a TAK Server](./connect-tak-server.md) - forward the maritime picture upstream.
 - [Device roles](../config/device-roles.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/multi-sensor.md
+++ b/docs/deploy/multi-sensor.md
@@ -2,14 +2,14 @@
 
 Run aircraft, vessels, and drones on a single box. Select the **`multi`** role and AryaOS fuses ADS-B/UAT, AIS, and drone detection into one Common Operating Picture (COP) delivered to ATAK/WinTAK/iTAK.
 
-`multi` is the default role. It enables **all** sensor pipelines at once — nothing is turned off.
+`multi` is the default role. It enables **all** sensor pipelines at once - nothing is turned off.
 
 ## What the multi role runs
 
 | Domain | Units enabled | Deep dive |
 |--------|---------------|-----------|
-| Air (ADS-B 1090 + UAT 978) | ADS-B decoder (`readsb`/`dump1090-fa`), `dump978-fa`, `adsbcot`, `gdltak` | [Air — ADS-B & UAT](./air-adsb.md) |
-| Maritime (AIS) | `ais-catcher`, `aiscot` | [Maritime — AIS](./maritime-ais.md) |
+| Air (ADS-B 1090 + UAT 978) | ADS-B decoder (`readsb`/`dump1090-fa`), `dump978-fa`, `adsbcot`, `gdltak` | [Air - ADS-B & UAT](./air-adsb.md) |
+| Maritime (AIS) | `ais-catcher`, `aiscot` | [Maritime - AIS](./maritime-ais.md) |
 | Drones (C-UAS) | `dronecot`, `sikw00fcot` | [Counter-UAS](./counter-uas.md) |
 | Position core (always on) | `charontak`, `lincot`, `gpstak`, `gpsd` | [Own position / GPS](./own-position-gps.md) |
 
@@ -17,7 +17,7 @@ Run aircraft, vessels, and drones on a single box. Select the **`multi`** role a
 
 === "Web console"
 
-    1. Open **Cockpit → AryaOS Site** (`https://<host>/admin/` or `https://aryaos.local`).
+    1. Open **Cockpit > AryaOS Site** (`https://<host>/admin/` or `https://aryaos.local`).
     2. In the **Device role** card, choose **Multi-sensor (all pipelines)**.
     3. Click **Apply role**.
 
@@ -29,7 +29,7 @@ Run aircraft, vessels, and drones on a single box. Select the **`multi`** role a
 
 ## Fusing into one COP
 
-Every feeder — air, maritime, drone, and position — publishes CoT to the **same** Charontak hub on `udp+wo://127.0.0.1:28087`. Charontak merges them and forwards a single stream to Mesh SA (and any [TAK Server lanes](./connect-tak-server.md)), so your EUD sees one unified picture.
+Every feeder - air, maritime, drone, and position - publishes CoT to the **same** Charontak hub on `udp+wo://127.0.0.1:28087`. Charontak merges them and forwards a single stream to Mesh SA (and any [TAK Server lanes](./connect-tak-server.md)), so your EUD sees one unified picture.
 
 ```mermaid
 flowchart LR
@@ -51,22 +51,22 @@ To actually *see* all three domains at once you need the radios for each:
 | ADS-B 1090 | RTL-SDR | 1090 MHz | `stx:1090:0` |
 | UAT 978 | RTL-SDR | 978 MHz | `stx:978:0` |
 | AIS | RTL-SDR | Marine VHF (~162 MHz) | (AIS-catcher input) |
-| DJI DroneID | SDR (e.g. AntSDR) | per receiver | — |
-| Remote ID | Wi-Fi/BT receiver | built-in | — |
+| DJI DroneID | SDR (e.g. AntSDR) | per receiver | - |
+| Remote ID | Wi-Fi/BT receiver | built-in | - |
 
 !!! danger "Give each SDR a unique EEPROM serial"
-    With multiple RTL-SDR dongles attached, each must have a distinct serial or the decoders will contend for the wrong device. Re-serial from the **Radios** card or `aryaos-sdr set-serial`. See [Air — ADS-B & UAT](./air-adsb.md#sdr-serials-dual-sdr-setups).
+    With multiple RTL-SDR dongles attached, each must have a distinct serial or the decoders will contend for the wrong device. Re-serial from the **Radios** card or `aryaos-sdr set-serial`. See [Air - ADS-B & UAT](./air-adsb.md#sdr-serials-dual-sdr-setups).
 
 ## Resource notes
 
 Running every pipeline is the heaviest configuration AryaOS supports.
 
 - **Compute.** Multiple SDR decoders (`readsb`/`dump978-fa`/`ais-catcher`) plus DroneID demod are CPU-bound. A Raspberry Pi 4 or 5 is recommended for a full `multi` build; a Pi 3 can struggle with all radios active.
-- **USB & power.** Several SDRs on one USB bus draw significant current — use a supply and cabling rated for the load, especially on battery in the field.
+- **USB & power.** Several SDRs on one USB bus draw significant current - use a supply and cabling rated for the load, especially on battery in the field.
 - **RF isolation.** Keep the 1090/978 MHz, marine VHF, and DroneID antennas spaced apart to reduce mutual desense; add band filters (e.g. a 1090 SAW filter) where interference is high.
 
 !!! tip "Scale down when you don't need everything"
-    If a mission only needs one domain, switch to the focused role (`air`, `maritime`, or `cuas`) to free CPU and USB bandwidth. Roles switch at runtime — no reflash.
+    If a mission only needs one domain, switch to the focused role (`air`, `maritime`, or `cuas`) to free CPU and USB bandwidth. Roles switch at runtime - no reflash.
 
 ## Related
 

--- a/docs/deploy/offline-backpack.md
+++ b/docs/deploy/offline-backpack.md
@@ -1,13 +1,13 @@
 # Offline backpack ops
 
-Run a full Common Operating Picture (COP) with **no internet at all**. AryaOS carries the sensors, the network, and the map in one box — power it from a battery, connect a phone over Wi-Fi or Bluetooth, and you have TAK situational awareness anywhere.
+Run a full Common Operating Picture (COP) with **no internet at all**. AryaOS carries the sensors, the network, and the map in one box - power it from a battery, connect a phone over Wi-Fi or Bluetooth, and you have TAK situational awareness anywhere.
 
-This is the original AirTAK concept of operations: a gateway in a backpack, an ATAK phone paired to it, and a portable USB battery — no LTE, no Wi-Fi infrastructure required.
+This is the original AirTAK concept of operations: a gateway in a backpack, an ATAK phone paired to it, and a portable USB battery - no LTE, no Wi-Fi infrastructure required.
 
 ![AirTAK on a backpack](../media/backpack.png){ width="640" }
 
 !!! example "Proven in the field"
-    In this configuration — a Samsung Galaxy S20 running ATAK paired to a backpack AirTAK on a USB battery, with **no** outside connectivity — a **55-mile** aircraft-detection range was achieved on a clear June day in San Diego. See the [Introduction](../get-started/overview.md).
+    In this configuration - a Samsung Galaxy S20 running ATAK paired to a backpack AirTAK on a USB battery, with **no** outside connectivity - a **55-mile** aircraft-detection range was achieved on a clear June day in San Diego. See the [Introduction](../get-started/overview.md).
 
 ## The disconnected CONOP
 
@@ -34,16 +34,16 @@ AryaOS runs a **comitup** onboarding hotspot on `wlan0`:
 | Property | Value |
 |----------|-------|
 | SSID | `AryaOS-xxxx` (the 4-hex device suffix) |
-| Security | **Open by default** — set WPA2 from the console (below) |
+| Security | **Open by default** - set WPA2 from the console (below) |
 | Gateway IP | `10.41.0.1` |
 | Console | `https://aryaos.local` or `https://10.41.0.1` |
 
 1. Power the box (on kitted units, match the color-coded connectors: yellow to yellow, black to black).
 2. Wait about two minutes for `AryaOS-xxxx` to appear, then join it.
-3. Open ATAK/WinTAK/iTAK — Mesh SA tracks arrive automatically.
+3. Open ATAK/WinTAK/iTAK - Mesh SA tracks arrive automatically.
 
 !!! danger "Lock the hotspot before you deploy"
-    The onboarding hotspot is **open** out of the box. Set a WPA2 passphrase (8–63 characters) in the **Onboarding hotspot password** card in **Cockpit → AryaOS Site** before operating anywhere the SSID could be reached by others.
+    The onboarding hotspot is **open by default**. Set a WPA2 passphrase (8-63 characters) in the **Onboarding hotspot password** card in **Cockpit > AryaOS Site** before operating anywhere the SSID could be reached by others.
 
 ## Connect over Bluetooth PAN
 
@@ -53,10 +53,10 @@ When you'd rather not use Wi-Fi (to save the radio for sensors, or to avoid RF),
 |----------|-------|-----------|
 | Bridge | `pan0` | `BT_PAN_BRIDGE` |
 | Box IP | `10.44.0.1/24` | `BT_PAN_ADDRESS` / `BT_PAN_PREFIX` |
-| DHCP pool for phones | `10.44.0.20`–`10.44.0.60`, 12h lease | `BT_PAN_DHCP_START` / `_END` / `_LEASE` |
-| Enabled | yes (`BT_PAN_ENABLED=1`) | — |
+| DHCP pool for phones | `10.44.0.20`-`10.44.0.60`, 12h lease | `BT_PAN_DHCP_START` / `_END` / `_LEASE` |
+| Enabled | yes (`BT_PAN_ENABLED=1`) | - |
 
-AryaOS serves DHCP to the paired phone over the PAN link. There is **no NAT or forwarding** — Bluetooth PAN is only for reaching AryaOS services (the console, Mesh SA), not internet sharing. Once paired, browse to `https://10.44.0.1` and TAK reaches the box over Bluetooth. See [Bluetooth PAN](../bluetooth-pan.md) for pairing steps.
+AryaOS serves DHCP to the paired phone over the PAN link. There is **no NAT or forwarding** - Bluetooth PAN is only for reaching AryaOS services (the console, Mesh SA), not internet sharing. Once paired, browse to `https://10.44.0.1` and TAK reaches the box over Bluetooth. See [Bluetooth PAN](../bluetooth-pan.md) for pairing steps.
 
 !!! warning "BLE advertising limitation"
     Bluetooth **PAN** (Classic) pairing works for phone-to-box networking. Note that BLE *advertising* is a separate function and is not the transport used here.
@@ -64,18 +64,18 @@ AryaOS serves DHCP to the paired phone over the PAN link. There is **no NAT or f
 ## Battery & power
 
 - Any quality USB power bank runs the box; use one sized for your mission duration and the number of active SDRs.
-- Multiple SDRs on the USB bus draw meaningful current — size the battery and cabling accordingly (see [Multi-sensor resource notes](./multi-sensor.md#resource-notes)).
+- Multiple SDRs on the USB bus draw meaningful current - size the battery and cabling accordingly (see [Multi-sensor resource notes](./multi-sensor.md#resource-notes)).
 - Keep the power connector fully seated; brownouts during radio ingest cause dropouts. *When in doubt, reboot.*
 
 ## Sharing position offline
 
-Even fully disconnected, the box beacons its own GPS to the map and can feed a phone with no receiver of its own — see [Own position / GPS](./own-position-gps.md). This keeps every node visible on the local COP without any network backhaul.
+Even fully disconnected, the box beacons its own GPS to the map and can feed a phone with no receiver of its own - see [Own position / GPS](./own-position-gps.md). This keeps every node visible on the local COP without any network backhaul.
 
 ## When connectivity returns
 
 If you later reach a LAN, MANET, or TAK Server, you can onboard the box onto that network and forward the picture upstream without losing the local Mesh SA picture:
 
-- Join an existing network via the onboarding portal or Ethernet — see [Counter-UAS CONOP modes](./counter-uas.md#three-conop-modes) and the [Networking](../networking/wifi-hotspot.md) pages.
+- Join an existing network via the onboarding portal or Ethernet - see [Counter-UAS CONOP modes](./counter-uas.md#three-conop-modes) and the [Networking](../networking/wifi-hotspot.md) pages.
 - Forward to a server with [Connect a TAK Server](./connect-tak-server.md).
 
 ## Related

--- a/docs/deploy/own-position-gps.md
+++ b/docs/deploy/own-position-gps.md
@@ -1,16 +1,16 @@
 # Own position & GPS
 
-Put the AryaOS box itself on the map, and share its GPS with your TAK client. This works in **every** role — the position core always runs — so your sensor gateway is also a self-locating node.
+Put the AryaOS box itself on the map, and share its GPS with your TAK client. This works in **every** role - the position core always runs - so your sensor gateway is also a self-locating node.
 
 AryaOS uses two cooperating tools for position:
 
 - **LINCOT** beacons the *host's own position* to TAK as a CoT marker, so the box shows up on the map like any other unit.
-- **GPSTAK** streams `gpsd` position data to the network as CoT and fans out NMEA for WinTAK — giving a connected phone or laptop a GPS fix even when it has no receiver of its own.
+- **GPSTAK** streams `gpsd` position data to the network as CoT and fans out NMEA for WinTAK - giving a connected phone or laptop a GPS fix even when it has no receiver of its own.
 
 Both feed from **`gpsd`**, which reads a connected GNSS receiver.
 
 !!! note "Always on"
-    `charontak`, `lincot`, `gpstak`, and `gpsd` are part of the CoT core and run regardless of the selected [device role](../config/device-roles.md) — including `relay`. You do not need a special role to share position.
+    `charontak`, `lincot`, `gpstak`, and `gpsd` are part of the CoT core and run regardless of the selected [device role](../config/device-roles.md) - including `relay`. You do not need a special role to share position.
 
 ## Hardware
 
@@ -31,8 +31,8 @@ flowchart LR
     H -->|Mesh SA 239.2.3.1:6969| E
 ```
 
-- **LINCOT → Charontak → Mesh SA:** the box appears as a self-marker on every connected EUD.
-- **GPSTAK → EUD:** a phone or WinTAK laptop on the AryaOS network uses the box's GPS as its own position source.
+- **LINCOT > Charontak > Mesh SA:** the box appears as a self-marker on every connected EUD.
+- **GPSTAK > EUD:** a phone or WinTAK laptop on the AryaOS network uses the box's GPS as its own position source.
 
 ## Share the box's position with TAK
 
@@ -42,7 +42,7 @@ To confirm the pipeline:
 
 ```bash
 systemctl status gpsd lincot gpstak
-gpspipe -w -n 5        # raw gpsd JSON — check for TPV with lat/lon
+gpspipe -w -n 5        # raw gpsd JSON - check for TPV with lat/lon
 ```
 
 !!! tip "Identity on the map"
@@ -64,13 +64,13 @@ See the [GPSTAK](https://github.com/snstac/gpstak) project for client-side setup
 
 ## Static position fallback
 
-If the box has no GNSS receiver — or you want a fixed marker for a base station or repeater — set a static position instead of relying on `gpsd`. LINCOT supports a fixed lat/lon so the host still beacons a location. Configure it from the LINCOT plugin in Cockpit (which edits `/etc/default/lincot`).
+If the box has no GNSS receiver - or you want a fixed marker for a base station or repeater - set a static position instead of relying on `gpsd`. LINCOT supports a fixed lat/lon so the host still beacons a location. Configure it from the LINCOT plugin in Cockpit (which edits `/etc/default/lincot`).
 
 !!! info "Wildland fire & SAR"
     In fire and search-and-rescue deployments, a self-locating gateway lets the incident COP show exactly where each sensor node sits, even when the carrying EUD is offline.
 
 ## Related
 
-- [Offline backpack](./offline-backpack.md) — position sharing over a disconnected hotspot.
-- [ForeFlight / GDL90](./foreflight-gdl90.md) — use this device's position as GDL90 ownship.
+- [Offline backpack](./offline-backpack.md) - position sharing over a disconnected hotspot.
+- [ForeFlight / GDL90](./foreflight-gdl90.md) - use this device's position as GDL90 ownship.
 - [Device roles](../config/device-roles.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/relay-routing.md
+++ b/docs/deploy/relay-routing.md
@@ -6,14 +6,14 @@ Use a relay when you need to *carry the picture*, not *make* it: bridge a Mesh S
 
 ## What Charontak is
 
-**Charontak** is the CoT bridge/router at the heart of every AryaOS box (named for the ferryman — it *ferries* CoT). Every local feeder sends to Charontak, and Charontak owns all egress:
+**Charontak** is the CoT bridge/router at the heart of every AryaOS box (named for the ferryman - it *ferries* CoT). Every local feeder sends to Charontak, and Charontak owns all egress:
 
 - It **listens** for CoT on `udp+ro://127.0.0.1:28087` (the site-config `COT_URL` default that feeders target with `udp+wo://127.0.0.1:28087`).
 - It **forwards** to one or more **lanes**. The default lane multicasts to **Mesh SA** at `udp+wo://239.2.3.1:6969`; optional lanes reach a [TAK Server](./connect-tak-server.md) over TLS.
 
-On AryaOS, Charontak is configured at `/etc/charontak.ini` and edited from **Cockpit → Charontak** at `https://<host>/admin/`. See [Charontak lanes](../admin/charontak-lanes.md) for the full editor reference.
+On AryaOS, Charontak is configured at `/etc/charontak.ini` and edited from **Cockpit > Charontak** at `https://<host>/admin/`. See [Charontak lanes](../admin/charontak-lanes.md) for the full editor reference.
 
-## Lanes: ingress → egress
+## Lanes: ingress > egress
 
 A **lane** is a one-directional route with an `ingress_cot_url` (where CoT comes in) and an `egress_cot_url` (where it goes out), plus `mode = forward`. Enable or disable each independently.
 
@@ -38,7 +38,7 @@ PYTAK_NO_HELLO = true
 
 For a pure relay you typically change the **ingress** to a network source rather than loopback. Common patterns:
 
-=== "Mesh → TAK Server"
+=== "Mesh > TAK Server"
 
     Bridge a local ATAK Mesh SA group up to a TAK Server.
 
@@ -51,7 +51,7 @@ For a pure relay you typically change the **ingress** to a network source rather
     PYTAK_NO_HELLO = true
     ```
 
-=== "Feeder network → mesh"
+=== "Feeder network > mesh"
 
     Accept UDP CoT from feeders elsewhere on the network and republish to mesh.
 
@@ -64,7 +64,7 @@ For a pure relay you typically change the **ingress** to a network source rather
     PYTAK_NO_HELLO = true
     ```
 
-=== "Mesh → TAK enrollment"
+=== "Mesh > TAK enrollment"
 
     Egress to a TAK Server via a `tak://` enrollment URL (needs `pytak[with-aiohttp,with-crypto]`).
 
@@ -84,8 +84,8 @@ For a pure relay you typically change the **ingress** to a network source rather
 
 === "Web console"
 
-    1. Open **Cockpit → AryaOS Site** (`https://<host>/admin/`).
-    2. In the **Device role** card, choose **Relay — CoT routing only**.
+    1. Open **Cockpit > AryaOS Site** (`https://<host>/admin/`).
+    2. In the **Device role** card, choose **Relay - CoT routing only**.
     3. Click **Apply role**.
 
     All sensor units are stopped; Charontak (and the position core) keep running.
@@ -102,7 +102,7 @@ For a pure relay you typically change the **ingress** to a network source rather
 ## When to use a relay
 
 - **Uplink node.** A box with backhaul (Ethernet/LTE/satellite) bridges a disconnected team's Mesh SA to a distant TAK Server.
-- **Network bridge.** Join two segments — for example a MANET and a command LAN — passing CoT between them.
+- **Network bridge.** Join two segments - for example a MANET and a command LAN - passing CoT between them.
 - **Fan-out / consolidation.** Collect CoT from several feeders and forward one consolidated stream upstream.
 
 ```mermaid
@@ -117,6 +117,6 @@ flowchart LR
 
 ## Related
 
-- [Charontak lanes](../admin/charontak-lanes.md) — full lane editor reference.
-- [Connect a TAK Server](./connect-tak-server.md) — provision the TLS/enrollment egress lane.
+- [Charontak lanes](../admin/charontak-lanes.md) - full lane editor reference.
+- [Connect a TAK Server](./connect-tak-server.md) - provision the TLS/enrollment egress lane.
 - [Offline backpack](./offline-backpack.md) · [Device roles](../config/device-roles.md) · [Glossary](../reference/glossary.md)

--- a/docs/deploy/sigint-limesdr.md
+++ b/docs/deploy/sigint-limesdr.md
@@ -1,7 +1,7 @@
-# SIGINT / wideband SDR (LimeSDR Mini) — "dragonegg"
+# SIGINT / wideband SDR (LimeSDR Mini) - "dragonegg"
 
 The **dragonegg** laydown is AryaOS + a **LimeSDR Mini** + GPS: a wideband
-(10&nbsp;MHz–3.5&nbsp;GHz) software-defined radio on the edge for spectrum monitoring and
+(10&nbsp;MHz-3.5&nbsp;GHz) software-defined radio on the edge for spectrum monitoring and
 signal-collection tasks, with the box's own position on the map.
 
 AryaOS ships the driver and access layer for the LimeSDR; the collection/analysis application
@@ -10,7 +10,7 @@ you point at it is deployment-specific.
 ## What one LimeSDR can receive
 
 Everything below was measured on a dragonegg box with an outdoor antenna, not
-inferred from datasheets. **One SDR does one band at a time** — these are
+inferred from datasheets. **One SDR does one band at a time** - these are
 alternatives, not a simultaneous list.
 
 | Capability | Band | Verified result |
@@ -19,8 +19,8 @@ alternatives, not a simultaneous list.
 | **UAT** | 978 MHz | aircraft decoded (`N93214`, light aircraft) |
 | **AIS** | 162 MHz | 15 vessels, incl. USCG base stations at −27 dBFS |
 | **APRS** | 144.39 MHz | 20 packets from 7 stations, MIC-E position reports |
-| **ACARS** | 130–132 MHz | 5 aircraft, incl. routes (`KSFO KABQ`) and ARINC-622 |
-| **Band survey** | 100 kHz–3.5 GHz | occupancy, noise floor, carrier detection |
+| **ACARS** | 130-132 MHz | 5 aircraft, incl. routes (`KSFO KABQ`) and ARINC-622 |
+| **Band survey** | 100 kHz-3.5 GHz | occupancy, noise floor, carrier detection |
 
 !!! warning "The antenna decides, not the SDR"
     This is the single most important fact about the laydown. The same box, same
@@ -32,16 +32,16 @@ alternatives, not a simultaneous list.
     else, and expect to swap it when you change bands.
 
     Because the box **cannot see what antenna is attached**, SDR capabilities are
-    never auto-enabled — see [Device roles](../config/device-roles.md).
+    never auto-enabled - see [Device roles](../config/device-roles.md).
 
 ## What's on the image
 
-- **`soapysdr-module-lms7`** — the SoapySDR driver for LimeSDR / LMS7002M. Any SoapySDR client
+- **`soapysdr-module-lms7`** - the SoapySDR driver for LimeSDR / LMS7002M. Any SoapySDR client
   (readsb, SDR++, SDRangel, GQRX, GNU Radio) can drive the Lime as `driver=lime`.
-- **`limesuite`** — LimeSuite tools: `LimeUtil` (find/probe/update), `LimeQuickTest`.
-- **`soapysdr-module-remote`** — SoapyRemote, so a remote operator can use the Lime over the
+- **`limesuite`** - LimeSuite tools: `LimeUtil` (find/probe/update), `LimeQuickTest`.
+- **`soapysdr-module-remote`** - SoapyRemote, so a remote operator can use the Lime over the
   network (see [Remote access](#remote-access-soapyremote)).
-- **`soapysdr-tools`** — `SoapySDRUtil` for enumeration/probing.
+- **`soapysdr-tools`** - `SoapySDRUtil` for enumeration/probing.
 
 ## First use
 
@@ -55,7 +55,7 @@ sudo LimeUtil --update                # one-time gateware/firmware update
 
 !!! warning "Power"
     The LimeSDR Mini is a **heavy, bursty USB draw**. With GPS and a Pi&nbsp;5 this is one of
-    the highest-draw laydowns — use a proper **5V/5A (27&nbsp;W)** supply (or a true PoE+
+    the highest-draw laydowns - use a proper **5V/5A (27&nbsp;W)** supply (or a true PoE+
     802.3at source). On a marginal supply the box can brown out; AryaOS will flag under-voltage
     (power-health) and, if it crash-loops, drop into
     [safe mode](../get-started/hardware.md#safe-mode).
@@ -76,7 +76,7 @@ argument, and passing `-d SOAPYSDR` sends it looking for a device with the liter
 `SOAPYSDR` instead of using the one you selected.
 
 Earlier builds were compiled **without** SoapySDR (`readelf -d` showed zero `libSoapySDR`
-entries), so the Lime was invisible to them no matter how it was configured — `-l` listed only
+entries), so the Lime was invisible to them no matter how it was configured - `-l` listed only
 the GPS.
 
 ### As the ADS-B 1090 front-end
@@ -86,20 +86,20 @@ sudo scripts/readsb-use-lime.sh          # driver=lime, gain 40
 ```
 
 This sets `readsb` to `--device-type soapysdr --soapy-device driver=lime` and restarts it.
-CoT then flows through `adsbcot` → Charontak as usual. Two `readsb` bugs that made this path
+CoT then flows through `adsbcot` > Charontak as usual. Two `readsb` bugs that made this path
 useless are fixed from **3.16.15-4** onward: `--gain` was applied ten times too large on the
 SoapySDR path, and a block was filled with a single `readStream()` call, which returns at most
-the driver's stream MTU — 2040 samples on a Lime against a 65536-sample buffer.
+the driver's stream MTU - 2040 samples on a Lime against a 65536-sample buffer.
 
 !!! success "The antenna decides this, not the SDR"
     With both fixes and an **outdoor antenna**, a LimeSDR Mini v2 decodes ADS-B properly.
     Measured on a dragonegg box, 70&nbsp;seconds at gain 40:
 
     - **5,173 usable messages**, **711 airborne position reports**
-    - **10 aircraft tracked, all 10 with position** — RSSI −42 to −48&nbsp;dBFS, altitudes
+    - **10 aircraft tracked, all 10 with position** - RSSI −42 to −48&nbsp;dBFS, altitudes
       3,200 to 39,000&nbsp;ft
 
-    The same box, same software, on a short indoor whip produced **0–2 usable messages and no
+    The same box, same software, on a short indoor whip produced **0-2 usable messages and no
     positions at all**. Nothing changed but the antenna.
 
     So budget for the antenna and its feedline before reaching for anything else. An inline
@@ -107,11 +107,11 @@ the driver's stream MTU — 2040 samples on a Lime against a 65536-sample buffer
     nearby, but it is **not** required, and it will not rescue a receiver that cannot hear the
     band in the first place.
 
-    An RTL-SDR remains a reasonable choice for a dedicated ADS-B box — it is cheaper and its
-    front end is already tuned for 1090 — but "the Lime cannot do ADS-B" is not true.
+    An RTL-SDR remains a reasonable choice for a dedicated ADS-B box - it is cheaper and its
+    front end is already tuned for 1090 - but "the Lime cannot do ADS-B" is not true.
 
 !!! note "USB stability"
-    The FT601 bridge has been observed dropping off the bus under sustained streaming —
+    The FT601 bridge has been observed dropping off the bus under sustained streaming -
     repeated `reset SuperSpeed USB device` messages, then a fallback to high-speed, then a full
     disconnect requiring a reboot or re-plug to recover. If a capture stops without explanation,
     check `lsusb` and `dmesg` before suspecting the decoder. A powered hub is worth trying.
@@ -125,8 +125,8 @@ position and weather reports, engine data, gate requests and crew messages.
 sudo aryaos-role caps <existing caps> acars
 ```
 
-That enables two units — `acarsdec` demodulates VHF, `acarscot` turns its JSON
-into CoT — mirroring the `readsb`/`adsbcot` split. Frequencies live in
+That enables two units - `acarsdec` demodulates VHF, `acarscot` turns its JSON
+into CoT - mirroring the `readsb`/`adsbcot` split. Frequencies live in
 `/etc/default/acarsdec`; the defaults are the common US channels.
 
 **ARINC-622 is decoded** from `acarsdec 4.6-snstac2` onward, via
@@ -147,7 +147,7 @@ opaque string.
     payloads were mostly airline engine and maintenance blobs.
 
     So `acarscot` emits nothing to the map for the majority of traffic, and that
-    is correct rather than broken — it refuses to invent a position. What ACARS
+    is correct rather than broken - it refuses to invent a position. What ACARS
     reliably adds is the operational context ADS-B cannot give you: tail number,
     flight ID and route.
 
@@ -170,7 +170,7 @@ aryaos-sdr-fm --freq 162.400M | aplay -f S16_LE -r 48000 -c 1
 
 `--mode am` handles aviation voice and other AM signals; it is **experimental**,
 with a documented level-settling caveat. De-emphasis is off by default because
-it distorts AFSK tone balance — use it only when a human is listening.
+it distorts AFSK tone balance - use it only when a human is listening.
 
 Tune the output level against the decoder, not by ear: `direwolf` prints
 `audio level = N` per packet and wants roughly 50.
@@ -185,7 +185,7 @@ SoapySDRServer --bind          # serves the local SDRs over the network
 ```
 
 !!! danger "Not enabled by default"
-    `SoapySDRServer` is **not** started automatically — it opens the SDR to the network
+    `SoapySDRServer` is **not** started automatically - it opens the SDR to the network
     unauthenticated. Start it manually only when needed, and **bind it to the Tailscale/VPN
     interface, not the open LAN** (see [Firewall](../networking/firewall.md) and
     [VPN](../networking/vpn-tailscale.md)). Stop it when you're done.
@@ -207,7 +207,7 @@ sudo aryaos-spectrum-survey --bands fmbcast,adsb1090 --json
 ```
 
 It reports **measurements, never identifications**. A band being busy does not tell you what
-is transmitting, and the tool will not guess — the band names are operator context only.
+is transmitting, and the tool will not guess - the band names are operator context only.
 
 Each band is classified as `bursty`, `continuous`, both, or neither, because those need
 different tests: a packetised emitter shows up as excursions above the band's noise floor,
@@ -217,8 +217,8 @@ while a steady carrier *is* the floor and has to be found in the frequency domai
     The `OCCUPIED` threshold is 0.5% of samples more than 20&nbsp;dB above the band's own
     median. That is tuned for continuously busy bands and it **under-reports short bursts**.
 
-    Measured case: with an outdoor antenna, 1090&nbsp;MHz surveys at **0.301% — below the
-    threshold, so it prints `quiet`** — while `readsb` on the same box at the same time decoded
+    Measured case: with an outdoor antenna, 1090&nbsp;MHz surveys at **0.301% - below the
+    threshold, so it prints `quiet`** - while `readsb` on the same box at the same time decoded
     **5,173 messages and tracked 10 aircraft**. ADS-B bursts are about 120&nbsp;µs against a
     2-second dwell, so low occupancy is the correct measurement and the boolean is what
     misleads. Read `occupancy_pct`, and compare a band against a known-quiet control rather
@@ -242,6 +242,6 @@ per deployment and is outside the base image.
 
 ## See also
 
-- [Radios & SDRs](../config/radios-sdr.md) — SDR selection and serials
-- [Own position (GPS)](own-position-gps.md) — the GPS half of dragonegg
-- [Hardware & requirements](../get-started/hardware.md#power--battery-for-backpack-ops) — power
+- [Radios & SDRs](../config/radios-sdr.md) - SDR selection and serials
+- [Own position (GPS)](own-position-gps.md) - the GPS half of dragonegg
+- [Hardware & requirements](../get-started/hardware.md#power-battery-for-backpack-ops) - power

--- a/docs/dev-pi.md
+++ b/docs/dev-pi.md
@@ -4,10 +4,10 @@ Use a dedicated Raspberry Pi on your LAN to try changes from this repository bef
 
 ## Default lab target (team convention)
 
-- **SSH:** `pi@aryaos-dev-pi` (via `~/.ssh/config`, see **`./scripts/setup-dev-ssh.sh`**) — resolves to **`172.17.2.158`**.
+- **SSH:** `pi@aryaos-dev-pi` (via `~/.ssh/config`, see **`./scripts/setup-dev-ssh.sh`**) - resolves to **`172.17.2.158`**.
 - **Password (fallback):** keep out of git. Use **gitignored** `scripts/.dev-pi-creds.local` or export `ARYAOS_DEV_PI_PASSWORD` when you cannot use the dev key below.
 
-**New images:** user **`pi`** has **passwordless sudo** (see `shared_files/aryaos/aryaos.sudoers`) so agents and scripts can run remote fixes over SSH without an interactive password. This matches the lab SSH key profile — anyone with **`aryaos-dev-lab`** can become root.
+**New images:** user **`pi`** has **passwordless sudo** (see `shared_files/aryaos/aryaos.sudoers`) so agents and scripts can run remote fixes over SSH without an interactive password. This matches the lab SSH key profile - anyone with **`aryaos-dev-lab`** can become root.
 
 **Existing Pi (already flashed):** apply once on the device (needs current `pi` password):
 
@@ -19,7 +19,7 @@ sudo visudo -c
 
 ## Lab SSH key (passwordless, preferred)
 
-The repo ships **`shared_files/aryaos/ssh/aryaos-dev-lab.pub`**; new AryaOS images append it to **`pi`**’s **`authorized_keys`**. The matching **private** key is **gitignored** at **`shared_files/aryaos/ssh/aryaos-dev-lab`** (generate once in the repo with `ssh-keygen`; see [shared_files/aryaos/ssh/README.md](https://github.com/snstac/aryaos/blob/main/shared_files/aryaos/ssh/README.md)).
+The repo ships **`shared_files/aryaos/ssh/aryaos-dev-lab.pub`**; new AryaOS images append it to **`pi`**'s **`authorized_keys`**. The matching **private** key is **gitignored** at **`shared_files/aryaos/ssh/aryaos-dev-lab`** (generate once in the repo with `ssh-keygen`; see [shared_files/aryaos/ssh/README.md](https://github.com/snstac/aryaos/blob/main/shared_files/aryaos/ssh/README.md)).
 
 **One-time on your workstation** (from repo root, after the private key exists):
 
@@ -36,7 +36,7 @@ That adds **`Host aryaos-dev-pi`** to `~/.ssh/config` pointing at **`172.17.2.15
 ssh-copy-id -i shared_files/aryaos/ssh/aryaos-dev-lab.pub pi@aryaos-dev-pi
 ```
 
-(`~/.ssh/config` must already contain **`Host aryaos-dev-pi`** with **`HostName 172.17.2.158`** — run **`./scripts/setup-dev-ssh.sh`** first, or add that block by hand.)
+(`~/.ssh/config` must already contain **`Host aryaos-dev-pi`** with **`HostName 172.17.2.158`** - run **`./scripts/setup-dev-ssh.sh`** first, or add that block by hand.)
 
 (or append the `.pub` line manually to `/home/pi/.ssh/authorized_keys` on the Pi).
 
@@ -44,7 +44,7 @@ ssh-copy-id -i shared_files/aryaos/ssh/aryaos-dev-lab.pub pi@aryaos-dev-pi
 
 ## USB power (multiple SDRs)
 
-If the Pi browns out USB devices under several dongles, run **`./scripts/enable-pi-usb-current.sh`** on the Pi from a synced repo (or after `scp` of that script plus `shared_files/aryaos/boot/firmware/aryaos-usb-power.fragment`). It appends **`max_usb_current=1`** (Pi 3–class) and **`usb_max_current_enable=1`** (Pi 5) to **`/boot/firmware/config.txt`**, then **reboot**. New AryaOS images apply the same fragment during **stage-aryaos** pi-gen.
+If the Pi browns out USB devices under several dongles, run **`./scripts/enable-pi-usb-current.sh`** on the Pi from a synced repo (or after `scp` of that script plus `shared_files/aryaos/boot/firmware/aryaos-usb-power.fragment`). It appends **`max_usb_current=1`** (Pi 3-class) and **`usb_max_current_enable=1`** (Pi 5) to **`/boot/firmware/config.txt`**, then **reboot**. New AryaOS images apply the same fragment during **stage-aryaos** pi-gen.
 
 ## Mirror the whole repo tree to the Pi
 
@@ -62,7 +62,7 @@ This mirrors the working tree to **`~/aryaos-sync/`** on the Pi (default **`pi@a
 
 ```bash
 cp scripts/dev-pi-creds.local.example scripts/.dev-pi-creds.local
-# edit scripts/.dev-pi-creds.local — it is gitignored
+# edit scripts/.dev-pi-creds.local - it is gitignored
 ./scripts/sync-to-dev-pi.sh
 ```
 

--- a/docs/get-started/first-boot.md
+++ b/docs/get-started/first-boot.md
@@ -1,13 +1,13 @@
 # First boot & first login
 
-What happens the first time an AryaOS device powers on, how to connect and log in, and — importantly — how to secure the unit before you field it.
+What happens the first time an AryaOS device powers on, how to connect and log in, and - importantly - how to secure the unit before you field it.
 
 ## The first-boot sequence (~120 seconds)
 
 A brand-new AryaOS device runs `aryaos-firstboot.service` once, on its first power-on. This takes about **120 seconds**; every boot after that takes about **90 seconds**. During first boot the device:
 
 1. **Resizes its filesystem** to fill the whole microSD card.
-2. **Derives [`DEVICE_SUFFIX`](../reference/glossary.md#device_suffix)** — four lowercase hex characters taken from the last four characters of `/etc/machine-id` (or the primary NIC MAC if machine-id is unavailable).
+2. **Derives [`DEVICE_SUFFIX`](../reference/glossary.md#device_suffix)** - four lowercase hex characters taken from the last four characters of `/etc/machine-id` (or the primary NIC MAC if machine-id is unavailable).
 3. **Sets the hostname** to `aryaos-xxxx`, where `xxxx` is the `DEVICE_SUFFIX`. This is also the mDNS name `aryaos-xxxx.local`.
 4. **Names the Wi-Fi hotspot** `AryaOS-xxxx` (same suffix) via comitup.
 5. **Stamps the CoT source id** `COT_HOST_ID=aryaos-xxxx`, used in Cursor on Target (CoT) flow-tags and remarks.
@@ -41,23 +41,23 @@ Other ways to reach the box are covered in [Wi-Fi & onboarding hotspot](../netwo
 Log in as user **`pi`** with the published default password for AryaOS images.
 
 !!! danger "The default password is public"
-    Because the default `pi` password ships in every published image, release images **expire it at first login** — you are required to set a new password immediately. Do not skip this. If your build did not force a change (for example a lab build), change it yourself right away.
+    Because the default `pi` password ships in every published image, release images **expire it at first login** - you are required to set a new password immediately. Do not skip this. If your build did not force a change (for example a lab build), change it yourself right away.
 
 ## Secure the device {#secure-the-device}
 
-Before you field a unit, walk this checklist. Each item links to the fuller page. All of it can be done from the web admin — SSH is optional.
+Before you field a unit, walk this checklist. Each item links to the fuller page. All of it can be done from the web admin - SSH is optional.
 
 - [ ] **Change the `pi` login password.** Forced at first login on release images. Set a strong password.
-- [ ] **Set a Wi-Fi hotspot (WPA2) password.** The onboarding hotspot is open by default. In **Cockpit → AryaOS Site → Onboarding hotspot password**, set a WPA2 passphrase of 8–63 characters. See [Wi-Fi & onboarding hotspot](../networking/wifi-hotspot.md).
-- [ ] **Rotate the Node-RED admin password.** AryaOS ships Node-RED with a publicly known default admin password, and the Node-RED editor can run arbitrary code. Rotate it in **Cockpit → AryaOS Site → Node-RED admin password** (or run [`aryaos-set-nodered-password`](../reference/cli-helpers.md#aryaos-set-nodered-password)). See [Node-RED dashboard](../node-red.md).
-- [ ] **(Optional) Join a VPN.** For remote management, join the device to Tailscale from **Cockpit → AryaOS Site → VPN**. See [VPN (Tailscale)](../networking/vpn-tailscale.md).
+- [ ] **Set a Wi-Fi hotspot (WPA2) password.** The onboarding hotspot is open by default. In **Cockpit > AryaOS Site > Onboarding hotspot password**, set a WPA2 passphrase of 8-63 characters. See [Wi-Fi & onboarding hotspot](../networking/wifi-hotspot.md).
+- [ ] **Rotate the Node-RED admin password.** AryaOS ships Node-RED with a publicly known default admin password, and the Node-RED editor can run arbitrary code. Rotate it in **Cockpit > AryaOS Site > Node-RED admin password** (or run [`aryaos-set-nodered-password`](../reference/cli-helpers.md#aryaos-set-nodered-password)). See [Node-RED dashboard](../node-red.md).
+- [ ] **(Optional) Join a VPN.** For remote management, join the device to Tailscale from **Cockpit > AryaOS Site > VPN**. See [VPN (Tailscale)](../networking/vpn-tailscale.md).
 
 !!! tip "Review the full security posture"
-    AryaOS ships hardened out of the box — a hardened SSH daemon, fail2ban, sysctl hardening, per-device TLS, firewalld, and Debian-security unattended-upgrades. See [Security posture](../security.md) for the complete picture.
+    AryaOS ships with a hardened SSH daemon, fail2ban, sysctl hardening, per-device TLS, firewalld, and Debian-security unattended-upgrades. See [Security posture](../security.md) for details.
 
 ## Self-assembled devices: set SDR serials
 
-If you built the device yourself, assign each RTL-SDR a unique serial so the decoders can tell them apart. Do this from **Cockpit → AryaOS Site → Radios** or with [`aryaos-sdr`](../reference/cli-helpers.md#aryaos-sdr):
+If you built the device yourself, assign each RTL-SDR a unique serial so the decoders can tell them apart. Do this from **Cockpit > AryaOS Site > Radios** or with [`aryaos-sdr`](../reference/cli-helpers.md#aryaos-sdr):
 
 ```bash
 sudo aryaos-sdr list
@@ -70,8 +70,8 @@ See [Radios & SDRs](../config/radios-sdr.md) for details.
 
 <div class="grid cards" markdown>
 
-- :material-cog: **Pick a mission** — Deploy for aircraft, vessels, drones, or position. [Deploy guides](../deploy/index.md)
-- :material-view-dashboard: **Web admin tour** — The AryaOS Site page and gateway plugins. [AryaOS Site page](../admin/aryaos-site.md)
-- :material-help-circle: **Something wrong?** — Symptom-to-fix checks. [Troubleshooting](../troubleshooting.md)
+- :material-cog: **Pick a mission** - Deploy for aircraft, vessels, drones, or position. [Deploy guides](../deploy/index.md)
+- :material-view-dashboard: **Web admin tour** - The AryaOS Site page and gateway plugins. [AryaOS Site page](../admin/aryaos-site.md)
+- :material-help-circle: **Something wrong?** - Symptom-to-fix checks. [Troubleshooting](../troubleshooting.md)
 
 </div>

--- a/docs/get-started/flash-the-image.md
+++ b/docs/get-started/flash-the-image.md
@@ -7,13 +7,13 @@ Write the AryaOS image to a microSD card, then boot your Raspberry Pi from it. T
 
 ## Before you begin
 
-- A supported Raspberry Pi and a microSD card of at least **16 GB** (32 GB recommended) — see [Hardware & requirements](hardware.md).
+- A supported Raspberry Pi and a microSD card of at least **16 GB** (32 GB recommended) - see [Hardware & requirements](hardware.md).
 - A workstation running Windows, macOS, or Linux.
 - The AryaOS image file (next section).
 
 ## Get the image
 
-**If you use AryaOS Imager you can skip this section** — it fetches the current image itself.
+**If you use AryaOS Imager you can skip this section** - it fetches the current image itself.
 
 | Source | Where | When to use |
 |---|---|---|
@@ -21,7 +21,7 @@ Write the AryaOS image to a microSD card, then boot your Raspberry Pi from it. T
 | GitHub Releases | [github.com/snstac/aryaos/releases](https://github.com/snstac/aryaos/releases) | Downloading the `.img.xz` by hand |
 | CI artifacts | GitHub Actions build artifacts on the repo | Testing an unreleased build your team pointed you to |
 
-Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads `.img.xz` directly — you do not need to decompress it first.
+Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads `.img.xz` directly - you do not need to decompress it first.
 
 !!! info "Every release is signed and bill-of-materials'd"
     Each image build attaches an SPDX and CycloneDX software bill of materials (SBOM) to its GitHub Release, and all AryaOS packages install from the [signed apt repository](https://snstac.github.io/packages). See [SBOM & supply chain](../operations/sbom.md).
@@ -35,19 +35,19 @@ Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads 
     | Platform | Download |
     |---|---|
     | Windows | `AryaOS-Imager-Setup-*.exe` (installer) or `aryaos-imager.exe` (portable) |
-    | Linux | `aryaos-imager` — an x86-64 binary |
-    | macOS | **not built yet** — use Raspberry Pi Imager or balenaEtcher |
+    | Linux | `aryaos-imager` - an x86-64 binary |
+    | macOS | **not built yet** - use Raspberry Pi Imager or balenaEtcher |
 
     1. Download and install AryaOS Imager.
     2. Insert the microSD card into your workstation.
-    3. Open AryaOS Imager and choose **AryaOS (latest release)**. A **latest dev** build is also offered — that one bakes in lab access and is not for field use.
-    4. Under storage, select the microSD card. **Confirm the device — this erases the card.**
+    3. Open AryaOS Imager and choose **AryaOS (latest release)**. A **latest dev** build is also offered - that one bakes in lab access and is not for field use.
+    4. Under storage, select the microSD card. **Confirm the device - this erases the card.**
     5. Write, and wait for the verify step to finish.
 
     !!! warning "Windows shows a SmartScreen warning, and you cannot yet checksum the fix"
-        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info → Run anyway**.
+        The installer is not code-signed, so Windows displays *"Windows protected your PC"*. Click **More info > Run anyway**.
 
-        Releases publish a `SHA256SUMS.txt`, but as of `v1.0.0` it covers **only the Linux binary** — the Windows installer, the portable `.exe` and the callback relay have no published checksum. So on Windows there is currently no way to verify the download, and the "run anyway" step is a genuine trust decision. Prefer the Linux build where you have the choice, and re-check `SHA256SUMS.txt` on newer releases.
+        Releases publish a `SHA256SUMS.txt`, but as of `v1.0.0` it covers **only the Linux binary** - the Windows installer, the portable `.exe` and the callback relay have no published checksum. So on Windows there is currently no way to verify the download, and the "run anyway" step is a genuine trust decision. Prefer the Linux build where you have the choice, and re-check `SHA256SUMS.txt` on newer releases.
 
     The image itself is a separate matter and *is* verifiable: every AryaOS release publishes an SBOM and an uncompressed-image SHA, and the imager verifies what it wrote after writing it.
 
@@ -61,7 +61,7 @@ Downloaded by hand, the image is a compressed `.img.xz`. Every tool below reads 
     2. Insert the microSD card into your workstation.
     3. Open Raspberry Pi Imager.
     4. Under **Choose OS**, scroll to the bottom and select **Use custom**, then pick the downloaded AryaOS `.img.xz`.
-    5. Under **Choose Storage**, select the microSD card. **Confirm the device — this erases the card.**
+    5. Under **Choose Storage**, select the microSD card. **Confirm the device - this erases the card.**
     6. Click **Next**, confirm, and wait for the write and verify steps to finish.
 
     !!! warning "Skip the OS customization prompt"
@@ -98,6 +98,6 @@ Within a few seconds the AryaOS device flashes its green and red LEDs as it star
 
 <div class="grid cards" markdown>
 
-- :material-power: **First boot & first login** — Connect to the hotspot, log in, and secure the device. [First boot & first login](first-boot.md)
+- :material-power: **First boot & first login** - Connect to the hotspot, log in, and secure the device. [First boot & first login](first-boot.md)
 
 </div>

--- a/docs/get-started/hardware.md
+++ b/docs/get-started/hardware.md
@@ -1,6 +1,6 @@
 # Hardware & requirements
 
-Everything you need to build or buy an AryaOS gateway. This page covers the single-board computer, storage, radios, antennas, GPS, and power for backpack operations — plus the pre-assembled [AirTAK go-kit](../purchase.md) if you would rather skip the shopping list.
+Hardware requirements for building or buying an AryaOS gateway. The list covers the single-board computer, storage, radios, antennas, GPS, and power for backpack operations. A pre-assembled [AirTAK go-kit](../purchase.md) is also available.
 
 !!! tip "Just want it to work?"
     Order an assembled and tested [AirTAK go-kit](../purchase.md). It ships with a Raspberry Pi, the right radios and antennas, GPS, and a field enclosure, all pre-flashed with AryaOS. The rest of this page is for teams building their own.
@@ -13,18 +13,18 @@ AryaOS runs the same image everywhere; a mission's needs come down to which radi
 |---|---|---|---|---|---|
 | Aircraft (ADS-B 1090 MHz) | [Aircraft (ADS-B)](../deploy/air-adsb.md) | RTL-SDR | 1090 MHz ADS-B | Optional | `air` |
 | Aircraft (UAT 978 MHz, US) | [Aircraft (ADS-B)](../deploy/air-adsb.md) | Second RTL-SDR | 978 MHz (or wideband ADS-B) | Optional | `air` |
-| Maritime vessels (AIS) | [Maritime vessels (AIS)](../deploy/maritime-ais.md) | RTL-SDR | VHF marine (161–162 MHz) | Optional | `maritime` |
+| Maritime vessels (AIS) | [Maritime vessels (AIS)](../deploy/maritime-ais.md) | RTL-SDR | VHF marine (161-162 MHz) | Optional | `maritime` |
 | Drones (Remote ID / DroneID) | [Counter-UAS (drones)](../deploy/counter-uas.md) | AntSDR (or Wi-Fi/BT sniffer) | 2.4/5.8 GHz per hardware | Optional | `cuas` |
-| Own position on the map | [Own position (GPS)](../deploy/own-position-gps.md) | — | — | USB GNSS puck | any |
+| Own position on the map | [Own position (GPS)](../deploy/own-position-gps.md) | - | - | USB GNSS puck | any |
 | Everything at once | [Multi-sensor COP](../deploy/multi-sensor.md) | Multiple SDRs | Per band above | USB GNSS puck | `multi` |
-| CoT relay / routing only | [Relay & routing](../deploy/relay-routing.md) | — | — | Optional | `relay` |
+| CoT relay / routing only | [Relay & routing](../deploy/relay-routing.md) | - | - | Optional | `relay` |
 
 !!! info "One SDR per band"
-    Each radio decodes one band at a time. To watch 1090 MHz and 978 MHz simultaneously (or add AIS), fit one RTL-SDR per band and give each a unique serial — see [Re-serializing radios](#re-serializing-radios).
+    Each radio decodes one band at a time. To watch 1090 MHz and 978 MHz simultaneously (or add AIS), fit one RTL-SDR per band and give each a unique serial - see [Re-serializing radios](#re-serializing-radios).
 
 ## Single-board computer
 
-AryaOS is a Debian trixie–based, `arm64` operating system built with pi-gen. It targets the Raspberry Pi and is tested on the following models.
+AryaOS is a Debian trixie-based, `arm64` operating system built with pi-gen. It targets the Raspberry Pi and is tested on the following models.
 
 | Model | Architecture | Status | Notes |
 |---|---|---|---|
@@ -59,7 +59,7 @@ AryaOS decodes signals with software-defined radio (SDR) dongles on USB.
     |---|---|---|---|
     | ADS-B | 1090 MHz | `readsb` / `dump1090-fa` | `stx:1090:0` |
     | UAT (US) | 978 MHz | `dump978-fa` | `stx:978:0` |
-    | AIS | 161–162 MHz (VHF) | `ais-catcher` | assign a distinct serial |
+    | AIS | 161-162 MHz (VHF) | `ais-catcher` | assign a distinct serial |
 
     A blog-favorite is the Nooelec NESDR series; the factory UAT preset on AryaOS matches the NESDR Nano 3 "978" EEPROM serial `stx:978:0`.
 
@@ -72,7 +72,7 @@ AryaOS decodes signals with software-defined radio (SDR) dongles on USB.
 
 ### Re-serializing radios
 
-Set serials from **Cockpit → AryaOS Site → Radios**, or from a shell with [`aryaos-sdr`](../reference/cli-helpers.md):
+Set serials from **Cockpit > AryaOS Site > Radios**, or from a shell with [`aryaos-sdr`](../reference/cli-helpers.md):
 
 ```bash
 sudo aryaos-sdr list
@@ -89,14 +89,14 @@ The right antenna does more for range than anything else in the kit.
 |---|---|---|
 | ADS-B 1090 MHz | Tuned 1090 MHz ADS-B antenna | A tuned whip or collinear outperforms the bundled telescopic; height and line of sight matter most |
 | UAT 978 MHz | 978 MHz or wideband ADS-B antenna | US-only band; a wideband ADS-B antenna covers both 978 and 1090 acceptably |
-| AIS (VHF) | Marine VHF antenna (161–162 MHz) | A proper VHF marine antenna dramatically improves vessel range |
+| AIS (VHF) | Marine VHF antenna (161-162 MHz) | A proper VHF marine antenna dramatically improves vessel range |
 
 !!! example "Range in the field"
     In a San Diego backpack test with no internet, a tuned ADS-B setup reached **55 miles** of aircraft coverage. See [Introduction](overview.md) for the full CONOP.
 
 ## GPS / GNSS
 
-A USB GNSS puck gives the gateway its own position, which AryaOS publishes to TAK via [GPSTAK and LINCOT](../reference/software-suite.md) — useful for backpack and vehicle operations where the box is on the move.
+A USB GNSS puck gives the gateway its own position, which AryaOS publishes to TAK via [GPSTAK and LINCOT](../reference/software-suite.md) - useful for backpack and vehicle operations where the box is on the move.
 
 - Any `gpsd`-compatible USB GNSS receiver works (the popular u-blox 7/8-class pucks are common choices).
 - GPS is optional for fixed-site installs but recommended for mobile and dismounted use.
@@ -104,26 +104,26 @@ A USB GNSS puck gives the gateway its own position, which AryaOS publishes to TA
 
 ## Power & battery for backpack ops
 
-AryaOS is designed for disconnected, dismounted use — no LTE, no Wi-Fi backhaul required.
+AryaOS is designed for disconnected, dismounted use - no LTE, no Wi-Fi backhaul required.
 Power is the most common field failure, so size it correctly:
 
-- **Raspberry Pi 5: use a 5V/5A (27&nbsp;W) USB-C PD supply** — the official Raspberry Pi 27&nbsp;W supply, or a charger that *explicitly* lists a `5V/5A` output. (Earlier Pis: a Pi 4 wants a solid 5V/3A source.)
-    - **A high-wattage GaN charger is not a substitute.** Multi-port GaN bricks (e.g. Anker Prime 100&nbsp;W, UGREEN Nexode) deliver 5A only at 9–20&nbsp;V; at 5&nbsp;V they cap at **3A (15&nbsp;W)**, so a Pi 5 runs starved and browns out under load. Verify the `5V/5A` line item, not the total wattage.
-- **SDRs draw additional current.** AryaOS ships `usb_max_current_enable=1`, so the Pi 5 feeds the full USB budget to the radios — but only if the supply can actually deliver it. Size the battery/supply for the Pi **plus** every attached radio.
-- **PoE:** the Waveshare PoE M.2 HAT+ (and similar) output **5V/4.5A (~22.5&nbsp;W) on 802.3at (PoE+)** — enough for a Pi 5 with an NVMe SSD and a couple of SDRs, but **only from a true PoE+ (802.3at) source**. A plain **802.3af** switch or injector (~13&nbsp;W) will brown the box out; use PoE+ (802.3at) or PoE++ (802.3bt).
+- **Raspberry Pi 5: use a 5V/5A (27&nbsp;W) USB-C PD supply** - the official Raspberry Pi 27&nbsp;W supply, or a charger that *explicitly* lists a `5V/5A` output. (Earlier Pis: a Pi 4 wants a solid 5V/3A source.)
+    - **A high-wattage GaN charger is not a substitute.** Multi-port GaN bricks (e.g. Anker Prime 100&nbsp;W, UGREEN Nexode) deliver 5A only at 9-20&nbsp;V; at 5&nbsp;V they cap at **3A (15&nbsp;W)**, so a Pi 5 runs starved and browns out under load. Verify the `5V/5A` line item, not the total wattage.
+- **SDRs draw additional current.** AryaOS ships `usb_max_current_enable=1`, so the Pi 5 feeds the full USB budget to the radios - but only if the supply can actually deliver it. Size the battery/supply for the Pi **plus** every attached radio.
+- **PoE:** the Waveshare PoE M.2 HAT+ (and similar) output **5V/4.5A (~22.5&nbsp;W) on 802.3at (PoE+)** - enough for a Pi 5 with an NVMe SSD and a couple of SDRs, but **only from a true PoE+ (802.3at) source**. A plain **802.3af** switch or injector (~13&nbsp;W) will brown the box out; use PoE+ (802.3at) or PoE++ (802.3bt).
 - A powered USB hub can help when running multiple SDRs on a Pi 3/4.
 
-If the supply still can't keep up, AryaOS does not just crash-loop: after repeated short boots it drops into **[safe mode](#safe-mode)** — USB peripherals off, sensors stopped, box still reachable — until you fit an adequate supply and restore it. The AryaOS Site page in Cockpit also shows a live **power-health** warning (from `vcgencmd get_throttled`) whenever it detects under-voltage or throttling.
+If the supply still can't keep up, AryaOS does not just crash-loop: after repeated short boots it drops into **[safe mode](#safe-mode)** - USB peripherals off, sensors stopped, box still reachable - until you fit an adequate supply and restore it. The AryaOS Site page in Cockpit also shows a live **power-health** warning (from `vcgencmd get_throttled`) whenever it detects under-voltage or throttling.
 
 See [Disconnected / backpack ops](../deploy/offline-backpack.md) for the full field loadout.
 
 ### Safe mode
 
-If the box reboots repeatedly without staying up — the classic symptom of an under-spec'd supply browning out under load — AryaOS latches **safe mode** after 3 consecutive short boots (each under 3 minutes):
+If the box reboots repeatedly without staying up - the classic symptom of an under-spec'd supply browning out under load - AryaOS latches **safe mode** after 3 consecutive short boots (each under 3 minutes):
 
 - USB peripherals are **powered off** and the sensor/SDR services are **withheld**, so the box idles at minimal draw and boots cleanly.
 - **Ethernet, SSH and Cockpit stay up**, so you can always get in and diagnose.
-- It is **sticky** — clear it from **Cockpit → AryaOS Site → Safe mode** ("Restore now" or "Restore &amp; reboot"), or on the command line with `sudo aryaos-safe-mode off`. Check state any time with `aryaos-safe-mode status`.
+- It is **sticky** - clear it from **Cockpit > AryaOS Site > Safe mode** ("Restore now" or "Restore &amp; reboot"), or on the command line with `sudo aryaos-safe-mode off`. Check state any time with `aryaos-safe-mode status`.
 
 The usual fix is a better power supply (above). Safe mode buys you a reachable box to fix instead of a dark one in a crash loop.
 
@@ -133,8 +133,8 @@ If assembling and tuning your own kit is not how you want to spend the week, the
 
 <div class="grid cards" markdown>
 
-- :material-package-variant-closed: **Buy assembled** — Pi, radios, antennas, GPS, enclosure, and AryaOS in one box. [Buy hardware](../purchase.md)
-- :material-tools: **Build your own** — Use the tables above, then [flash the image](flash-the-image.md).
+- :material-package-variant-closed: **Buy assembled** - Pi, radios, antennas, GPS, enclosure, and AryaOS in one box. [Buy hardware](../purchase.md)
+- :material-tools: **Build your own** - Use the tables above, then [flash the image](flash-the-image.md).
 
 </div>
 
@@ -142,8 +142,8 @@ If assembling and tuning your own kit is not how you want to spend the week, the
 
 <div class="grid cards" markdown>
 
-- :material-download: **Flash the image** — Write AryaOS to your microSD card. [Flash the image](flash-the-image.md)
-- :material-power: **First boot** — What happens on first power-on, and how to log in. [First boot & first login](first-boot.md)
-- :material-cart: **Buy hardware** — The assembled AirTAK go-kit. [Buy hardware](../purchase.md)
+- :material-download: **Flash the image** - Write AryaOS to your microSD card. [Flash the image](flash-the-image.md)
+- :material-power: **First boot** - What happens on first power-on, and how to log in. [First boot & first login](first-boot.md)
+- :material-cart: **Buy hardware** - The assembled AirTAK go-kit. [Buy hardware](../purchase.md)
 
 </div>

--- a/docs/get-started/overview.md
+++ b/docs/get-started/overview.md
@@ -3,8 +3,8 @@
 AryaOS is a Linux operating system that turns a small, inexpensive computer into
 a **situational-awareness gateway** for [TAK](../reference/glossary.md#tak). It
 ingests data from radios and sensors, converts it to
-[Cursor on Target (CoT)](../reference/glossary.md#cot) — the native language of
-ATAK, WinTAK, iTAK, and TAK Server — and delivers it to the operators who need
+[Cursor on Target (CoT)](../reference/glossary.md#cot) - the native language of
+ATAK, WinTAK, iTAK, and TAK Server - and delivers it to the operators who need
 it, whether they are standing next to the box or across a wide-area network.
 
 Everything is pre-installed and pre-wired. You flash a card, power it on, and
@@ -26,9 +26,9 @@ A single AryaOS box can run one of these missions or all of them at once, and ca
 relay the combined picture to a TAK Server for the wider force.
 
 !!! example "Proven in the field"
-    In its original **AirTAK** configuration — an AryaOS box and an ADS-B antenna
+    In its original **AirTAK** configuration - an AryaOS box and an ADS-B antenna
     in a backpack, powered by a USB battery, paired to a phone over Wi-Fi with no
-    internet — operators have tracked aircraft at ranges past 50 miles. AryaOS is
+    internet - operators have tracked aircraft at ranges past 50 miles. AryaOS is
     in daily use for wildland fire, security, and search-and-rescue.
 
 ## How it works
@@ -77,11 +77,11 @@ AryaOS is designed so an operator **never needs to SSH in**. A hardened
 [Cockpit](https://cockpit-project.org/) web console on port 9090 (reachable over
 HTTPS) exposes:
 
-- **The AryaOS Site page** — TAK destination, TLS certificates, TAK Server
+- **The AryaOS Site page** - TAK destination, TLS certificates, TAK Server
   enrollment, device role, radios, updates, VPN, hotspot password, support
   bundles, and Node-RED admin password. See [AryaOS Site](../admin/aryaos-site.md).
-- **The Charontak lane editor** — a structured editor for where CoT flows.
-- **Per-gateway pages** — one for each sensor (adsbcot, aiscot, dronecot, …).
+- **The Charontak lane editor** - a structured editor for where CoT flows.
+- **Per-gateway pages** - one for each sensor (adsbcot, aiscot, dronecot, ...).
 
 SSH is still available for advanced work, but it is never required for normal
 operation.
@@ -89,8 +89,8 @@ operation.
 ## Device roles
 
 Rather than shipping a different image per mission, one AryaOS image adapts at
-runtime. Pick a **[device role](../config/device-roles.md)** in the web console —
-Air, Maritime, Counter-UAS, Multi-sensor, or Relay — and AryaOS enables the right
+runtime. Pick a **[device role](../config/device-roles.md)** in the web console -
+Air, Maritime, Counter-UAS, Multi-sensor, or Relay - and AryaOS enables the right
 sensor pipelines and disables the rest. The CoT routing core always runs.
 
 ## What's in the box
@@ -108,9 +108,9 @@ sensor pipelines and disables the rest. The CoT routing core always runs.
 
 <div class="grid cards" markdown>
 
--   :material-rocket-launch: **[Quickstart](quickstart.md)** — from flash to first track.
--   :material-chip: **[Hardware & requirements](hardware.md)** — what to buy.
--   :material-map-marker-path: **[Choose a deployment](../deploy/index.md)** — mission-by-mission guides.
--   :material-book-open-variant: **[Glossary](../reference/glossary.md)** — TAK, CoT, ADS-B, and friends.
+-   :material-rocket-launch: **[Quickstart](quickstart.md)** - from flash to first track.
+-   :material-chip: **[Hardware & requirements](hardware.md)** - what to buy.
+-   :material-map-marker-path: **[Choose a deployment](../deploy/index.md)** - mission-by-mission guides.
+-   :material-book-open-variant: **[Glossary](../reference/glossary.md)** - TAK, CoT, ADS-B, and friends.
 
 </div>

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -14,7 +14,7 @@ apply to every mission.
 ## 1. Flash the card
 
 The short way, on **Windows or Linux**, is
-[**AryaOS Imager**](https://github.com/snstac/aryaos-imager/releases) — a
+[**AryaOS Imager**](https://github.com/snstac/aryaos-imager/releases) - a
 single-purpose build of Raspberry Pi Imager that offers only AryaOS and
 downloads the image itself, so there is nothing to find and no wrong operating
 system to pick by accident.
@@ -22,7 +22,7 @@ system to pick by accident.
 1. Install [AryaOS Imager](https://github.com/snstac/aryaos-imager/releases).
 2. Insert the microSD card, open the imager, and choose
    **AryaOS (latest release)**.
-3. Select the card — **this erases it** — then write and let it verify.
+3. Select the card - **this erases it** - then write and let it verify.
 
 On **macOS**, or if you already have the tools, download the latest
 `aryaos-*.img.xz` from [GitHub Releases](https://github.com/snstac/aryaos/releases)
@@ -51,14 +51,14 @@ set your password.
 === "Phone / tablet (Wi-Fi)"
 
     1. On the phone, join the **`AryaOS-xxxx`** Wi-Fi network.
-    2. The onboarding hotspot is open by default — you can set a
+    2. The onboarding hotspot is open by default - you can set a
        [WPA2 password](../networking/wifi-hotspot.md) later from the web console.
     3. Open your browser to **`https://aryaos-xxxx.local:9090/`** (accept the
-       self-signed certificate warning — the cert is unique to your device).
+       self-signed certificate warning - the cert is unique to your device).
 
     !!! note
         If `aryaos-xxxx.local` does not resolve on your phone, browse to the
-        gateway's IP address instead — the hotspot hands out addresses on
+        gateway's IP address instead - the hotspot hands out addresses on
         `10.41.0.0/24` with the box at `10.41.0.1`.
 
 === "Computer (Wi-Fi or Ethernet)"
@@ -70,26 +70,26 @@ set your password.
 
 ## 4. Point TAK at the gateway
 
-Configure your TAK end-user device to receive **Mesh SA** — the local multicast
+Configure your TAK end-user device to receive **Mesh SA** - the local multicast
 CoT stream AryaOS broadcasts by default.
 
 === "ATAK / iTAK"
 
-    1. **Settings → Network Preferences → Network Connections**.
-    2. Ensure **SA Multicast** (Mesh SA) is enabled — this is on by default in
+    1. **Settings > Network Preferences > Network Connections**.
+    2. Ensure **SA Multicast** (Mesh SA) is enabled - this is on by default in
        most builds.
     3. Return to the map. Aircraft appear as they are received.
 
 === "WinTAK"
 
-    1. Enable multicast SA in **Settings → Network**.
-    2. If your network blocks multicast, use a direct feed instead — see
+    1. Enable multicast SA in **Settings > Network**.
+    2. If your network blocks multicast, use a direct feed instead - see
        [Connect to a TAK Server](../deploy/connect-tak-server.md) or the NMEA/GDL90
        options for [ForeFlight & EFBs](../deploy/foreflight-gdl90.md).
 
 ## 5. Confirm you see tracks
 
-- In the AryaOS web console, open **AryaOS Site → Sensor services** and confirm
+- In the AryaOS web console, open **AryaOS Site > Sensor services** and confirm
   `adsbcot` and `readsb` are **active**.
 - On the TAK map, aircraft icons should appear within a minute if any are in range
   of your antenna. A local ADS-B map is also served on the box (tar1090).
@@ -101,10 +101,10 @@ CoT stream AryaOS broadcasts by default.
 
 <div class="grid cards" markdown>
 
--   :material-airplane: **[Tune the ADS-B setup](../deploy/air-adsb.md)** — decoder choice, UAT, gain, dual SDRs.
--   :material-map-marker-path: **[Other missions](../deploy/index.md)** — maritime, drones, GPS, multi-sensor.
--   :material-server-network: **[Connect a TAK Server](../deploy/connect-tak-server.md)** — forward the picture upstream.
--   :material-application-cog: **[Tour the web console](../admin/index.md)** — everything you can configure.
--   :material-shield-check: **[Harden for the field](../get-started/first-boot.md#secure-the-device)** — passwords, Wi-Fi, VPN.
+-   :material-airplane: **[Tune the ADS-B setup](../deploy/air-adsb.md)** - decoder choice, UAT, gain, dual SDRs.
+-   :material-map-marker-path: **[Other missions](../deploy/index.md)** - maritime, drones, GPS, multi-sensor.
+-   :material-server-network: **[Connect a TAK Server](../deploy/connect-tak-server.md)** - forward the picture upstream.
+-   :material-application-cog: **[Tour the web console](../admin/index.md)** - everything you can configure.
+-   :material-shield-check: **[Harden for the field](../get-started/first-boot.md#secure-the-device)** - passwords, Wi-Fi, VPN.
 
 </div>

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -5,13 +5,13 @@ Short answers to the questions we hear most, each linking to the page with the f
 ## Getting started
 
 ??? question "Do I need internet to use AryaOS?"
-    No. AryaOS is designed for disconnected operation — no LTE, no Wi-Fi backhaul. Pair a TAK device to the onboarding hotspot and you see live tracks over local Mesh SA with nothing else connected. Internet is only needed to reach a remote TAK Server or to fetch updates. See [Disconnected / backpack ops](../deploy/offline-backpack.md).
+    No. AryaOS is designed for disconnected operation - no LTE, no Wi-Fi backhaul. Pair a TAK device to the onboarding hotspot and you see live tracks over local Mesh SA with nothing else connected. Internet is only needed to reach a remote TAK Server or to fetch updates. See [Disconnected / backpack ops](../deploy/offline-backpack.md).
 
 ??? question "Which Raspberry Pi do I need?"
     A Raspberry Pi 3, 4, or 5 (`arm64`), with a 16 GB+ microSD card (32 GB recommended). The Pi 4 is the common field build; the Pi 5 has the most headroom. See [Hardware & requirements](../get-started/hardware.md).
 
 ??? question "Is amd64 (Intel) supported?"
-    Not as an image yet — AryaOS images are `arm64` only today ([#129](https://github.com/snstac/aryaos/issues/129)). But the full gateway suite already installs on any Debian host, including `amd64`, from the [signed apt repository](https://snstac.github.io/packages).
+    Not as an image yet - AryaOS images are `arm64` only today ([#129](https://github.com/snstac/aryaos/issues/129)). But the full gateway suite already installs on any Debian host, including `amd64`, from the [signed apt repository](https://snstac.github.io/packages).
 
 ??? question "Can I buy one already assembled?"
     Yes. The [AirTAK go-kit](../purchase.md) ships assembled, tested, and pre-flashed with AryaOS.
@@ -30,36 +30,36 @@ Short answers to the questions we hear most, each linking to the page with the f
 ## Using it
 
 ??? question "How do I see aircraft/vessels/drones in TAK?"
-    Pick your sensor's mission page — [Aircraft (ADS-B)](../deploy/air-adsb.md), [Maritime (AIS)](../deploy/maritime-ais.md), or [Counter-UAS (drones)](../deploy/counter-uas.md) — attach the right radio and antenna, set the [device role](../config/device-roles.md), and the tracks flow to TAK over Mesh SA. If nothing shows up, see [Troubleshooting](../troubleshooting.md).
+    Pick your sensor's mission page - [Aircraft (ADS-B)](../deploy/air-adsb.md), [Maritime (AIS)](../deploy/maritime-ais.md), or [Counter-UAS (drones)](../deploy/counter-uas.md) - attach the right radio and antenna, set the [device role](../config/device-roles.md), and the tracks flow to TAK over Mesh SA. If nothing shows up, see [Troubleshooting](../troubleshooting.md).
 
 ??? question "How do I connect AryaOS to a TAK Server?"
-    Import your TAK connection **data package** or a `tak://` **enrollment link** from the TAK connection card in **Cockpit → AryaOS Site**. AryaOS installs the certificates and adds a CharonTAK egress lane to the server. See [Connect to a TAK Server](../deploy/connect-tak-server.md).
+    Import your TAK connection **data package** or a `tak://` **enrollment link** from the TAK connection card in **Cockpit > AryaOS Site**. AryaOS installs the certificates and adds a CharonTAK egress lane to the server. See [Connect to a TAK Server](../deploy/connect-tak-server.md).
 
 ??? question "How do I show tracks in ForeFlight or another EFB?"
     AryaOS converts CoT to GDL90 via GDLTAK (UDP 4000). Point your EFB at the device. See [ForeFlight & EFBs (GDL90)](../deploy/foreflight-gdl90.md).
 
 ??? question "How do I change SDR serial numbers?"
-    From **Cockpit → AryaOS Site → Radios**, or run `sudo aryaos-sdr set-serial 0 stx:1090:0`. Replug the dongle (or reboot) afterward. See [Radios & SDRs](../config/radios-sdr.md) and [`aryaos-sdr`](../reference/cli-helpers.md#aryaos-sdr).
+    From **Cockpit > AryaOS Site > Radios**, or run `sudo aryaos-sdr set-serial 0 stx:1090:0`. Replug the dongle (or reboot) afterward. See [Radios & SDRs](../config/radios-sdr.md) and [`aryaos-sdr`](../reference/cli-helpers.md#aryaos-sdr).
 
 ??? question "What's the difference between the device roles?"
-    Roles select which sensor pipelines run: `multi` (all), `air` (ADS-B/UAT), `maritime` (AIS), `cuas` (drones), `relay` (routing only). The CoT core always runs. Set it in **Cockpit → AryaOS Site → Device role**. See [Device roles](../config/device-roles.md).
+    Roles select which sensor pipelines run: `multi` (all), `air` (ADS-B/UAT), `maritime` (AIS), `cuas` (drones), `relay` (routing only). The CoT core always runs. Set it in **Cockpit > AryaOS Site > Device role**. See [Device roles](../config/device-roles.md).
 
 ## Operating & maintaining
 
 ??? question "How do I update AryaOS?"
-    Use **Cockpit → AryaOS Site → Software updates** (it keeps running even if you close the browser), or run `sudo aryaos-update apply`. Everything comes from the [signed apt repository](https://snstac.github.io/packages). See [Updates](../operations/updates.md).
+    Use **Cockpit > AryaOS Site > Software updates** (it keeps running even if you close the browser), or run `sudo aryaos-update apply`. Everything comes from the [signed apt repository](https://snstac.github.io/packages). See [Updates](../operations/updates.md).
 
 ??? question "How do I get logs to send to support?"
-    Generate a support bundle from **Cockpit → AryaOS Site → Support bundle**, or run `sudo aryaos-support-bundle`. Secrets are automatically redacted. See [Support bundles](../operations/support-bundles.md).
+    Generate a support bundle from **Cockpit > AryaOS Site > Support bundle**, or run `sudo aryaos-support-bundle`. Secrets are automatically redacted. See [Support bundles](../operations/support-bundles.md).
 
 ??? question "Do I have to use SSH?"
     No. Everything is available from the Cockpit web admin. SSH is optional and hardened (no root login, `fail2ban`). See [CLI helpers](../reference/cli-helpers.md).
 
 ??? question "How do I secure the Node-RED editor?"
-    Rotate its default admin password immediately — the editor can run arbitrary code. Use **Cockpit → AryaOS Site → Node-RED admin password** or `aryaos-set-nodered-password`. See [Node-RED dashboard](../node-red.md).
+    Rotate its default admin password immediately - the editor can run arbitrary code. Use **Cockpit > AryaOS Site > Node-RED admin password** or `aryaos-set-nodered-password`. See [Node-RED dashboard](../node-red.md).
 
 ??? question "How do I reach the device remotely?"
-    Join it to Tailscale from **Cockpit → AryaOS Site → VPN**. See [VPN (Tailscale)](../networking/vpn-tailscale.md).
+    Join it to Tailscale from **Cockpit > AryaOS Site > VPN**. See [VPN (Tailscale)](../networking/vpn-tailscale.md).
 
 ??? question "Can I connect over Bluetooth instead of Wi-Fi?"
     Yes. AryaOS runs a Bluetooth PAN (`10.44.0.1/24`); pair a phone and reach AryaOS services over the PAN link. See [Bluetooth PAN](../bluetooth-pan.md).
@@ -68,8 +68,8 @@ Short answers to the questions we hear most, each linking to the page with the f
 
 <div class="grid cards" markdown>
 
-- :material-help-circle: **Troubleshooting** — When something is broken. [Troubleshooting](../troubleshooting.md)
-- :material-book-open: **Glossary** — Terms and acronyms. [Glossary](../reference/glossary.md)
-- :material-rocket-launch: **Get started** — From zero to first track. [Overview](../get-started/overview.md)
+- :material-help-circle: **Troubleshooting** - When something is broken. [Troubleshooting](../troubleshooting.md)
+- :material-book-open: **Glossary** - Terms and acronyms. [Glossary](../reference/glossary.md)
+- :material-rocket-launch: **Get started** - From zero to first track. [Overview](../get-started/overview.md)
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,12 +10,12 @@ hide:
 
 AryaOS turns an inexpensive single-board computer into a turn-key gateway that
 puts live aircraft, vessels, and drones onto any [TAK](reference/glossary.md#tak)
-device — ATAK, WinTAK, iTAK, or a TAK Server — with no cloud, no subscription,
+device - ATAK, WinTAK, iTAK, or a TAK Server - with no cloud, no subscription,
 and no command line required. Sensors in, [Cursor on Target](reference/glossary.md#cot)
 out, managed entirely from a touch-friendly web console.
 
 ADS-B and UAT aircraft, AIS vessels, drone Remote ID over Wi-Fi and Bluetooth,
-DJI DroneID, APRS, and your own GPS position — on one box, in one picture.
+DJI DroneID, APRS, and your own GPS position - on one box, in one picture.
 
 [Get started in 15 minutes](get-started/quickstart.md){ .md-button .md-button--primary }
 [What is AryaOS?](get-started/overview.md){ .md-button }
@@ -30,7 +30,7 @@ DJI DroneID, APRS, and your own GPS position — on one box, in one picture.
 
     ---
 
-    Display ADS-B and UAT air traffic in TAK. The original AirTAK use case —
+    Display ADS-B and UAT air traffic in TAK. The original AirTAK use case -
     proven in wildland fire and SAR.
 
     [:octicons-arrow-right-24: Aircraft (ADS-B)](deploy/air-adsb.md)
@@ -47,7 +47,7 @@ DJI DroneID, APRS, and your own GPS position — on one box, in one picture.
 
     ---
 
-    Detect and track drones by Remote ID — over Wi-Fi *and* over Bluetooth — plus
+    Detect and track drones by Remote ID - over Wi-Fi *and* over Bluetooth - plus
     DJI DroneID. Reports the aircraft and the operator's location.
 
     [:octicons-arrow-right-24: Counter-UAS](deploy/counter-uas.md)
@@ -56,7 +56,7 @@ DJI DroneID, APRS, and your own GPS position — on one box, in one picture.
 
     ---
 
-    Fuse air, maritime, and drone feeds into one picture — or relay CoT between
+    Fuse air, maritime, and drone feeds into one picture - or relay CoT between
     networks and a TAK Server.
 
     [:octicons-arrow-right-24: Multi-sensor](deploy/multi-sensor.md)
@@ -65,22 +65,22 @@ DJI DroneID, APRS, and your own GPS position — on one box, in one picture.
 
 ## What it can hear
 
-Capabilities are named after the signal, not after a product — `adsb`, `ais`,
+Capabilities are named after the signal, not after a product - `adsb`, `ais`,
 `wifi-rid`, `ble-rid`, `rid`, `dji`, `sik`, `sapient`. They are exactly the names
 you type, the names the box reports, and the names on the map.
 
 The image ships with every sensor **switched off**; on first boot the box works
 out what is actually plugged in and enables what it finds, then reports anything
-it could do but did not turn on. Mix them freely — it will tell you when two
+it could do but did not turn on. Mix them freely - it will tell you when two
 capabilities want the same radio.
 
 | Capability | Enable with | What appears on the map | Hardware needed |
 |------------|-------------|-------------------------|-----------------|
-| **ADS-B / UAT** | `adsb` | Crewed aircraft on 1090 MHz and 978 MHz | **SDR** — RTL-SDR, or any SoapySDR device |
+| **ADS-B / UAT** | `adsb` | Crewed aircraft on 1090 MHz and 978 MHz | **SDR** - RTL-SDR, or any SoapySDR device |
 | **AIS** | `ais` | Ships and vessels | dAISy NMEA receiver, or a spare **SDR** |
-| **Remote ID** — Wi-Fi | `wifi-rid` | ASTM F3411 Remote ID over 802.11, plus operator location | Monitor-mode Wi-Fi adapter (e.g. Atheros AR9271) |
-| **Remote ID** — Bluetooth | `ble-rid` | ASTM F3411 Remote ID over Bluetooth LE | **None** — the board's own radio |
-| **Remote ID** — receiver | `rid` | Remote ID via a dedicated receiver, over **MAVLink** | BlueMark DroneScout DS110 |
+| **Remote ID** - Wi-Fi | `wifi-rid` | ASTM F3411 Remote ID over 802.11, plus operator location | Monitor-mode Wi-Fi adapter (e.g. Atheros AR9271) |
+| **Remote ID** - Bluetooth | `ble-rid` | ASTM F3411 Remote ID over Bluetooth LE | **None** - the board's own radio |
+| **Remote ID** - receiver | `rid` | Remote ID via a dedicated receiver, over **MAVLink** | BlueMark DroneScout DS110 |
 | **DJI DroneID** | `dji` | DJI aircraft and the pilot's position | AntSDR E200 |
 | **MAVLink telemetry** | `sik` | Drone telemetry from a SiK radio | SiK / SiKW00F radio |
 | **SAPIENT C-UAS** | `sapient` | Counter-UAS sensors speaking BSI Flex 335 | Networked sensor |
@@ -109,7 +109,7 @@ Two things are **not** capabilities, because they are not optional receivers:
     ---
 
     Write AryaOS to a microSD card with AryaOS Imager, which fetches the image
-    for you — or Raspberry Pi Imager or Etcher.
+    for you - or Raspberry Pi Imager or Etcher.
 
     [:octicons-arrow-right-24: Flash the image](get-started/flash-the-image.md)
 
@@ -117,7 +117,7 @@ Two things are **not** capabilities, because they are not optional receivers:
 
     ---
 
-    Everything is configurable from the browser — no SSH needed.
+    Everything is configurable from the browser - no SSH needed.
 
     [:octicons-arrow-right-24: Tour the web console](admin/index.md)
 
@@ -138,7 +138,7 @@ Two things are **not** capabilities, because they are not optional receivers:
 - **Never touch a terminal.** Network, radios, TAK certificates, VPN, updates,
   device role, and diagnostics all live in the web console.
 - **Quiet by default.** A stock image ships with every sensor disabled and only starts
-  what the attached hardware supports, so a box with no radios is a working TAK node —
+  what the attached hardware supports, so a box with no radios is a working TAK node -
   not a wall of errors.
 - **Built on open standards.** Every gateway is powered by
   [PyTAK](reference/glossary.md#pytak) and speaks Cursor on Target to the whole

--- a/docs/networking/emcon.md
+++ b/docs/networking/emcon.md
@@ -3,9 +3,9 @@
 An AryaOS box has two onboard radios that emit RF: **Wi-Fi** (the `aryaos-xxxx`
 onboarding hotspot, and any Wi-Fi client link) and **Bluetooth** (the PAN
 onboarding path). For low-probability-of-intercept / low-probability-of-detection
-(**LPI/LPD**) operation you often want to silence them — or just turn off the
+(**LPI/LPD**) operation you often want to silence them - or just turn off the
 Wi-Fi hotspot once a unit is fielded on ethernet. The `aryaos-radio` helper and
-the **Radios** controls in Cockpit → AryaOS Site do both.
+the **Radios** controls in Cockpit > AryaOS Site do both.
 
 !!! info "Wired ethernet is never affected"
     EMCON and the AP controls only touch the *onboard radios*. The wired
@@ -19,7 +19,7 @@ at all. Disabling the hotspot stops the broadcast and keeps it off across reboot
 
 === "In Cockpit"
 
-    **AryaOS Site → Radios → Wi-Fi hotspot → Disable.** Re-enable from the same
+    **AryaOS Site > Radios > Wi-Fi hotspot > Disable.** Re-enable from the same
     card.
 
 === "From the shell"
@@ -37,13 +37,13 @@ entirely, use EMCON below.
 ## EMCON (radio silence)
 
 EMCON blocks **both Wi-Fi and Bluetooth** at the `rfkill` level, so the onboard
-radios stop transmitting entirely. The block **persists across reboots** — a flag
+radios stop transmitting entirely. The block **persists across reboots** - a flag
 at `/etc/aryaos/emcon` is re-applied at boot by `aryaos-radio-silence.service`
 before the network stack comes up, so an EMCON box never emits RF on boot.
 
 === "In Cockpit"
 
-    **AryaOS Site → Radios → EMCON / radio silence → On.** The hotspot drops and
+    **AryaOS Site > Radios > EMCON / radio silence > On.** The hotspot drops and
     the Wi-Fi/Bluetooth adapters go dark. Toggle **Off** to restore.
 
 === "From the shell"
@@ -55,7 +55,7 @@ before the network stack comes up, so an EMCON box never emits RF on boot.
     ```
 
 !!! warning "SDR receivers are not silenced by EMCON"
-    Software-defined radios (ADS-B/AIS/drone dongles) are **receive-only** — they
+    Software-defined radios (ADS-B/AIS/drone dongles) are **receive-only** - they
     do not transmit, so they present no emissions signature and EMCON leaves them
     running. If you want them powered down anyway, stop their services (e.g.
     `sudo systemctl stop adsbcot dronecot`) or unplug them.
@@ -66,7 +66,7 @@ Independent of EMCON, AryaOS **never bridges or routes** a wireless onboarding
 client onto the wired ethernet. The firewalld default zone ships with no
 intra-zone forwarding, so a device connected to the `aryaos-xxxx` hotspot (or the
 Bluetooth PAN) can reach the box's own onboarding/admin services **but is never
-routed to `eth0` or the upstream network** — even if `net.ipv4.ip_forward` is
+routed to `eth0` or the upstream network** - even if `net.ipv4.ip_forward` is
 enabled on the host (Docker, for example, turns it on). See
 [Firewall](firewall.md) for the zone details.
 
@@ -74,8 +74,8 @@ enabled on the host (Docker, for example, turns it on). See
 
 <div class="grid cards" markdown>
 
-- :material-wifi: **Wi-Fi & onboarding** — the hotspot and how a box joins Wi-Fi. [Wi-Fi & onboarding hotspot](wifi-hotspot.md)
-- :material-wall-fire: **Firewall** — the zone allowlist and AP/PAN isolation. [Firewall](firewall.md)
-- :material-radio-tower: **Radios & SDRs** — SDR dongle management. [Radios & SDRs](../config/radios-sdr.md)
+- :material-wifi: **Wi-Fi & onboarding** - the hotspot and how a box joins Wi-Fi. [Wi-Fi & onboarding hotspot](wifi-hotspot.md)
+- :material-wall-fire: **Firewall** - the zone allowlist and AP/PAN isolation. [Firewall](firewall.md)
+- :material-radio-tower: **Radios & SDRs** - SDR dongle management. [Radios & SDRs](../config/radios-sdr.md)
 
 </div>

--- a/docs/networking/firewall.md
+++ b/docs/networking/firewall.md
@@ -13,14 +13,14 @@ implicitly accepted by firewalld.
 
 | Service | Port(s) | Purpose |
 | --- | --- | --- |
-| `ssh` | 22/tcp | SSH administration (sshd hardened — see [Security](../security.md)). |
+| `ssh` | 22/tcp | SSH administration (sshd hardened - see [Security](../security.md)). |
 | `http` | 80/tcp | Web portal (lighttpd) and Cockpit proxy. |
 | `https` | 443/tcp | TLS portal; lighttpd terminates TLS and proxies `/admin` to Cockpit. |
 | `mdns` | 5353/udp | mDNS/ZeroConf so the box is findable as `aryaos-xxxx.local`. |
-| `dhcp` | 67/udp | DHCP leases — served only while the comitup hotspot runs; also leases [Bluetooth PAN](../bluetooth-pan.md) clients. |
+| `dhcp` | 67/udp | DHCP leases - served only while the comitup hotspot runs; also leases [Bluetooth PAN](../bluetooth-pan.md) clients. |
 | `dhcpv6-client` | 546/udp | DHCPv6 client. |
-| `dns` | 53/tcp+udp | DNS — answered only while the comitup onboarding hotspot is up (dnsmasq is not otherwise active). |
-| `aryaos-mesh-sa` | 6969/udp | TAK **Mesh SA** multicast — Charontak egress/ingress and `aryaos-neighbord` on `239.2.3.1:6969`. |
+| `dns` | 53/tcp+udp | DNS - answered only while the comitup onboarding hotspot is up (dnsmasq is not otherwise active). |
+| `aryaos-mesh-sa` | 6969/udp | TAK **Mesh SA** multicast - Charontak egress/ingress and `aryaos-neighbord` on `239.2.3.1:6969`. |
 | `aryaos-node-red` | 1880/tcp | Node-RED low-code editor and dashboards (admin API is `adminAuth`-protected). |
 | `aryaos-ais-catcher` | 8100/tcp | AIS-catcher live map / statistics dashboard. |
 | `aryaos-comitup` | 9080/tcp | Comitup captive Wi-Fi onboarding portal (listens only in hotspot mode). |
@@ -48,7 +48,7 @@ the box's own services (the allowlist above) but is **never routed or bridged
 onto `eth0` or the upstream network.**
 
 Because the rule is enforced in the firewall's `FORWARD` path, it holds **even
-when `net.ipv4.ip_forward` is enabled** on the host — which happens whenever
+when `net.ipv4.ip_forward` is enabled** on the host - which happens whenever
 Docker is running. Without this, a hotspot client could otherwise be routed
 straight onto the wired LAN. Docker's own container networking is unaffected (it
 lives in a separate `docker` zone with its own forwarding rules).
@@ -64,7 +64,7 @@ The AntSDR point-to-point link (`eth1`, `aryaos-antsdr.nmconnection`) is placed
 in firewalld's **`trusted`** zone rather than the default `AryaOS` zone, so the
 drone-detection sensor can reach the dronecot listener over that dedicated
 cable without you poking a hole in the field-facing allowlist. This is a private
-sensor link, not a general network — treat the `trusted` zone as reserved for
+sensor link, not a general network - treat the `trusted` zone as reserved for
 it.
 
 !!! info "Docker-published ports are separate"
@@ -74,9 +74,9 @@ it.
 
 ## Manage the firewall in Cockpit
 
-Everything is editable from the browser — no shell needed.
+Everything is editable from the browser - no shell needed.
 
-1. Open **Cockpit → Networking → Firewall**.
+1. Open **Cockpit > Networking > Firewall**.
 2. The active zone (`AryaOS`) lists its allowed services. Toggle a service off
    to close its ports, or on to reopen them.
 3. Add a service (below) to open a new capability.
@@ -92,7 +92,7 @@ Say you want to expose a new dashboard on TCP `8200`.
 
 === "In Cockpit"
 
-    1. Open **Cockpit → Networking → Firewall**.
+    1. Open **Cockpit > Networking > Firewall**.
     2. Click **Add services** on the `AryaOS` zone.
     3. Pick a predefined service, or choose **Custom ports** and enter
        `8200/tcp`.
@@ -131,9 +131,9 @@ Say you want to expose a new dashboard on TCP `8200`.
 
 <div class="grid cards" markdown>
 
-- :material-lan: **Ports & protocols** — the full port reference. [Ports & protocols](../reference/ports.md)
-- :material-shield-lock: **Security posture** — sshd, fail2ban, sysctl, TLS. [Security posture](../security.md)
-- :material-wifi: **Wi-Fi & onboarding** — why `9080`/DHCP/DNS come and go. [Wi-Fi & onboarding hotspot](wifi-hotspot.md)
-- :material-access-point-network: **Nearby nodes** — the Mesh SA `6969/udp` traffic. [Nearby nodes](../operations/neighbors.md)
+- :material-lan: **Ports & protocols** - the full port reference. [Ports & protocols](../reference/ports.md)
+- :material-shield-lock: **Security posture** - sshd, fail2ban, sysctl, TLS. [Security posture](../security.md)
+- :material-wifi: **Wi-Fi & onboarding** - why `9080`/DHCP/DNS come and go. [Wi-Fi & onboarding hotspot](wifi-hotspot.md)
+- :material-access-point-network: **Nearby nodes** - the Mesh SA `6969/udp` traffic. [Nearby nodes](../operations/neighbors.md)
 
 </div>

--- a/docs/networking/vpn-tailscale.md
+++ b/docs/networking/vpn-tailscale.md
@@ -1,7 +1,7 @@
 # VPN (Tailscale)
 
 AryaOS ships with [Tailscale](https://tailscale.com/) so you can reach a fielded
-unit from anywhere — no port forwarding, no public IP, no firewall holes. Join
+unit from anywhere - no port forwarding, no public IP, no firewall holes. Join
 the box to your tailnet from the browser and it becomes reachable by its
 tailnet name from any other device you own.
 
@@ -11,7 +11,7 @@ Field units live behind whatever network they can get: a base-camp router, a
 vehicle hotspot, a cellular modem doing carrier-grade NAT. None of those let you
 open an inbound port to the box. Tailscale builds an encrypted WireGuard mesh
 between your devices, so the AryaOS unit dials *out* to the coordination service
-and you connect to it by name — the same whether it's on the next bench or a
+and you connect to it by name - the same whether it's on the next bench or a
 ridge 200 miles away.
 
 !!! info "Tailscale is already in the image"
@@ -21,7 +21,7 @@ ridge 200 miles away.
 
 !!! warning "Tailscale is remote access, not a replacement for hardening"
     A tailnet reaches Cockpit, SSH, and the sensor dashboards on the box. Keep
-    the rest of the [security posture](../security.md) in place — rotate the
+    the rest of the [security posture](../security.md) in place - rotate the
     [Node-RED admin password](../admin/aryaos-site.md), let the
     [default password expire](../security.md), and only invite trusted devices
     to your tailnet.
@@ -29,7 +29,7 @@ ridge 200 miles away.
 ## Connect from Cockpit
 
 Everything happens in the **VPN (Tailscale)** card on
-**Cockpit → AryaOS Site**. The card reads `tailscale status --json` and shows
+**Cockpit > AryaOS Site**. The card reads `tailscale status --json` and shows
 one of a few states, then offers the matching action.
 
 ```mermaid
@@ -51,18 +51,18 @@ stateDiagram-v2
 
 ### First-time connect
 
-1. Open **Cockpit → AryaOS Site → VPN (Tailscale)**.
+1. Open **Cockpit > AryaOS Site > VPN (Tailscale)**.
 2. If you see *Tailscale daemon not running*, click **Start Tailscale service**.
 3. Click **Connect (get login link)**. The card runs `tailscale up` and waits
    for a login URL.
-4. A one-time link of the form `https://login.tailscale.com/…` appears in the
+4. A one-time link of the form `https://login.tailscale.com/...` appears in the
    card. **Open it on any device already signed in to your tailnet** and
    approve the node.
 5. The card flips to **Running** and shows the node's tailnet IP address. The
    box is now reachable from your other tailnet devices.
 
 !!! tip "Authorize from your phone"
-    You don't have to authorize the link on the box itself — that's the point.
+    You don't have to authorize the link on the box itself - that's the point.
     Copy the login link to a phone or laptop that's already signed in to your
     tailnet, approve it there, and the field unit joins. Click **Cancel login**
     in the card if you change your mind before authorizing.
@@ -70,7 +70,7 @@ stateDiagram-v2
 ### Disconnect or leave the tailnet
 
 - **Disconnect** (`tailscale down`) drops the WireGuard link but keeps the node
-  enrolled — reconnect later without a new login link.
+  enrolled - reconnect later without a new login link.
 - **Log out of tailnet** (`tailscale logout`) removes the enrollment entirely.
   The node must get a **new** login link to rejoin. Use this before handing a
   unit to someone else or standing it down.
@@ -80,9 +80,9 @@ stateDiagram-v2
 Once the node is **Running**, use its tailnet identity from any of your
 signed-in devices:
 
-- **Tailnet IP** — shown in the VPN card (a `100.x.y.z` address). Cockpit is at
+- **Tailnet IP** - shown in the VPN card (a `100.x.y.z` address). Cockpit is at
   `https://100.x.y.z:9090/`.
-- **MagicDNS name** — if MagicDNS is enabled on your tailnet, the box is
+- **MagicDNS name** - if MagicDNS is enabled on your tailnet, the box is
   reachable by its hostname (`aryaos-xxxx`) with no IP to remember. Enable
   MagicDNS in the Tailscale admin console; it is a tailnet-wide setting, not an
   AryaOS one.
@@ -96,9 +96,9 @@ signed-in devices:
 
 <div class="grid cards" markdown>
 
-- :material-wifi: **Wi-Fi & onboarding** — get the box onto a network first. [Wi-Fi & onboarding hotspot](wifi-hotspot.md)
-- :material-wall-fire: **Firewall** — what's exposed on the box. [Firewall](firewall.md)
-- :material-shield-lock: **Security posture** — the full hardening picture. [Security posture](../security.md)
-- :material-tune: **AryaOS Site** — the admin page hosting the VPN card. [AryaOS Site](../admin/aryaos-site.md)
+- :material-wifi: **Wi-Fi & onboarding** - get the box onto a network first. [Wi-Fi & onboarding hotspot](wifi-hotspot.md)
+- :material-wall-fire: **Firewall** - what's exposed on the box. [Firewall](firewall.md)
+- :material-shield-lock: **Security posture** - the full hardening picture. [Security posture](../security.md)
+- :material-tune: **AryaOS Site** - the admin page hosting the VPN card. [AryaOS Site](../admin/aryaos-site.md)
 
 </div>

--- a/docs/networking/wifi-hotspot.md
+++ b/docs/networking/wifi-hotspot.md
@@ -24,10 +24,10 @@ stateDiagram-v2
     CONNECTED --> HOTSPOT: known Wi-Fi disappears
 ```
 
-- **`CONNECTED`** — the box has joined a Wi-Fi network it has credentials for
+- **`CONNECTED`** - the box has joined a Wi-Fi network it has credentials for
   and behaves as a normal client. The onboarding portal is not served in this
   state.
-- **`HOTSPOT`** — no known network is in range, so the box broadcasts its own
+- **`HOTSPOT`** - no known network is in range, so the box broadcasts its own
   access point named **`AryaOS-xxxx`** (the `xxxx` is the per-device suffix set
   at first boot, matching the hostname `aryaos-xxxx`). Connect to that AP and
   the onboarding portal appears so you can hand the box a network.
@@ -37,7 +37,7 @@ stateDiagram-v2
     at first boot and uses it for the hostname (`aryaos-xxxx`) and the hotspot
     SSID (`AryaOS-xxxx`). Comitup fills the `<nnn>` token in `ap_name` from its
     own persistent instance number, so the exact SSID is printed on the box's
-    label — trust the label.
+    label - trust the label.
 
 ## Configuration
 
@@ -46,15 +46,15 @@ Comitup is configured in `/etc/comitup.conf`. The keys AryaOS sets:
 | Key | Value | Meaning |
 | --- | --- | --- |
 | `ap_name` | `AryaOS-<nnn>` | Hotspot SSID and ZeroConf host name. `<nnn>` is a persistent per-device number. |
-| `ap_password` | *(unset by default)* | If set, the hotspot uses WPA2 (`WPA-psk`) and requires this password. Must be **8–63 characters**. |
+| `ap_password` | *(unset by default)* | If set, the hotspot uses WPA2 (`WPA-psk`) and requires this password. Must be **8-63 characters**. |
 | `primary_wifi_device` | `wlan0` | The Wi-Fi adapter used to spawn the access point. |
 | `external_callback` | `/usr/local/sbin/comitup-callback.sh` | Script run on every state change (`HOTSPOT` / `CONNECTING` / `CONNECTED`) so AryaOS can react (for example, toggle onboarding services). |
 | `enable_appliance_mode` | `false` | AryaOS does not chain a second adapter or NAT hotspot clients to the internet. |
 
 !!! warning "The hotspot is open by default"
-    Out of the box, `ap_password` is unset, so **anyone in range can join the
+    By default, `ap_password` is unset, so **anyone in range can join the
     onboarding hotspot and reach the portal**. Set a WPA2 password before
-    fielding a unit in any area where that matters — see
+    fielding a unit in any area where that matters - see
     [Set a hotspot password](#set-a-hotspot-password) below.
 
 ## Join the box to an existing Wi-Fi
@@ -75,7 +75,7 @@ example, a base-camp router or a vehicle hotspot).
 
 !!! tip "You lose the hotspot once it connects"
     When the box successfully joins your Wi-Fi, the `AryaOS-xxxx` hotspot goes
-    away — that is expected. Find the unit again by its hostname
+    away - that is expected. Find the unit again by its hostname
     (`aryaos-xxxx.local` via mDNS) or by the IP address your router hands it,
     then administer it in [Cockpit](../admin/aryaos-site.md).
 
@@ -93,24 +93,24 @@ service (see [Firewall](firewall.md)); comitup itself stops listening once the
 box has joined a network.
 
 Because it accepts credentials, treat the onboarding portal like any other
-admin surface — do onboarding somewhere you control, and keep the hotspot
+admin surface - do onboarding somewhere you control, and keep the hotspot
 password set (below) so a stranger can't reach the portal in the first place.
 
 ## Set a hotspot password
 
-Protect the onboarding hotspot with a WPA2 pre-shared key from Cockpit — no
+Protect the onboarding hotspot with a WPA2 pre-shared key from Cockpit - no
 shell required.
 
 === "In Cockpit (recommended)"
 
-    1. Open **Cockpit → AryaOS Site**.
+    1. Open **Cockpit > AryaOS Site**.
     2. Scroll to the **Onboarding hotspot password** card.
-    3. Type a password of **8–63 characters** into *Hotspot password* and click
+    3. Type a password of **8-63 characters** into *Hotspot password* and click
        **Save hotspot password**.
     4. To go back to an open AP, click **Remove password (open AP)** and confirm.
 
     The card writes the `ap_password` key into `/etc/comitup.conf`. The new
-    password applies to the *next* hotspot session — **reboot** (or restart
+    password applies to the *next* hotspot session - **reboot** (or restart
     comitup) to force it to take effect immediately.
 
 === "Edit the config file"
@@ -128,7 +128,7 @@ shell required.
     ```
 
 !!! danger "Passwords under 8 or over 63 characters are rejected"
-    WPA2 pre-shared keys must be 8–63 characters. The Cockpit field enforces
+    WPA2 pre-shared keys must be 8-63 characters. The Cockpit field enforces
     this (`minlength="8" maxlength="63"`); if you edit the file by hand, stay in
     range or comitup will refuse to bring up a protected AP.
 
@@ -136,9 +136,9 @@ shell required.
 
 <div class="grid cards" markdown>
 
-- :material-bluetooth: **Bluetooth PAN** — reach the box with no Wi-Fi at all. [Bluetooth PAN](../bluetooth-pan.md)
-- :material-wall-fire: **Firewall** — which inbound ports (including `9080`) are open. [Firewall](firewall.md)
-- :material-vpn: **VPN (Tailscale)** — remote access once the box is on a network. [VPN (Tailscale)](vpn-tailscale.md)
-- :material-shield-lock: **Security posture** — the full hardening picture. [Security posture](../security.md)
+- :material-bluetooth: **Bluetooth PAN** - reach the box with no Wi-Fi at all. [Bluetooth PAN](../bluetooth-pan.md)
+- :material-wall-fire: **Firewall** - which inbound ports (including `9080`) are open. [Firewall](firewall.md)
+- :material-vpn: **VPN (Tailscale)** - remote access once the box is on a network. [VPN (Tailscale)](vpn-tailscale.md)
+- :material-shield-lock: **Security posture** - the full hardening picture. [Security posture](../security.md)
 
 </div>

--- a/docs/node-red.md
+++ b/docs/node-red.md
@@ -1,13 +1,13 @@
 # Node-RED
 
 AryaOS ships [Node-RED](https://nodered.org/) as an **optional** low-code
-automation surface — it is **not required for any AryaOS functionality**. It
+automation surface - it is **not required for any AryaOS functionality**. It
 boots with **empty flows** and is **not the admin surface** (that's Cockpit).
 
 ## Accessing it
 
 Node-RED binds **loopback only** and is served behind the box's HTTPS reverse
-proxy — the flow editor is at **`https://<host>/nr/`** (accept the self-signed
+proxy - the flow editor is at **`https://<host>/nr/`** (accept the self-signed
 cert). It is **not** reachable on `:1880` over the LAN; the public firewall zone
 no longer opens the Node-RED port, so the editor (which can run code on the
 device) is not exposed as walk-up attack surface. For remote access, reach
@@ -15,30 +15,30 @@ device) is not exposed as walk-up attack surface. For remote access, reach
 
 !!! warning "Set a strong Node-RED admin password before fielding a unit"
     The editor can run code on the device. Set a unique password from **AryaOS
-    Site → Node-RED admin password** (see [AryaOS Site](admin/aryaos-site.md)) or
+    Site > Node-RED admin password** (see [AryaOS Site](admin/aryaos-site.md)) or
     with `sudo aryaos-set-nodered-password`.
 
 ## Optional legacy flows
 
 The previous AryaOS demo flows (dashboard, Mesh SA map, TFR/recorder helpers)
 are **no longer loaded by default**. The bundle still ships at
-`/home/node-red/.node-red/aryaos_flows.json` — import it by hand from the editor
-(**Menu → Import**) if you want those flows.
+`/home/node-red/.node-red/aryaos_flows.json` - import it by hand from the editor
+(**Menu > Import**) if you want those flows.
 
 ## Node-RED is not the admin surface
 
 Earlier AryaOS builds used Node-RED to edit configuration. That role has moved
-entirely to the [web console](admin/index.md) — Node-RED is now for
+entirely to the [web console](admin/index.md) - Node-RED is now for
 visualization and custom automation only. Configure the system here instead:
 
 | Need | Where |
 |------|-------|
 | Site TAK destination, TLS, role, updates | [AryaOS Site page](admin/aryaos-site.md) |
 | Where CoT flows (Mesh SA / TAK Server) | [Charontak lane editor](admin/charontak-lanes.md) |
-| Per-sensor settings | [Gateway pages](admin/gateways.md) → `/etc/default/<svc>` |
+| Per-sensor settings | [Gateway pages](admin/gateways.md) > `/etc/default/<svc>` |
 | SDR serials & decoder | [Radios & SDRs](config/radios-sdr.md) |
 | Wi-Fi / hotspot | [Wi-Fi & onboarding hotspot](networking/wifi-hotspot.md) |
-| Services (start/stop/restart) | Cockpit → Services, or each gateway page |
+| Services (start/stop/restart) | Cockpit > Services, or each gateway page |
 
 ## Security
 

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -3,14 +3,14 @@
 An AryaOS box holds a lot of hard-won state: your site config, the sensor
 role, charontak lanes, TAK client certificates, saved Wi-Fi networks, and the
 Node-RED flows. The `aryaos-config-backup` helper packs all of it into one
-restorable tarball — so you can snapshot a working unit before a change, or
+restorable tarball - so you can snapshot a working unit before a change, or
 migrate a whole configuration onto a replacement box in minutes.
 
 ## Make a backup
 
 === "In Cockpit (recommended)"
 
-    1. Open **Cockpit → AryaOS Site → Backup & restore**.
+    1. Open **Cockpit > AryaOS Site > Backup & restore**.
     2. Click **Create backup**. AryaOS packs the config set into a tarball on
        the box and lists it under existing backups.
     3. Download it to your machine to keep a copy off the unit.
@@ -53,7 +53,7 @@ genuine AryaOS backup.
     keys, NetworkManager Wi-Fi PSKs, and Node-RED credentials.** Anyone holding
     that archive can impersonate the unit and its TAK connection. AryaOS writes
     every archive **`0600` root** and keeps the directory `0700`, but once you
-    copy it off the box it is your responsibility — **store full backups
+    copy it off the box it is your responsibility - **store full backups
     securely.**
 
     For a copy you can safely share (attach to a ticket, hand to a teammate,
@@ -67,7 +67,7 @@ Backups are written to **`/var/lib/aryaos/backups/`** as
 `aryaos-config_<hostname>_<timestamp>.tar.gz`.
 
 - Each archive is mode **`0600`** (root-only) and the directory is `0700`.
-- Only the **five newest** backups are kept — older ones are pruned
+- Only the **five newest** backups are kept - older ones are pruned
   automatically each time you create a new one.
 - The most recent backup's path and size are recorded in
   `/var/lib/aryaos/config-backup.json`, which is how the Cockpit card lists it.
@@ -76,7 +76,7 @@ Backups are written to **`/var/lib/aryaos/backups/`** as
 
 === "In Cockpit"
 
-    Open **Cockpit → AryaOS Site → Backup & restore**, pick a backup, and
+    Open **Cockpit > AryaOS Site > Backup & restore**, pick a backup, and
     click **Restore**. The card confirms with you first, then unpacks the
     archive and restarts the affected services.
 
@@ -96,7 +96,7 @@ permissions and ownership, runs `systemctl daemon-reload`, and does a
 `adsbcot`, `dronecot`) plus `lighttpd`.
 
 !!! warning "Restore is additive"
-    Restore *overlays* the backed-up files onto the device — it brings back
+    Restore *overlays* the backed-up files onto the device - it brings back
     everything in the archive but does **not** remove files created since the
     backup (for example, a TAK certificate uploaded afterwards stays in place).
     If you need an exact return to the backed-up state, do a
@@ -116,7 +116,7 @@ permissions and ownership, runs `systemctl daemon-reload`, and does a
 Backups are the fast path when hardware fails or you're swapping a fielded unit:
 
 1. On the **old box** (or from your last saved backup), make a **full** backup
-   and download it — you want the TAK certs and Wi-Fi PSKs, so *do not* use
+   and download it - you want the TAK certs and Wi-Fi PSKs, so *do not* use
    `--no-secrets` here.
 2. Flash AryaOS onto the **replacement box** and let it complete first boot.
 3. Copy the archive onto the new box (over SSH or the
@@ -135,9 +135,9 @@ Backups are the fast path when hardware fails or you're swapping a fielded unit:
 
 <div class="grid cards" markdown>
 
-- :material-backup-restore: **Factory reset** — clear config back to defaults (back up first). [Factory reset](./factory-reset.md)
-- :material-nuke: **Zeroize** — securely sanitize a box for decommission. [Zeroize](./zeroize.md)
-- :material-console: **CLI helpers** — the full `aryaos-config-backup` reference. [CLI helpers](../reference/cli-helpers.md#aryaos-config-backup)
-- :material-tune: **AryaOS Site** — the admin page hosting the backup card. [AryaOS Site](../admin/aryaos-site.md)
+- :material-backup-restore: **Factory reset** - clear config back to defaults (back up first). [Factory reset](./factory-reset.md)
+- :material-nuke: **Zeroize** - securely sanitize a box for decommission. [Zeroize](./zeroize.md)
+- :material-console: **CLI helpers** - the full `aryaos-config-backup` reference. [CLI helpers](../reference/cli-helpers.md#aryaos-config-backup)
+- :material-tune: **AryaOS Site** - the admin page hosting the backup card. [AryaOS Site](../admin/aryaos-site.md)
 
 </div>

--- a/docs/operations/factory-reset.md
+++ b/docs/operations/factory-reset.md
@@ -3,45 +3,45 @@
 A **factory reset** returns a box to its just-flashed, pre-first-boot state
 without re-flashing the media. It's the clean-slate button: hand a unit to a
 new operator, recover from a botched configuration, or repurpose a box for a
-different mission — all without touching the OS or reinstalling packages.
+different mission - all without touching the OS or reinstalling packages.
 
 !!! info "This is not a secure wipe"
     Factory reset restores config and clears identity; it does **not** securely
     erase anything from the media. To sanitize a box for decommission or before
     it leaves your control, use **[Zeroize](./zeroize.md)** instead.
 
-## What it does — and doesn't
+## What it does - and doesn't
 
 === "What it clears"
 
-    - **Site config** — restores `/etc/aryaos/aryaos-config.txt` and
+    - **Site config** - restores `/etc/aryaos/aryaos-config.txt` and
       `/etc/charontak.ini` from the packaged defaults in
       `/usr/share/aryaos/defaults`; resets `issue`, `issue.net`, and `motd`.
-    - **Per-gateway `/etc/default/<svc>`** — reinstalled to package defaults
+    - **Per-gateway `/etc/default/<svc>`** - reinstalled to package defaults
       **when online** (via `apt-get --reinstall`). Offline, these are left as-is
-      — reset again online to restore them.
-    - **Operator-uploaded TAK certificates** — deletes the files under
+      - reset again online to restore them.
+    - **Operator-uploaded TAK certificates** - deletes the files under
       `/etc/aryaos/tls`, `/etc/charontak/tls`, and the per-gateway `tls`
       directories (the directories themselves are kept).
-    - **Device identity** — removes the machine-id and firstboot markers so
+    - **Device identity** - removes the machine-id and firstboot markers so
       `aryaos-firstboot` re-runs: the box gets a **new**
       [`DEVICE_SUFFIX`](../reference/glossary.md#device_suffix), hostname, and
       per-device web TLS certificate on the next boot, and the login password is
       re-expired.
-    - **Local state** — drops update, support-bundle, and config-backup state
+    - **Local state** - drops update, support-bundle, and config-backup state
       JSON that referenced the old identity.
 
 === "What it keeps"
 
-    - **The OS and all installed packages** — nothing is uninstalled or
+    - **The OS and all installed packages** - nothing is uninstalled or
       re-flashed.
-    - **The network connection, by default** — saved Wi-Fi/NetworkManager
+    - **The network connection, by default** - saved Wi-Fi/NetworkManager
       connections and the onboarding hotspot password are **preserved** unless
       you pass `--wipe-network`, so a remote box isn't stranded off the network
       after a reset. (The AntSDR point-to-point link is always kept.)
 
 After the reset the box **reboots into first-boot setup**, exactly like a
-freshly flashed image — first boot re-derives identity and regenerates the web
+freshly flashed image - first boot re-derives identity and regenerates the web
 TLS certificate.
 
 ## When to use it
@@ -52,15 +52,15 @@ TLS certificate.
 
 !!! warning "Back up first"
     A factory reset overwrites your site config and deletes uploaded TAK
-    certs. If there's any chance you'll want the current setup again — or want
-    to move it to a replacement box — make a
+    certs. If there's any chance you'll want the current setup again - or want
+    to move it to a replacement box - make a
     [backup](./backup-restore.md) first.
 
 ## How to run it
 
 === "In Cockpit (recommended)"
 
-    1. Open **Cockpit → AryaOS Site → Factory reset**.
+    1. Open **Cockpit > AryaOS Site > Factory reset**.
     2. Read the confirmation, which lists what will be cleared, and confirm.
     3. The card runs the reset (`--service`) and the box reboots into first-boot
        setup.
@@ -85,7 +85,7 @@ TLS certificate.
     | *(none)* | Reset config + identity, **keep** the network, prompt, then reboot. |
     | `--wipe-network` | Also remove saved Wi-Fi/NetworkManager connections and the hotspot password (box reverts to open onboarding). |
     | `--service` | Non-interactive (used by the Cockpit card, which already confirmed). |
-    | `--no-reboot` | Do the reset but don't reboot — for testing. |
+    | `--no-reboot` | Do the reset but don't reboot - for testing. |
 
 ## Factory reset vs. zeroize
 
@@ -108,9 +108,9 @@ If the box is going somewhere you don't control, use
 
 <div class="grid cards" markdown>
 
-- :material-content-save: **Back up & restore** — snapshot config before you reset. [Back up & restore](./backup-restore.md)
-- :material-nuke: **Zeroize** — the secure-erase counterpart for decommission. [Zeroize](./zeroize.md)
-- :material-console: **CLI helpers** — the full `aryaos-factory-reset` reference. [CLI helpers](../reference/cli-helpers.md#aryaos-factory-reset)
-- :material-restart: **First boot** — what the box does when it comes back up. [First boot & first login](../get-started/first-boot.md)
+- :material-content-save: **Back up & restore** - snapshot config before you reset. [Back up & restore](./backup-restore.md)
+- :material-nuke: **Zeroize** - the secure-erase counterpart for decommission. [Zeroize](./zeroize.md)
+- :material-console: **CLI helpers** - the full `aryaos-factory-reset` reference. [CLI helpers](../reference/cli-helpers.md#aryaos-factory-reset)
+- :material-restart: **First boot** - what the box does when it comes back up. [First boot & first login](../get-started/first-boot.md)
 
 </div>

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -5,7 +5,7 @@ season, an exercise, or a search-and-rescue callout is the day-2 job. This
 section covers the routine operations: keeping units patched, diagnosing them
 when something's off, and letting them find each other on the mesh.
 
-## Day-2 at a glance
+## Day-2 operations
 
 ```mermaid
 flowchart LR
@@ -17,14 +17,14 @@ flowchart LR
     M -.-> N[aryaos-neighbord]
 ```
 
-- **Keep updated** — apply patches from the signed snstac repo with one click.
+- **Keep updated** - apply patches from the signed snstac repo with one click.
   Debian security fixes land automatically; the sensor stack is a deliberate,
   operator-driven decision so you never restart a sensor mid-operation by
   surprise.
-- **Diagnose** — when a unit misbehaves in the field, generate a redacted
+- **Diagnose** - when a unit misbehaves in the field, generate a redacted
   support bundle and attach it to a report instead of trying to describe the
   problem over the radio.
-- **Monitor** — every AryaOS box beacons itself on Mesh SA, so any unit's
+- **Monitor** - every AryaOS box beacons itself on Mesh SA, so any unit's
   *Nearby nodes* card shows the rest of the fleet, their roles, health, and a
   direct admin link.
 
@@ -32,11 +32,11 @@ flowchart LR
 
 <div class="grid cards" markdown>
 
-- :material-update: **Updates** — one-click patching from the signed snstac apt repo; what's automatic and what isn't. [Updates](updates.md)
-- :material-briefcase-search: **Support bundles** — redacted diagnostics for field reports; exactly what's collected and redacted. [Support bundles](support-bundles.md)
-- :material-file-certificate: **SBOM & supply chain** — SPDX + CycloneDX for every image build, and the signed-repo trust anchor. [SBOM & supply chain](sbom.md)
-- :material-access-point-network: **Nearby nodes** — Mesh SA self-discovery so a fleet finds itself. [Nearby nodes](neighbors.md)
-- :material-shield-lock: **Security posture** — the hardening every operation rests on. [Security posture](../security.md)
+- :material-update: **Updates** - one-click patching from the signed snstac apt repo; what's automatic and what isn't. [Updates](updates.md)
+- :material-briefcase-search: **Support bundles** - redacted diagnostics for field reports; exactly what's collected and redacted. [Support bundles](support-bundles.md)
+- :material-file-certificate: **SBOM & supply chain** - SPDX + CycloneDX for every image build, and the signed-repo trust anchor. [SBOM & supply chain](sbom.md)
+- :material-access-point-network: **Nearby nodes** - Mesh SA self-discovery so a fleet finds itself. [Nearby nodes](neighbors.md)
+- :material-shield-lock: **Security posture** - the hardening every operation rests on. [Security posture](../security.md)
 
 </div>
 
@@ -44,16 +44,16 @@ flowchart LR
 
 <div class="grid cards" markdown>
 
-- :material-sd: **Install media longevity** — the write-avoidance tuning that keeps SD/NVMe media alive; on by default, nothing to configure. [Install media longevity](media-longevity.md)
-- :material-content-save: **Back up & restore** — snapshot the full config set and migrate it to a replacement box. [Back up & restore](backup-restore.md)
-- :material-backup-restore: **Factory reset** — return a box to its just-flashed state without re-flashing. [Factory reset](factory-reset.md)
-- :material-nuke: **Zeroize** — best-effort secure sanitize for decommission or capture. [Zeroize](zeroize.md)
+- :material-sd: **Install media longevity** - the write-avoidance tuning that keeps SD/NVMe media alive; on by default, nothing to configure. [Install media longevity](media-longevity.md)
+- :material-content-save: **Back up & restore** - snapshot the full config set and migrate it to a replacement box. [Back up & restore](backup-restore.md)
+- :material-backup-restore: **Factory reset** - return a box to its just-flashed state without re-flashing. [Factory reset](factory-reset.md)
+- :material-nuke: **Zeroize** - best-effort secure sanitize for decommission or capture. [Zeroize](zeroize.md)
 
 </div>
 
 !!! tip "Most of this lives on one page"
     Software updates, support bundles, the Node-RED admin password, and the
-    nearby-nodes list are all cards on **Cockpit → [AryaOS Site](../admin/aryaos-site.md)** —
+    nearby-nodes list are all cards on **Cockpit > [AryaOS Site](../admin/aryaos-site.md)** -
     one browser page you can drive with gloves on. The pages in this section
     explain what each card does under the hood.
 
@@ -61,13 +61,13 @@ flowchart LR
     Node-RED ships with a publicly known default admin password and its editor
     can run code on the device. Rotate it from the **Node-RED admin password**
     control on the [AryaOS Site](../admin/aryaos-site.md) page before a unit
-    leaves the bench — see [Security posture](../security.md).
+    leaves the bench - see [Security posture](../security.md).
 
 ## Remote and disconnected operations
 
 Not every unit is within arm's reach:
 
-- **Remote units** — reach a fielded box from anywhere over the
+- **Remote units** - reach a fielded box from anywhere over the
   [Tailscale VPN](../networking/vpn-tailscale.md); no port forwarding required.
-- **No-network units** — administer a box over a
+- **No-network units** - administer a box over a
   [Bluetooth PAN](../bluetooth-pan.md) link when there's no Wi-Fi or Ethernet.

--- a/docs/operations/media-longevity.md
+++ b/docs/operations/media-longevity.md
@@ -1,22 +1,22 @@
 # Install media longevity
 
 AryaOS runs from flash: a microSD card, eMMC, or an NVMe SSD. Flash media wears
-out by *writing* — every block has a finite number of program/erase cycles, and
+out by *writing* - every block has a finite number of program/erase cycles, and
 a chatty Linux install (swap, logs, atime updates) can burn through a cheap SD
 card in a single fire season. AryaOS is tuned from the factory to write to the
 install media as little as possible, so a fielded box survives.
 
-There is **nothing to configure** — the tuning below is on by default in every
+There is **nothing to configure** - the tuning below is on by default in every
 image.
 
 ## What AryaOS does by default
 
 | Technique | What it saves |
 | --- | --- |
-| **`dphys-swapfile` disabled + zram swap** | No swapfile writes ever hit the SD/NVMe. Swap lives in RAM instead (`zstd`-compressed, sized `min(ram / 2, 4096)` MB), so a memory spike from multi-SDR + Node-RED + containers still can't OOM-kill a service — and it costs zero media writes. |
+| **`dphys-swapfile` disabled + zram swap** | No swapfile writes ever hit the SD/NVMe. Swap lives in RAM instead (`zstd`-compressed, sized `min(ram / 2, 4096)` MB), so a memory spike from multi-SDR + Node-RED + containers still can't OOM-kill a service - and it costs zero media writes. |
 | **journald volatile (logs in RAM)** | The systemd journal is stored in RAM, not on disk, so the constant log churn from a running sensor stack never touches the media. |
 | **tmpfs for `/tmp`, `/var/tmp`, `/var/log`** | These write-heavy directories are RAM-backed tmpfs mounts (`/tmp` and `/var/tmp` capped at 100 MB, `/var/log` at 50 MB). Scratch files and logs live and die in memory. |
-| **`noatime` on the root filesystem** | Reading a file no longer triggers a metadata *write* to update its access time — a huge, invisible source of wear on a busy box. |
+| **`noatime` on the root filesystem** | Reading a file no longer triggers a metadata *write* to update its access time - a huge, invisible source of wear on a busy box. |
 | **Weekly `fstrim` (TRIM)** | `fstrim.timer` is enabled, so the filesystem periodically tells the flash controller which blocks are free. That keeps wear-leveling effective and sustains write performance over the life of the card. |
 
 !!! info "zram is swap in RAM, not on disk"
@@ -35,7 +35,7 @@ persistent on-disk history.
 
 !!! tip "Capture logs before they're gone"
     If you need the logs from a misbehaving unit, grab them *while the problem
-    is happening* — generate a [support bundle](./support-bundles.md), which
+    is happening* - generate a [support bundle](./support-bundles.md), which
     snapshots the current journal into a redacted tarball you can attach to a
     field report. A reboot clears the RAM journal, so fresh is always better.
 
@@ -46,7 +46,7 @@ itself matters:
 
 === "SNS-supplied boxes (NVMe/eMMC)"
 
-    The hardware Sensors & Signals sells runs from **NVMe SSD or eMMC** —
+    The hardware Sensors & Signals sells runs from **NVMe SSD or eMMC** -
     endurance-rated flash with a real controller and far higher write budgets
     than an SD card. Combined with the write-avoidance tuning, these units are
     built to run continuously for years. TRIM (`fstrim.timer`) keeps NVMe write
@@ -75,8 +75,8 @@ itself matters:
 
 <div class="grid cards" markdown>
 
-- :material-briefcase-search: **Support bundles** — capture the RAM-only journal before a reboot loses it. [Support bundles](./support-bundles.md)
-- :material-content-save: **Back up & restore** — persist your *configuration* off the box (config, not logs). [Back up & restore](./backup-restore.md)
-- :material-cart: **Buy hardware** — the NVMe/eMMC boxes built for continuous field use. [Buy hardware](../purchase.md)
+- :material-briefcase-search: **Support bundles** - capture the RAM-only journal before a reboot loses it. [Support bundles](./support-bundles.md)
+- :material-content-save: **Back up & restore** - persist your *configuration* off the box (config, not logs). [Back up & restore](./backup-restore.md)
+- :material-cart: **Buy hardware** - the NVMe/eMMC boxes built for continuous field use. [Buy hardware](../purchase.md)
 
 </div>

--- a/docs/operations/neighbors.md
+++ b/docs/operations/neighbors.md
@@ -1,7 +1,7 @@
 # Nearby nodes
 
 An AryaOS fleet finds itself. Every unit quietly beacons its identity on the TAK
-Mesh SA multicast group, and every unit listens for the others — so any box's
+Mesh SA multicast group, and every unit listens for the others - so any box's
 **Nearby AryaOS nodes** card shows the rest of the fleet, their roles, health,
 position, and a one-click admin link. No central server, no manual inventory.
 
@@ -9,17 +9,17 @@ position, and a one-click admin link. No central server, no manual inventory.
 
 The `aryaos-neighbord` daemon runs on each box and does two things at once on
 the Mesh SA group **`239.2.3.1:6969`** (the same multicast lane Charontak uses
-for Situational Awareness — see [Firewall](../networking/firewall.md)):
+for Situational Awareness - see [Firewall](../networking/firewall.md)):
 
-- **Beacon** — periodically it multicasts a small Cursor on Target (CoT) event
+- **Beacon** - periodically it multicasts a small Cursor on Target (CoT) event
   describing itself: hostname, roles, health, and GPS position (from `gpsd`,
   falling back to a no-fix marker).
-- **Listen** — it joins the multicast group and, for every AryaOS beacon it
+- **Listen** - it joins the multicast group and, for every AryaOS beacon it
   hears, records the neighbor into a local cache with the time it was last seen.
 
 ```mermaid
 flowchart LR
-    subgraph mesh["Mesh SA — 239.2.3.1:6969"]
+    subgraph mesh["Mesh SA - 239.2.3.1:6969"]
       direction LR
       A[aryaos-alpha] -- beacon --> M(( ))
       B[aryaos-bravo] -- beacon --> M
@@ -34,7 +34,7 @@ flowchart LR
 
 The cache is written to **`/run/aryaos/neighbors.json`** (world-readable,
 `0644`, on tmpfs so it never persists across reboots). Entries carry a
-**time-to-live of 240 seconds** — a neighbor that stops beaconing ages out of
+**time-to-live of 240 seconds** - a neighbor that stops beaconing ages out of
 the list, so what you see is what's currently alive on the mesh.
 
 !!! info "It's just CoT on the SA lane"
@@ -45,21 +45,21 @@ the list, so what you see is what's currently alive on the mesh.
 
 ## The Nearby AryaOS nodes card
 
-The **Nearby AryaOS nodes** card on **Cockpit → AryaOS Site** reads
+The **Nearby AryaOS nodes** card on **Cockpit > AryaOS Site** reads
 `/run/aryaos/neighbors.json` (via the `aryaos-neighbors` CGI endpoint) and
 refreshes every few seconds. Each heard node is one row:
 
 | Column | Shows | Source |
 | --- | --- | --- |
 | **Node** | The neighbor's hostname (`aryaos-xxxx`), or its UID / source IP if the name is unknown. | beacon `host` |
-| **Roles** | Which sensor pipelines it runs — e.g. `ADS-B / AIS / UAS`, or `base` if none. | beacon `roles` |
+| **Roles** | Which sensor pipelines it runs - e.g. `ADS-B / AIS / UAS`, or `base` if none. | beacon `roles` |
 | **Health** | System load, memory %, CPU temperature, and active/total service count (e.g. `load 0.42 \| mem 61% \| 47 C \| 8/9 svc`). | beacon `system` / `services` |
-| **Position** | Latitude, longitude — or `no fix` when GPS has no lock. | beacon `point` |
+| **Position** | Latitude, longitude - or `no fix` when GPS has no lock. | beacon `point` |
 | **Seen** | How long ago the node was last heard (`12s`, `3m`, `1h`). | cache `age_s` |
 | **Admin** | An **Open** link straight to that node's Cockpit, when it advertises one. | beacon `host.admin_url` |
 
 The summary line reports how many nodes are currently heard on Mesh SA; if none
-are, it shows *"Listening for AryaOS CoT beacons…"* — which usually just means
+are, it shows *"Listening for AryaOS CoT beacons..."* - which usually just means
 you're the only unit on the mesh right now.
 
 !!! tip "Jump straight to a neighbor's Cockpit"
@@ -70,27 +70,27 @@ you're the only unit on the mesh right now.
 
 ## Using it to run a fleet
 
-- **Muster check** — glance at the card to confirm every unit you deployed is up
+- **Muster check** - glance at the card to confirm every unit you deployed is up
   and beaconing. A missing node either dropped off the mesh or aged past its
   240-second TTL.
-- **Triage** — the **Health** column surfaces load, memory, temperature, and
-  failed services at a glance; the **Position** column tells you where each unit
+- **Triage** - the **Health** column lists load, memory, temperature, and
+  failed services; the **Position** column tells you where each unit
   physically is. Spot the unhealthy one, click **Open**, and dig in.
-- **Coverage** — because roles are shown per node, you can see at a glance that
-  your air, maritime, and drone coverage are all present on the mesh.
+- **Coverage** - roles shown per node confirm whether air, maritime, and drone
+  coverage are present on the mesh.
 
 !!! note "Discovery is read-only and low-cost"
     Beacons are tiny CoT events sent about once a minute with a multicast TTL of
     1, and the cache lives on tmpfs. Neighbor discovery doesn't move sensor data
-    or reconfigure anything — it only tells you who else is out there.
+    or reconfigure anything - it only tells you who else is out there.
 
 ## Related
 
 <div class="grid cards" markdown>
 
-- :material-wall-fire: **Firewall** — the Mesh SA `6969/udp` rule this rides on. [Firewall](../networking/firewall.md)
-- :material-tune: **AryaOS Site** — the admin page hosting the nearby-nodes card. [AryaOS Site](../admin/aryaos-site.md)
-- :material-briefcase-search: **Support bundles** — the neighbor cache is included for diagnostics. [Support bundles](support-bundles.md)
-- :material-view-grid: **Operating a fleet** — the day-2 overview. [Operating a fleet](index.md)
+- :material-wall-fire: **Firewall** - the Mesh SA `6969/udp` rule this rides on. [Firewall](../networking/firewall.md)
+- :material-tune: **AryaOS Site** - the admin page hosting the nearby-nodes card. [AryaOS Site](../admin/aryaos-site.md)
+- :material-briefcase-search: **Support bundles** - the neighbor cache is included for diagnostics. [Support bundles](support-bundles.md)
+- :material-view-grid: **Operating a fleet** - the day-2 overview. [Operating a fleet](index.md)
 
 </div>

--- a/docs/operations/nvme-boot.md
+++ b/docs/operations/nvme-boot.md
@@ -1,12 +1,12 @@
 # Boot from NVMe
 
-AryaOS boots from a **microSD card** by default. On hardware with an NVMe slot — the Waveshare
-PoE M.2 HAT+, other M.2 HATs, or SNS-supplied boxes — you can run AryaOS from an **NVMe SSD**
+AryaOS boots from a **microSD card** by default. On hardware with an NVMe slot - the Waveshare
+PoE M.2 HAT+, other M.2 HATs, or SNS-supplied boxes - you can run AryaOS from an **NVMe SSD**
 instead, which is far more endurance-friendly for continuous field use (see
 [Media longevity](media-longevity.md)) and noticeably faster.
 
 Booting from NVMe is a **Raspberry Pi bootloader change**, not something the AryaOS image does
-for you — the steps below are one-time, per unit.
+for you - the steps below are one-time, per unit.
 
 ## 1. Fit the drive
 
@@ -28,9 +28,9 @@ SD install to the NVMe on the box:
 
 ```bash
 lsblk                              # confirm the NVMe is /dev/nvme0n1
-# Option A — clone the running SD card to NVMe:
+# Option A - clone the running SD card to NVMe:
 sudo rpi-clone nvme0n1             # if rpi-clone is available
-# Option B — write a downloaded image (see the OS image backup card in Cockpit):
+# Option B - write a downloaded image (see the OS image backup card in Cockpit):
 sudo sh -c 'xzcat /var/lib/aryaos/image/*.img.xz > /dev/nvme0n1'
 ```
 
@@ -49,7 +49,7 @@ BOOT_ORDER=0xf416
 ```
 
 Boot-order digits are read right-to-left: `6`=NVMe, `1`=SD, `4`=USB, `f`=retry. `0xf416` means
-**NVMe → SD → USB → repeat**, so a box with no NVMe still falls back to the SD card. Reboot.
+**NVMe > SD > USB > repeat**, so a box with no NVMe still falls back to the SD card. Reboot.
 
 ## 4. Verify
 
@@ -59,14 +59,14 @@ rpi-eeprom-config | grep BOOT_ORDER
 ```
 
 !!! warning "Power headroom"
-    NVMe adds roughly **2–4&nbsp;W** on the PCIe link. On a marginal supply — a 5V/3A brick, or
-    a PoE HAT fed from plain **802.3af** — adding NVMe (plus SDRs) can tip the box into a
+    NVMe adds roughly **2-4&nbsp;W** on the PCIe link. On a marginal supply - a 5V/3A brick, or
+    a PoE HAT fed from plain **802.3af** - adding NVMe (plus SDRs) can tip the box into a
     brownout. Pair NVMe boot with a proper **5V/5A (27&nbsp;W)** supply or a true **PoE+
     (802.3at)** source. AryaOS surfaces under-voltage via power-health and falls back to
     [safe mode](../get-started/hardware.md#safe-mode) if it crash-loops. See
-    [Hardware & requirements](../get-started/hardware.md#power--battery-for-backpack-ops).
+    [Hardware & requirements](../get-started/hardware.md#power-battery-for-backpack-ops).
 
 ## See also
 
-- [Media longevity](media-longevity.md) — why NVMe/eMMC beats SD for continuous use
-- [OS image backup](backup-restore.md) — pulling the unit's own `.img` to re-flash
+- [Media longevity](media-longevity.md) - why NVMe/eMMC beats SD for continuous use
+- [OS image backup](backup-restore.md) - pulling the unit's own `.img` to re-flash

--- a/docs/operations/sbom.md
+++ b/docs/operations/sbom.md
@@ -1,7 +1,7 @@
 # SBOM & supply chain
 
-Every AryaOS image build emits a **Software Bill of Materials (SBOM)** — a
-machine-readable inventory of everything installed in the image — in both SPDX
+Every AryaOS image build emits a **Software Bill of Materials (SBOM)** - a
+machine-readable inventory of everything installed in the image - in both SPDX
 and CycloneDX formats, attached to the GitHub Release. This page explains what
 an SBOM is, why it matters for government deployments, and how to fetch and read
 one.
@@ -14,18 +14,18 @@ label for the OS image. When a new vulnerability is announced against some
 library, an SBOM lets you answer *"is that library in our fielded units, and at
 what version?"* in seconds instead of guessing.
 
-!!! info "Why AryaOS ships one — the government context"
+!!! info "Why AryaOS ships one - the government context"
     AryaOS is funded by the Colorado Center of Excellence and the USDA Forest
     Service and is deployed on wildland fire and other public-safety missions.
     US federal guidance (Executive Order 14028 and the NTIA minimum elements)
     directs agencies to obtain SBOMs for the software they field. Shipping an
-    SBOM with every image is table stakes for that context — and it's simply
-    good supply-chain hygiene for anyone.
+    An SBOM is required in that context and provides a useful software inventory
+    for every deployment.
 
 ## What each build produces
 
-The SBOM covers the **full rootfs** of the loop-mounted image — Debian packages,
-Python site-packages, and the Node-RED npm tree — generated with
+The SBOM covers the **full rootfs** of the loop-mounted image - Debian packages,
+Python site-packages, and the Node-RED npm tree - generated with
 [syft](https://github.com/anchore/syft) by `scripts/generate-sbom.sh`:
 
 | File | Format | Notes |
@@ -81,14 +81,14 @@ grype sbom:aryaos.cdx.json
     # writes out/aryaos.spdx.json and out/aryaos.cdx.json
     ```
 
-    It loop-mounts the image read-only and runs syft over the rootfs — set
+    It loop-mounts the image read-only and runs syft over the rootfs - set
     `SYFT_BIN` to point at a specific syft binary if it isn't on `PATH`.
 
 ## The trust anchor
 
 An SBOM tells you *what* is installed; the signed apt repository tells you it
-came from a source you trust. AryaOS installs every package — at build time and
-during [updates](updates.md) — from the **GPG-signed snstac apt repository**,
+came from a source you trust. AryaOS installs every package - at build time and
+during [updates](updates.md) - from the **GPG-signed snstac apt repository**,
 [`https://snstac.github.io/packages`](https://snstac.github.io/packages). A unit
 only installs packages it can cryptographically verify came from Sensors &
 Signals, and the SBOM lets you audit exactly what those packages were.
@@ -97,8 +97,8 @@ Signals, and the SBOM lets you audit exactly what those packages were.
 
 <div class="grid cards" markdown>
 
-- :material-update: **Updates** — the signed repo in the update path. [Updates](updates.md)
-- :material-shield-lock: **Security posture** — image verification and the broader trust story. [Security posture](../security.md)
-- :material-briefcase-search: **Support bundles** — capture the installed-package state from a live unit. [Support bundles](support-bundles.md)
+- :material-update: **Updates** - the signed repo in the update path. [Updates](updates.md)
+- :material-shield-lock: **Security posture** - image verification and the broader trust story. [Security posture](../security.md)
+- :material-briefcase-search: **Support bundles** - capture the installed-package state from a live unit. [Support bundles](support-bundles.md)
 
 </div>

--- a/docs/operations/support-bundles.md
+++ b/docs/operations/support-bundles.md
@@ -1,8 +1,8 @@
 # Support bundles
 
 When a fielded unit misbehaves, generate a **support bundle**: one redacted
-tarball with everything a troubleshooter needs — system state, service status,
-recent logs, network and firewall state, and sensor configs — with passwords,
+tarball with everything a troubleshooter needs - system state, service status,
+recent logs, network and firewall state, and sensor configs - with passwords,
 tokens, and enrollment credentials stripped out. Attach it to a field report
 instead of describing the problem over the radio.
 
@@ -10,7 +10,7 @@ instead of describing the problem over the radio.
 
 === "In Cockpit (recommended)"
 
-    1. Open **Cockpit → AryaOS Site → Support bundle**.
+    1. Open **Cockpit > AryaOS Site > Support bundle**.
     2. Click **Generate support bundle**. AryaOS collects diagnostics and packs
        them into a tarball.
     3. Click **Download** to save the `.tar.gz` to your machine, then attach it
@@ -43,10 +43,10 @@ failing command is noted rather than aborting the bundle.
 | **Services** | `systemctl --failed`, plus per-unit `systemctl status` for the sensor gateways and infrastructure units. |
 | **Journals** | The last 4000 lines of this boot's journal, plus per-unit logs (last 500 lines each) for the sensor gateways, `readsb`, and `gpsd`. |
 | **Network** | `ip addr` / `ip route`, `resolv.conf`, `nmcli device status`, firewalld state and all zones, and listening sockets (`ss -tulnp`). |
-| **Configs (redacted)** | Site config `aryaos-config.txt`, `charontak.ini`, and each gateway's `/etc/default/<svc>` — passed through the redactor. |
+| **Configs (redacted)** | Site config `aryaos-config.txt`, `charontak.ini`, and each gateway's `/etc/default/<svc>` - passed through the redactor. |
 | **Sensor snapshots** | A capped `aircraft.json` (ADS-B), the neighbor cache `neighbors.json`, and a short `gpsd` sample. |
 
-## What's redacted — and what's never included
+## What's redacted - and what's never included
 
 This is the part to be sure of before you send a bundle to anyone.
 
@@ -54,14 +54,14 @@ This is the part to be sure of before you send a bundle to anyone.
     - Any config value whose key matches
       **`PASSWORD` / `TOKEN` / `SECRET` / `PASSPHRASE` / `PSK`** is replaced with
       `[REDACTED]` before the file goes into the bundle.
-    - `tak://` enrollment credentials — the `token=` and `username=` fields in
-      TAK enrollment URLs — are redacted the same way.
+    - `tak://` enrollment credentials - the `token=` and `username=` fields in
+      TAK enrollment URLs - are redacted the same way.
     - **No private key material is ever included.** Nothing from
       `/etc/aryaos/tls` or `/etc/charontak/tls` (client certificates, keys, CA
       material) is copied into the bundle at all.
 
-In short: the bundle carries the *shape* of your configuration — which services
-run, how they're wired, what's failing — without the credentials that would let
+In short: the bundle carries the *shape* of your configuration - which services
+run, how they're wired, what's failing - without the credentials that would let
 someone impersonate the unit or its TAK connection.
 
 !!! tip "Sanity-check with your eyes"
@@ -79,7 +79,7 @@ Bundles are written to **`/var/lib/aryaos/support/`** as
 `aryaos-support_<hostname>_<timestamp>.tar.gz`.
 
 - Each bundle file is mode **`0600`** (root-only) and the directory is `0700`.
-- Only the **three newest** bundles are kept — older ones are pruned
+- Only the **three newest** bundles are kept - older ones are pruned
   automatically each time you generate a new one.
 - The most recent bundle's path and size are recorded in
   `/var/lib/aryaos/support-bundle.json`, which is how the Cockpit card offers
@@ -88,7 +88,7 @@ Bundles are written to **`/var/lib/aryaos/support/`** as
 !!! note "Download over an admin channel"
     The Cockpit **Download** button pulls the file over your existing
     authenticated Cockpit session. If you copy a bundle off the box by hand
-    (`scp`, etc.), do it over SSH or the [VPN](../networking/vpn-tailscale.md) —
+    (`scp`, etc.), do it over SSH or the [VPN](../networking/vpn-tailscale.md) -
     the file is redacted, but it still describes your deployment.
 
 ## Attaching to a field report
@@ -103,9 +103,9 @@ Bundles are written to **`/var/lib/aryaos/support/`** as
 
 <div class="grid cards" markdown>
 
-- :material-update: **Updates** — rule out a stale build before deep-diving. [Updates](updates.md)
-- :material-shield-lock: **Security posture** — the redaction policy in the wider hardening picture. [Security posture](../security.md)
-- :material-access-point-network: **Nearby nodes** — check the rest of the fleet's health. [Nearby nodes](neighbors.md)
-- :material-tune: **AryaOS Site** — the admin page hosting the support-bundle card. [AryaOS Site](../admin/aryaos-site.md)
+- :material-update: **Updates** - rule out a stale build before deep-diving. [Updates](updates.md)
+- :material-shield-lock: **Security posture** - the redaction policy in the wider hardening picture. [Security posture](../security.md)
+- :material-access-point-network: **Nearby nodes** - check the rest of the fleet's health. [Nearby nodes](neighbors.md)
+- :material-tune: **AryaOS Site** - the admin page hosting the support-bundle card. [AryaOS Site](../admin/aryaos-site.md)
 
 </div>

--- a/docs/operations/updates.md
+++ b/docs/operations/updates.md
@@ -6,14 +6,14 @@ closed browser, and never restart your sensors without you saying so.
 
 ## One-click updates in Cockpit
 
-The **Software updates** card on **Cockpit → AryaOS Site** is the operator path.
+The **Software updates** card on **Cockpit > AryaOS Site** is the operator path.
 
-1. Open **Cockpit → AryaOS Site → Software updates**.
+1. Open **Cockpit > AryaOS Site > Software updates**.
 2. Click **Check for updates**. The card shows the current AryaOS version and
    lists every upgradable package (with current and candidate versions).
 3. Click **Install all updates**. Sensor services may restart briefly while the
    upgrade applies.
-4. If a reboot is required afterward, the card tells you — reboot at a
+4. If a reboot is required afterward, the card tells you - reboot at a
    convenient time.
 
 ```mermaid
@@ -28,7 +28,7 @@ flowchart LR
 
 !!! tip "The upgrade survives a closed browser"
     The card starts the apply step under **`aryaos-update.service`**, not inside
-    the browser session. Close the tab, lose Wi-Fi, walk away — the upgrade
+    the browser session. Close the tab, lose Wi-Fi, walk away - the upgrade
     keeps running on the box, and the card picks the result back up when you
     return.
 
@@ -84,7 +84,7 @@ sudo aryaos-update status    # last check/apply results + reboot-required (JSON)
     upgrade ran from the browser or the shell.
 
 !!! warning "`apply` requires root"
-    `aryaos-update` refuses to run its privileged subcommands as a normal user —
+    `aryaos-update` refuses to run its privileged subcommands as a normal user -
     always `sudo aryaos-update apply`. The Cockpit card handles privilege for
     you.
 
@@ -92,9 +92,9 @@ sudo aryaos-update status    # last check/apply results + reboot-required (JSON)
 
 <div class="grid cards" markdown>
 
-- :material-file-certificate: **SBOM & supply chain** — the signed-repo trust anchor and per-build SBOMs. [SBOM & supply chain](sbom.md)
-- :material-shield-lock: **Security posture** — how the update split fits the hardening story. [Security posture](../security.md)
-- :material-briefcase-search: **Support bundles** — capture state if an update goes sideways. [Support bundles](support-bundles.md)
-- :material-tune: **AryaOS Site** — the admin page hosting the updates card. [AryaOS Site](../admin/aryaos-site.md)
+- :material-file-certificate: **SBOM & supply chain** - the signed-repo trust anchor and per-build SBOMs. [SBOM & supply chain](sbom.md)
+- :material-shield-lock: **Security posture** - how the update split fits the hardening story. [Security posture](../security.md)
+- :material-briefcase-search: **Support bundles** - capture state if an update goes sideways. [Support bundles](support-bundles.md)
+- :material-tune: **AryaOS Site** - the admin page hosting the updates card. [AryaOS Site](../admin/aryaos-site.md)
 
 </div>

--- a/docs/operations/zeroize.md
+++ b/docs/operations/zeroize.md
@@ -3,29 +3,29 @@
 **Zeroize** removes and overwrites every secret, credential, key, log, recorded
 track, and identity on the box, then TRIMs and overwrites free space and
 reboots to a clean first-boot state. It's the control you reach for when a unit
-is being **decommissioned** or is at risk of **capture** — when what matters is
+is being **decommissioned** or is at risk of **capture** - when what matters is
 that nothing sensitive can be recovered from it, not that it stays configured.
 
 The box is **not bricked.** After a zeroize it reboots into a clean first-boot
-state and is fully usable again — it just has no more secrets on it.
+state and is fully usable again - it just has no more secrets on it.
 
-!!! danger "Flash-media limitation — read this before you rely on zeroize"
+!!! danger "Flash-media limitation - read this before you rely on zeroize"
     On flash media (microSD, eMMC, NVMe) **wear-leveling means overwriting a
     file or free space does *not* guarantee the prior contents are
     unrecoverable.** The controller may have written your data elsewhere, and
     the old physical blocks can persist beyond software's reach.
 
     Zeroize removes secrets, shreds their current blocks, issues TRIM, and
-    overwrites free space as a **best effort** — nothing more. It is honest
+    overwrites free space as a **best effort** - nothing more. It is honest
     hygiene, not a hardware guarantee.
 
     **For a hard guarantee, you need one of:**
 
-    - **Full-disk encryption with key destruction (crypto-erase)** — if the data
+    - **Full-disk encryption with key destruction (crypto-erase)** - if the data
       was only ever written encrypted, destroying the key makes it unrecoverable
       regardless of where the controller put the ciphertext. *(Full-disk
       encryption is on the AryaOS roadmap as the stronger sanitization path.)*
-    - **Physical destruction of the media** — the only unconditional guarantee.
+    - **Physical destruction of the media** - the only unconditional guarantee.
 
     Treat zeroize as the software best-effort layer, not a substitute for
     crypto-erase or physical destruction when the threat model demands
@@ -34,7 +34,7 @@ state and is fully usable again — it just has no more secrets on it.
 ## What gets erased
 
 Zeroize (`/usr/local/sbin/aryaos-zeroize`) shreds each file (single pass +
-zero — multi-pass is pointless on flash), then removes it. In order, it wipes:
+zero - multi-pass is pointless on flash), then removes it. In order, it wipes:
 
 | Category | What is destroyed |
 | --- | --- |
@@ -43,23 +43,23 @@ zero — multi-pass is pointless on flash), then removes it. In order, it wipes:
 | **VPN state** | `tailscale logout`, then `/var/lib/tailscale` wiped. |
 | **Node-RED credentials** | `flows_cred.json` wiped; admin password reset to a **random, unrecorded** value (rotate it from the web console after reboot). |
 | **Recorded tracks & local files** | `/var/www/html/recorder` (recorded CoT), `/var/lib/aryaos/backups`, `/var/lib/aryaos/support`, and the state JSON files. |
-| **Saved networks** | `/etc/NetworkManager/system-connections` and the comitup hotspot password — **wiped by default** (they hold PSKs); `--keep-network` preserves them. |
+| **Saved networks** | `/etc/NetworkManager/system-connections` and the comitup hotspot password - **wiped by default** (they hold PSKs); `--keep-network` preserves them. |
 | **Site-config secrets** | Restores the packaged default `aryaos-config.txt` (no secrets) and strips any remaining `PASSWORD`/`TOKEN`/`SECRET`/`PASSPHRASE`/`PSK` lines. |
 | **Shell history & lab key** | `root` and per-user `.bash_history`; removes the `aryaos-dev-lab` key from `pi`'s `authorized_keys`. |
 | **Logs** | Rotates and vacuums journald (already RAM-volatile), then shreds anything on disk under `/var/log`. |
 | **Device identity** | Removes machine-id and firstboot markers so a **new** [`DEVICE_SUFFIX`](../reference/glossary.md#device_suffix)/hostname is derived on next boot. |
 | **Free space** | Fills each writable filesystem with zeros until full, deletes the fill, then runs `fstrim -av` to return blocks to the controller. |
 
-The free-space overwrite is the slow step — the command prints *"overwriting
-free space (this can take a while)…"* while it runs. When it finishes the box
+The free-space overwrite is the slow step - the command prints *"overwriting
+free space (this can take a while)..."* while it runs. When it finishes the box
 reboots into a clean first-boot state.
 
 ## How to run it
 
 === "In Cockpit (recommended)"
 
-    1. Open **Cockpit → AryaOS Site → Zeroize**.
-    2. The card requires you to **type a confirmation phrase** — this is
+    1. Open **Cockpit > AryaOS Site > Zeroize**.
+    2. The card requires you to **type a confirmation phrase** - this is
        destructive and irreversible, so there is no single-click path.
     3. Confirm. The card runs the wipe (`--service`), overwrites free space, and
        the box reboots clean.
@@ -83,9 +83,9 @@ reboots into a clean first-boot state.
     | Flag | Effect |
     | --- | --- |
     | *(none)* | Wipe everything, **including** saved networks, then reboot. |
-    | `--keep-network` | Preserve saved Wi-Fi/NetworkManager connections (they contain PSKs — only for a box you're keeping on your own network). |
+    | `--keep-network` | Preserve saved Wi-Fi/NetworkManager connections (they contain PSKs - only for a box you're keeping on your own network). |
     | `--service` | Non-interactive (used by the Cockpit card, which required the confirmation phrase). |
-    | `--no-reboot` | Do the wipe but don't reboot — for testing. |
+    | `--no-reboot` | Do the wipe but don't reboot - for testing. |
 
 ## Zeroize vs. factory reset
 
@@ -99,8 +99,8 @@ network by default. If the box will leave your control, use zeroize. See the
 
 <div class="grid cards" markdown>
 
-- :material-backup-restore: **Factory reset** — the non-destructive clean-slate counterpart. [Factory reset](./factory-reset.md)
-- :material-shield-lock: **Security posture** — where zeroize fits in decommissioning. [Security posture](../security.md#decommissioning)
-- :material-console: **CLI helpers** — the full `aryaos-zeroize` reference. [CLI helpers](../reference/cli-helpers.md#aryaos-zeroize)
+- :material-backup-restore: **Factory reset** - the non-destructive clean-slate counterpart. [Factory reset](./factory-reset.md)
+- :material-shield-lock: **Security posture** - where zeroize fits in decommissioning. [Security posture](../security.md#decommissioning)
+- :material-console: **CLI helpers** - the full `aryaos-zeroize` reference. [CLI helpers](../reference/cli-helpers.md#aryaos-zeroize)
 
 </div>

--- a/docs/portal.md
+++ b/docs/portal.md
@@ -30,10 +30,10 @@ flowchart LR
 
 ## Landing page features (current)
 
-- **Hero — TAK gateways:** `charontak`, `adsbcot`, `aiscot`, `lincot`, `dronecot`, `sikw00fcot` via `tak_gateways` in JSON; colored tiles (green / amber / red / gray) from `systemctl show`.
-- **Hero — system health:** CPU temp, load (1/5/15), power/throttle pill from `system` in JSON (`vcgencmd` on Pi; `/proc` + thermal sysfs fallback).
+- **Hero - TAK gateways:** `charontak`, `adsbcot`, `aiscot`, `lincot`, `dronecot`, `sikw00fcot` via `tak_gateways` in JSON; colored tiles (green / amber / red / gray) from `systemctl show`.
+- **Hero - system health:** CPU temp, load (1/5/15), power/throttle pill from `system` in JSON (`vcgencmd` on Pi; `/proc` + thermal sysfs fallback).
 - **Connection & status:** hostname, FQDN, primary IP, IPv4 block, uptime; grouped rows (`.aos-status-group--meta|net`) with left accent.
-- **GNSS:** gpsd snapshot — position, **MSL** (`alt_m`), **HAE** (`altHAE` → `alt_hae_m`), **CE/LE** (`eph` or √(epx²+epy²), `epv` → `le_m`), grid, sats, motion; status **pill** from fix quality.
+- **GNSS:** gpsd snapshot - position, **MSL** (`alt_m`), **HAE** (`altHAE` > `alt_hae_m`), **CE/LE** (`eph` or √(epx²+epy²), `epv` > `le_m`), grid, sats, motion; status **pill** from fix quality.
 - **Copy:** icon-only clipboard buttons (SVG); feedback via `.aos-copy-btn--ok` / `--fail` (do not set `textContent` on the button).
 - **Radios / RF:** table from `radios.devices` (Wi‑Fi, BT, USB SDR, decoder services).
 
@@ -42,7 +42,7 @@ flowchart LR
 | Key | Purpose |
 |-----|---------|
 | `hostname`, `fqdn`, `primary_ip`, `ipv4_text`, `uptime` | Host |
-| `gps` | GNSS (`alt_m`, `alt_hae_m`, `ce_m`, `le_m`, `epx_m`, …) |
+| `gps` | GNSS (`alt_m`, `alt_hae_m`, `ce_m`, `le_m`, `epx_m`, ...) |
 | `tak_gateways` | `{ ok, items[] }` per gateway unit (`charontak`, feeders) |
 
 Node-RED is **not** on the configuration critical path; use Cockpit and Comitup for writes (see [node-red.md](node-red.md)).
@@ -82,7 +82,7 @@ Installed in **stage-aryaos** [`00-run.sh`](https://github.com/snstac/aryaos/blo
 
 After portal/CGI edits on **`main`**, CI builds a new image; local lab can use **sync-portal-review** without waiting for CI.
 
-## Agent handoff — state as of 2026-05-16
+## Agent handoff - state as of 2026-05-16
 
 **On `main` (pushed):**
 
@@ -94,10 +94,10 @@ After portal/CGI edits on **`main`**, CI builds a new image; local lab can use *
 | `79b096e` | GNSS MSL/HAE, CE/LE, text Copy buttons |
 | `8d2304a` | Status UI polish: grouped rows, icon copy, GNSS pill, TAK tile tints |
 
-**Lab Pi (`aryaos-dev-pi` / `172.17.2.158`) — operational notes:**
+**Lab Pi (`aryaos-dev-pi` / `172.17.2.158`) - operational notes:**
 
 - **readsb:** pi-gen now runs [`readsb-install.sh`](https://github.com/snstac/aryaos/blob/main/shared_files/adsbcot/readsb-install.sh) (`RTLSDR=yes`) after the stock `.deb` and restores the AryaOS `run_readsb.sh` unit.
-- **readsb RTL serial `2002`:** `RECEIVER_OPTIONS="--device-type rtlsdr --device 2002 …"`; helper [`scripts/readsb-use-rtl-serial.sh`](https://github.com/snstac/aryaos/blob/main/scripts/readsb-use-rtl-serial.sh).
+- **readsb RTL serial `2002`:** `RECEIVER_OPTIONS="--device-type rtlsdr --device 2002 ..."`; helper [`scripts/readsb-use-rtl-serial.sh`](https://github.com/snstac/aryaos/blob/main/scripts/readsb-use-rtl-serial.sh).
 - **adsbcot** enabled; polls `file:///run/adsb/aircraft.json` (same path for readsb or dump1090-fa).
 - **USB power:** `enable-pi-usb-current.sh` applied; **reboot** if not done since append.
 - **Portal UI polish (`8d2304a`):** may **not** be on the Pi until `sync-portal-review` succeeds from a host on the lab LAN (agent environment often gets **No route to host**).
@@ -105,7 +105,7 @@ After portal/CGI edits on **`main`**, CI builds a new image; local lab can use *
 ## Next steps for agents
 
 1. **Verify portal on lab Pi** (when SSH works):  
-   `ARYAOS_SSH=aryaos-dev-pi ./scripts/sync-portal-review.sh` → open `https://<pi>/` — check TAK strip, GNSS CE/LE/HAE, icon copy, grouped status rows.
+   `ARYAOS_SSH=aryaos-dev-pi ./scripts/sync-portal-review.sh` > open `https://<pi>/` - check TAK strip, GNSS CE/LE/HAE, icon copy, grouped status rows.
 2. **Optional follow-ups (not started):**
    - RF table: per-row copy or compact state badges (v1 scope excluded icon copy on RF).
    - `adsbcot_feed_ok`: mark ADS-B chip degraded if `readsb` up but `aircraft.json` stale/empty.

--- a/docs/purchase.md
+++ b/docs/purchase.md
@@ -1,16 +1,16 @@
 # Buy hardware
 
-The fastest way to a working AryaOS gateway is the assembled, tested **AirTAK go-kit** — a turnkey box with AryaOS pre-installed. Prefer to build your own? That path is here too.
+The fastest way to a working AryaOS gateway is the assembled, tested **AirTAK go-kit** - a turnkey box with AryaOS pre-installed. Prefer to build your own? That path is here too.
 
 ## AirTAK go-kit (assembled)
 
 <div class="grid cards" markdown>
 
-- :material-cart: **Order the AirTAK go-kit** — Assembled, tested, and pre-flashed with AryaOS. [snstac.com store](https://www.snstac.com/store/p/airtak-v2)
+- :material-cart: **Order the AirTAK go-kit** - Assembled, tested, and pre-flashed with AryaOS. [snstac.com store](https://www.snstac.com/store/p/airtak-v2)
 
 </div>
 
-The AirTAK go-kit is a standalone ADS-B–to-TAK gateway you can carry in a backpack, power from a USB battery, and use with **no internet** — no LTE, no Wi-Fi backhaul. Pair any ATAK, WinTAK, or iTAK device to its hotspot and see live aircraft on the map. It is in active use by wildland fire, security, and safety and response organizations worldwide.
+The AirTAK go-kit is a standalone ADS-B-to-TAK gateway you can carry in a backpack, power from a USB battery, and use with **no internet** - no LTE, no Wi-Fi backhaul. Pair any ATAK, WinTAK, or iTAK device to its hotspot and see live aircraft on the map. It is in active use by wildland fire, security, and safety and response organizations worldwide.
 
 !!! example "Proven in the field"
     In a San Diego backpack test with no outside connectivity, this configuration achieved a **55-mile** aircraft-detection range. See the [Introduction](get-started/overview.md) for the full concept of operations.
@@ -22,14 +22,14 @@ An assembled go-kit arrives ready to run:
 - A supported Raspberry Pi with AryaOS pre-installed and personalized.
 - SDR radio(s) and a tuned ADS-B antenna.
 - A field enclosure suitable for backpack carry.
-- Everything you need to power on and pair a TAK device.
+- Power and connection hardware for pairing a TAK device.
 
 !!! tip "Turn it on and go"
     Because the go-kit ships pre-flashed, you can skip [Flash the image](get-started/flash-the-image.md) and go straight to [First boot & first login](get-started/first-boot.md) to connect and secure the unit.
 
 ## Build your own
 
-AryaOS is free and open source. If you already have a Raspberry Pi — or want a custom radio and antenna loadout for maritime, drone, or multi-sensor missions — build it yourself:
+AryaOS is free and open source. If you already have a Raspberry Pi - or want a custom radio and antenna loadout for maritime, drone, or multi-sensor missions - build it yourself:
 
 1. Gather hardware using [Hardware & requirements](get-started/hardware.md).
 2. [Flash the image](get-started/flash-the-image.md) to a microSD card.
@@ -40,9 +40,9 @@ AryaOS is free and open source. If you already have a Raspberry Pi — or want a
 
 <div class="grid cards" markdown>
 
-- :material-web: **Sensors & Signals** — Products, support, and contact. [snstac.com](https://www.snstac.com/)
-- :material-github: **Report an issue** — File bugs and feature requests. [github.com/snstac/aryaos](https://github.com/snstac/aryaos/issues)
-- :material-help-circle: **Troubleshooting** — Symptom-to-fix checks. [Troubleshooting](troubleshooting.md)
+- :material-web: **Sensors & Signals** - Products, support, and contact. [snstac.com](https://www.snstac.com/)
+- :material-github: **Report an issue** - File bugs and feature requests. [github.com/snstac/aryaos](https://github.com/snstac/aryaos/issues)
+- :material-help-circle: **Troubleshooting** - Symptom-to-fix checks. [Troubleshooting](troubleshooting.md)
 
 </div>
 

--- a/docs/reference/cli-helpers.md
+++ b/docs/reference/cli-helpers.md
@@ -1,11 +1,11 @@
 # CLI helpers
 
-AryaOS installs a small set of `aryaos-*` helper commands in `/usr/local/sbin`. These are the same actions the [AryaOS Site](../admin/aryaos-site.md) web cards run — so **SSH is optional**. Reach for the shell when you are already on the console, scripting a fleet, or want to see raw output.
+AryaOS installs a small set of `aryaos-*` helper commands in `/usr/local/sbin`. These are the same actions the [AryaOS Site](../admin/aryaos-site.md) web cards run - so **SSH is optional**. Reach for the shell when you are already on the console, scripting a fleet, or want to see raw output.
 
 !!! tip "Every command has a web-console equivalent"
-    You never have to touch the shell. Each helper below is backed by a card in **Cockpit → AryaOS Site**. See [AryaOS Site page](../admin/aryaos-site.md).
+    You never have to touch the shell. Each helper below is backed by a card in **Cockpit > AryaOS Site**. See [AryaOS Site page](../admin/aryaos-site.md).
 
-## At a glance
+## Command summary
 
 | Command | What it does | Root? | Web equivalent |
 |---|---|---|---|
@@ -18,7 +18,7 @@ AryaOS installs a small set of `aryaos-*` helper commands in `/usr/local/sbin`. 
 | [`aryaos-config-backup {backup\|restore\|list}`](#aryaos-config-backup) | Back up / restore the full config set | yes | Backup & restore |
 | [`aryaos-factory-reset`](#aryaos-factory-reset) | Return the box to its just-flashed state | yes | Factory reset |
 | [`aryaos-zeroize`](#aryaos-zeroize) | Best-effort secure sanitize (decommission) | yes | Zeroize |
-| [`aryaos-firstboot.sh`](#aryaos-firstboot) | One-time first-boot personalization | yes | — (runs automatically) |
+| [`aryaos-firstboot.sh`](#aryaos-firstboot) | One-time first-boot personalization | yes | - (runs automatically) |
 
 Commands print JSON where a machine (Cockpit) consumes the output, and require `sudo` for anything that changes the system.
 
@@ -40,7 +40,7 @@ aryaos-update status        # report last check/apply + reboot-required (JSON, n
 
 ## aryaos-support-bundle {#aryaos-support-bundle}
 
-Collects **redacted** diagnostics — system identity, package versions, service status, journals, network state, config files, and a sensor snapshot — into a single tarball for support.
+Collects **redacted** diagnostics - system identity, package versions, service status, journals, network state, config files, and a sensor snapshot - into a single tarball for support.
 
 ```bash
 sudo aryaos-support-bundle
@@ -75,7 +75,7 @@ sudo aryaos-sdr set-serial 0 stx:1090:0     # write a new EEPROM serial to devic
 
 - AryaOS serial conventions: `stx:1090:0` for the ADS-B 1090 MHz path (`readsb`/`dump1090-fa`), `stx:978:0` for UAT 978 MHz (`dump978-fa`, `ARYAOS_UAT_RTL_SERIAL`).
 - `set-serial` stops any active SDR consumers (`readsb`, `dump1090-fa`, `dump978-fa`, `ais-catcher`), writes the serial, and restarts what it stopped.
-- A serial is 1–32 characters of `[A-Za-z0-9:._-]`. **Replug the dongle (or reboot)** before the new serial is visible to consumers.
+- A serial is 1-32 characters of `[A-Za-z0-9:._-]`. **Replug the dongle (or reboot)** before the new serial is visible to consumers.
 
 See [Radios & SDRs](../config/radios-sdr.md).
 
@@ -94,7 +94,7 @@ sudo aryaos-role set air    # enable this role's units, disable the rest, persis
 | `air` | ADS-B / UAT (`readsb` or `dump1090-fa`, `dump978-fa`, `adsbcot`, `gdltak`) |
 | `maritime` | AIS (`ais-catcher`, `aiscot`) |
 | `cuas` | Drones (`dronecot`, `sikw00fcot`) |
-| `relay` | CoT routing only — no sensors |
+| `relay` | CoT routing only - no sensors |
 
 The ADS-B decoder unit follows `ARYAOS_ADSB_DECODER` (`readsb` or `dump1090_fa`). Units missing from the image are skipped, not errors. See [Device roles](../config/device-roles.md).
 
@@ -113,7 +113,7 @@ sudo aryaos-import-tak-dp --enrollment-url-file /path/to/tak-url.txt
 
 ## aryaos-config-backup {#aryaos-config-backup}
 
-Backs up and restores the full AryaOS configuration set — site config, charontak lanes, gateway `/etc/default` files, saved networks, TAK certs, and Node-RED credentials — as a single tarball.
+Backs up and restores the full AryaOS configuration set - site config, charontak lanes, gateway `/etc/default` files, saved networks, TAK certs, and Node-RED credentials - as a single tarball.
 
 ```bash
 sudo aryaos-config-backup backup                 # full backup (includes secrets)
@@ -127,11 +127,11 @@ aryaos-config-backup list                         # list existing backups (JSON)
 - `restore` validates the archive by its `MANIFEST.txt`, unpacks in place preserving perms, then `try-restart`s the CoT fleet and `lighttpd`; recommends a reboot.
 
 !!! danger "A full backup contains private keys and Wi-Fi PSKs"
-    The default `backup` includes TAK client certs, TLS keys, NetworkManager PSKs, and Node-RED credentials — store it securely. Use `--no-secrets` for a shareable, config-only archive. Same action as the **Backup & restore** card. See [Back up & restore](../operations/backup-restore.md).
+    The default `backup` includes TAK client certs, TLS keys, NetworkManager PSKs, and Node-RED credentials - store it securely. Use `--no-secrets` for a shareable, config-only archive. Same action as the **Backup & restore** card. See [Back up & restore](../operations/backup-restore.md).
 
 ## aryaos-factory-reset {#aryaos-factory-reset}
 
-Returns the box to its just-flashed, pre-first-boot state **without re-flashing**: restores AryaOS config from `/usr/share/aryaos/defaults`, deletes uploaded TAK certs, clears device identity (so `aryaos-firstboot` re-runs and picks a new suffix/hostname), re-expires the login password, then reboots. Keeps the OS, packages, and — by default — the network.
+Returns the box to its just-flashed, pre-first-boot state **without re-flashing**: restores AryaOS config from `/usr/share/aryaos/defaults`, deletes uploaded TAK certs, clears device identity (so `aryaos-firstboot` re-runs and picks a new suffix/hostname), re-expires the login password, then reboots. Keeps the OS, packages, and - by default - the network.
 
 ```bash
 sudo aryaos-factory-reset                  # keep network; type the hostname to confirm; reboot
@@ -140,7 +140,7 @@ sudo aryaos-factory-reset --service        # non-interactive (Cockpit card)
 sudo aryaos-factory-reset --no-reboot      # reset but don't reboot (testing)
 ```
 
-- **Not a secure erase** — it restores/clears config but does not sanitize the media. For decommission use [`aryaos-zeroize`](#aryaos-zeroize).
+- **Not a secure erase** - it restores/clears config but does not sanitize the media. For decommission use [`aryaos-zeroize`](#aryaos-zeroize).
 - Per-gateway `/etc/default/<svc>` files are reset via `apt-get --reinstall` **only when online**; offline they're left as-is.
 - Same action as the **Factory reset** card. See [Factory reset](../operations/factory-reset.md).
 
@@ -160,14 +160,14 @@ sudo aryaos-zeroize --no-reboot      # wipe but don't reboot (testing)
 
 ## aryaos-firstboot.sh {#aryaos-firstboot}
 
-Runs once automatically via `aryaos-firstboot.service` on the first boot — you should not need to invoke it by hand. It derives [`DEVICE_SUFFIX`](glossary.md#device_suffix), sets the hostname `aryaos-xxxx`, names the hotspot `AryaOS-xxxx`, regenerates the per-device web TLS certificate, and (on release images) expires the default `pi` password. See [First boot & first login](../get-started/first-boot.md).
+Runs once automatically via `aryaos-firstboot.service` on the first boot - you should not need to invoke it by hand. It derives [`DEVICE_SUFFIX`](glossary.md#device_suffix), sets the hostname `aryaos-xxxx`, names the hotspot `AryaOS-xxxx`, regenerates the per-device web TLS certificate, and (on release images) expires the default `pi` password. See [First boot & first login](../get-started/first-boot.md).
 
 ## See also
 
 <div class="grid cards" markdown>
 
-- :material-view-dashboard: **AryaOS Site page** — The web equivalents of these commands. [AryaOS Site page](../admin/aryaos-site.md)
-- :material-book-open: **Glossary** — Terms these commands touch. [Glossary](glossary.md)
-- :material-shield-check: **Security posture** — Why passwords must be rotated. [Security posture](../security.md)
+- :material-view-dashboard: **AryaOS Site page** - The web equivalents of these commands. [AryaOS Site page](../admin/aryaos-site.md)
+- :material-book-open: **Glossary** - Terms these commands touch. [Glossary](glossary.md)
+- :material-shield-check: **Security posture** - Why passwords must be rotated. [Security posture](../security.md)
 
 </div>

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,14 +1,14 @@
 # Glossary
 
-Definitions of the terms used throughout the AryaOS documentation. Each term has a stable anchor so other pages can deep-link to it — for example [`#device_suffix`](#device_suffix) or [`#cot`](#cot).
+Definitions of the terms used throughout the AryaOS documentation. Each term has a stable anchor so other pages can deep-link to it - for example [`#device_suffix`](#device_suffix) or [`#cot`](#cot).
 
 ## ADS-B {#ads-b}
 
-**Automatic Dependent Surveillance–Broadcast.** Aircraft broadcast their GPS-derived position, altitude, velocity, and identity, typically on **1090 MHz** (worldwide) or **978 MHz** UAT (US, low-altitude). AryaOS decodes ADS-B with `readsb` or `dump1090-fa` and turns it into TAK tracks via [ADSBCOT](../reference/software-suite.md). See [Aircraft (ADS-B)](../deploy/air-adsb.md).
+**Automatic Dependent Surveillance-Broadcast.** Aircraft broadcast their GPS-derived position, altitude, velocity, and identity, typically on **1090 MHz** (worldwide) or **978 MHz** UAT (US, low-altitude). AryaOS decodes ADS-B with `readsb` or `dump1090-fa` and turns it into TAK tracks via [ADSBCOT](../reference/software-suite.md). See [Aircraft (ADS-B)](../deploy/air-adsb.md).
 
 ## AIS {#ais}
 
-**Automatic Identification System.** Ships and other vessels broadcast their position, course, speed, and identity over VHF (161–162 MHz). AryaOS decodes AIS with `ais-catcher` and publishes vessels to TAK via [AISCOT](../reference/software-suite.md). See [Maritime vessels (AIS)](../deploy/maritime-ais.md).
+**Automatic Identification System.** Ships and other vessels broadcast their position, course, speed, and identity over VHF (161-162 MHz). AryaOS decodes AIS with `ais-catcher` and publishes vessels to TAK via [AISCOT](../reference/software-suite.md). See [Maritime vessels (AIS)](../deploy/maritime-ais.md).
 
 ## ATAK {#atak}
 
@@ -24,11 +24,11 @@ The open-source, browser-based server management UI that AryaOS uses as its **si
 
 ## COP {#cop}
 
-**Common Operating Picture.** A single, shared, real-time view of a situation — the aircraft, vessels, drones, and friendly positions relevant to a mission — assembled from multiple sensors. Building a COP for TAK is AryaOS's core purpose. See [Multi-sensor COP](../deploy/multi-sensor.md).
+**Common Operating Picture.** A single, shared, real-time view of a situation - the aircraft, vessels, drones, and friendly positions relevant to a mission - assembled from multiple sensors. Building a COP for TAK is AryaOS's core purpose. See [Multi-sensor COP](../deploy/multi-sensor.md).
 
 ## CoT {#cot}
 
-**Cursor on Target.** The XML (and Protobuf) message format TAK uses to represent an "event" — an aircraft, vessel, drone, marker, or friendly position — with a location, type, and time. Every AryaOS gateway produces CoT. Written **Cursor on Target (CoT)** on first use per page.
+**Cursor on Target.** The XML (and Protobuf) message format TAK uses to represent an "event" - an aircraft, vessel, drone, marker, or friendly position - with a location, type, and time. Every AryaOS gateway produces CoT. Written **Cursor on Target (CoT)** on first use per page.
 
 ## cUAS {#cuas}
 
@@ -76,7 +76,7 @@ The regulatory broadcast standard (Open Drone ID / ASTM Remote ID) by which dron
 
 ## TAK Server {#tak-server}
 
-The central server component of TAK that relays CoT between many clients, manages users and channels, and issues client certificates for TLS. AryaOS can forward its CoT to a TAK Server — via a data package or a `tak://` enrollment link — in addition to (or instead of) [Mesh SA](#mesh-sa). See [Connect to a TAK Server](../deploy/connect-tak-server.md).
+The central server component of TAK that relays CoT between many clients, manages users and channels, and issues client certificates for TLS. AryaOS can forward its CoT to a TAK Server - via a data package or a `tak://` enrollment link - in addition to (or instead of) [Mesh SA](#mesh-sa). See [Connect to a TAK Server](../deploy/connect-tak-server.md).
 
 ## UAT {#uat}
 
@@ -86,8 +86,8 @@ The central server component of TAK that relays CoT between many clients, manage
 
 <div class="grid cards" markdown>
 
-- :material-package: **Software suite** — Every gateway and plugin. [Software suite](software-suite.md)
-- :material-lan: **Ports & protocols** — Where these protocols listen. [Ports & protocols](ports.md)
-- :material-file-document: **Specifications** — Standards and identity. [Specifications](../specs.md)
+- :material-package: **Software suite** - Every gateway and plugin. [Software suite](software-suite.md)
+- :material-lan: **Ports & protocols** - Where these protocols listen. [Ports & protocols](ports.md)
+- :material-file-document: **Specifications** - Standards and identity. [Specifications](../specs.md)
 
 </div>

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -3,7 +3,7 @@
 Every port, multicast group, and network address AryaOS uses, and what each is for. Use this when configuring a firewall, troubleshooting connectivity, or reaching a service directly.
 
 !!! info "Most services are localhost or firewalled by default"
-    AryaOS runs a `firewalld` default-zone allowlist. Ports below that face the network (Cockpit, the portal, Node-RED, AIS-catcher, Mesh SA, comitup, SSH) are opened by explicit firewalld services; the rest bind to `127.0.0.1`. Manage the allowlist in **Cockpit → Networking → Firewall**. See [Firewall](../networking/firewall.md).
+    AryaOS runs a `firewalld` default-zone allowlist. Ports below that face the network (Cockpit, the portal, Node-RED, AIS-catcher, Mesh SA, comitup, SSH) are opened by explicit firewalld services; the rest bind to `127.0.0.1`. Manage the allowlist in **Cockpit > Networking > Firewall**. See [Firewall](../networking/firewall.md).
 
 ## Listening ports
 
@@ -26,7 +26,7 @@ Every port, multicast group, and network address AryaOS uses, and what each is f
 
 | Group | Port | Proto | Purpose |
 |---|---|---|---|
-| `239.2.3.1` | 6969 | UDP | **TAK Mesh SA** — CharonTAK egress/ingress and `aryaos-neighbord` neighbor discovery. `udp+wo://239.2.3.1:6969`. |
+| `239.2.3.1` | 6969 | UDP | **TAK Mesh SA** - CharonTAK egress/ingress and `aryaos-neighbord` neighbor discovery. `udp+wo://239.2.3.1:6969`. |
 
 Multicast source binding is controlled by `PYTAK_MULTICAST_LOCAL_ADDR` in the site config (default `10.41.0.1`, the hotspot IP). See [Relay & routing](../deploy/relay-routing.md) and [Nearby nodes](../operations/neighbors.md).
 
@@ -35,7 +35,7 @@ Multicast source binding is controlled by `PYTAK_MULTICAST_LOCAL_ADDR` in the si
 | Interface | Address | Purpose |
 |---|---|---|
 | Wi-Fi hotspot (`wlan0`) | `10.41.0.1/24` | Onboarding/AP network `AryaOS-xxxx`. Phones and laptops get DHCP here; this is the default multicast bind address. |
-| Bluetooth PAN (`pan0`) | `10.44.0.1/24` | Local Bluetooth NAP. AryaOS serves DHCP (`10.44.0.20`–`10.44.0.60`) to paired phones. **No NAT or forwarding** — for reaching AryaOS services over Bluetooth. |
+| Bluetooth PAN (`pan0`) | `10.44.0.1/24` | Local Bluetooth NAP. AryaOS serves DHCP (`10.44.0.20`-`10.44.0.60`) to paired phones. **No NAT or forwarding** - for reaching AryaOS services over Bluetooth. |
 
 See [Wi-Fi & onboarding hotspot](../networking/wifi-hotspot.md) and [Bluetooth PAN](../bluetooth-pan.md).
 
@@ -45,17 +45,17 @@ AryaOS forwards CoT outward through CharonTAK:
 
 | Destination | URL | When |
 |---|---|---|
-| Mesh SA multicast | `udp+wo://239.2.3.1:6969` | Default — phones on the hotspot see tracks with no server |
+| Mesh SA multicast | `udp+wo://239.2.3.1:6969` | Default - phones on the hotspot see tracks with no server |
 | TAK Server | `tls://host:port` (or `tcp://`) | When a TAK connection is imported |
 
-TAK Server lanes are added by importing a connection data package or `tak://` enrollment link — see [Connect to a TAK Server](../deploy/connect-tak-server.md).
+TAK Server lanes are added by importing a connection data package or `tak://` enrollment link - see [Connect to a TAK Server](../deploy/connect-tak-server.md).
 
 ## See also
 
 <div class="grid cards" markdown>
 
-- :material-security: **Firewall** — Manage the allowlist. [Firewall](../networking/firewall.md)
-- :material-book-open: **Glossary** — What these protocols are. [Glossary](glossary.md)
-- :material-package: **Software suite** — The services behind each port. [Software suite](software-suite.md)
+- :material-security: **Firewall** - Manage the allowlist. [Firewall](../networking/firewall.md)
+- :material-book-open: **Glossary** - What these protocols are. [Glossary](glossary.md)
+- :material-package: **Software suite** - The services behind each port. [Software suite](software-suite.md)
 
 </div>

--- a/docs/reference/software-suite.md
+++ b/docs/reference/software-suite.md
@@ -10,63 +10,63 @@ AryaOS ships the full [Sensors & Signals](https://www.snstac.com) open-source su
 | Project | What it does |
 |---|---|
 | [PyTAK](https://github.com/snstac/pytak) {#pytak} | Python framework for building TAK and Cursor on Target (CoT) integrations. Every gateway below is built on it. ([docs](https://pytak.readthedocs.io/)) |
-| [CharonTAK](https://github.com/snstac/charontak) {#charontak} | The CoT "ferryman" — bridges and routes CoT between the local hub, Mesh SA multicast, and TAK Servers. On AryaOS it is the single egress point every feeder writes to. |
+| [CharonTAK](https://github.com/snstac/charontak) {#charontak} | The CoT "ferryman" - bridges and routes CoT between the local hub, Mesh SA multicast, and TAK Servers. On AryaOS it is the single egress point every feeder writes to. |
 
-## Air — aircraft
+## Air - aircraft
 
 <div class="grid cards" markdown>
 
-- :material-airplane: **[ADSBCOT](https://github.com/snstac/adsbcot)** — Displays live aircraft from ADS-B receivers in ATAK, WinTAK, and iTAK. ([docs](https://adsbcot.readthedocs.io/)) · Deploy: [Aircraft (ADS-B)](../deploy/air-adsb.md)
-- :material-shape: **[AIRCOT](https://github.com/snstac/aircot)** — Classifies aircraft into TAK/CoT types from ADS-B and Mode S data. ([docs](https://aircot.readthedocs.io/))
-- :material-satellite-uplink: **[APRSCOT](https://github.com/snstac/aprscot)** — Displays amateur-radio APRS stations in TAK. ([docs](https://aprscot.readthedocs.io/))
-- :material-satellite-variant: **[INRCOT](https://github.com/snstac/inrcot)** — Displays Garmin inReach satellite-tracker positions in TAK.
+- :material-airplane: **[ADSBCOT](https://github.com/snstac/adsbcot)** - Displays live aircraft from ADS-B receivers in ATAK, WinTAK, and iTAK. ([docs](https://adsbcot.readthedocs.io/)) · Deploy: [Aircraft (ADS-B)](../deploy/air-adsb.md)
+- :material-shape: **[AIRCOT](https://github.com/snstac/aircot)** - Classifies aircraft into TAK/CoT types from ADS-B and Mode S data. ([docs](https://aircot.readthedocs.io/))
+- :material-satellite-uplink: **[APRSCOT](https://github.com/snstac/aprscot)** - Displays amateur-radio APRS stations in TAK. ([docs](https://aprscot.readthedocs.io/))
+- :material-satellite-variant: **[INRCOT](https://github.com/snstac/inrcot)** - Displays Garmin inReach satellite-tracker positions in TAK.
 
 </div>
 
-## Maritime — vessels
+## Maritime - vessels
 
 <div class="grid cards" markdown>
 
-- :material-ferry: **[AISCOT](https://github.com/snstac/aiscot)** — Displays ships and maritime vessel traffic from AIS in TAK. ([docs](https://aiscot.readthedocs.io/)) · Deploy: [Maritime vessels (AIS)](../deploy/maritime-ais.md)
+- :material-ferry: **[AISCOT](https://github.com/snstac/aiscot)** - Displays ships and maritime vessel traffic from AIS in TAK. ([docs](https://aiscot.readthedocs.io/)) · Deploy: [Maritime vessels (AIS)](../deploy/maritime-ais.md)
 
 </div>
 
-## Drone — counter-UAS
+## Drone - counter-UAS
 
 <div class="grid cards" markdown>
 
-- :material-quadcopter: **[DroneCOT](https://github.com/snstac/dronecot)** — Detects and tracks drones (Remote ID / Open Drone ID) in TAK for counter-UAS awareness.
-- :material-drone: **[DJICOT](https://github.com/snstac/djicot)** — Detects and tracks DJI drones (DroneID) in TAK. ([docs](https://djicot.readthedocs.io/))
-- :material-radio-tower: **[SiKW00FCOT](https://github.com/snstac/sikw00fcot)** — Converts SiK-radio MAVLink drone telemetry to Cursor on Target.
+- :material-quadcopter: **[DroneCOT](https://github.com/snstac/dronecot)** - Detects and tracks drones (Remote ID / Open Drone ID) in TAK for counter-UAS awareness.
+- :material-drone: **[DJICOT](https://github.com/snstac/djicot)** - Detects and tracks DJI drones (DroneID) in TAK. ([docs](https://djicot.readthedocs.io/))
+- :material-radio-tower: **[SiKW00FCOT](https://github.com/snstac/sikw00fcot)** - Converts SiK-radio MAVLink drone telemetry to Cursor on Target.
 
 </div>
 
 Deploy: [Counter-UAS (drones)](../deploy/counter-uas.md).
 
-## Position — own location
+## Position - own location
 
 <div class="grid cards" markdown>
 
-- :material-crosshairs-gps: **[GPSTAK](https://github.com/snstac/gpstak)** — Streams `gpsd` position data to TAK as CoT, with NMEA fan-out for WinTAK.
-- :material-map-marker: **[LINCOT](https://github.com/snstac/lincot)** — Sends a Linux device's own position (GPS) to TAK.
+- :material-crosshairs-gps: **[GPSTAK](https://github.com/snstac/gpstak)** - Streams `gpsd` position data to TAK as CoT, with NMEA fan-out for WinTAK.
+- :material-map-marker: **[LINCOT](https://github.com/snstac/lincot)** - Sends a Linux device's own position (GPS) to TAK.
 
 </div>
 
 Deploy: [Own position (GPS)](../deploy/own-position-gps.md).
 
-## Routing — bridge & relay
+## Routing - bridge & relay
 
 <div class="grid cards" markdown>
 
-- :material-transit-connection-variant: **[CharonTAK](https://github.com/snstac/charontak)** — Bridges and relays CoT between networks and TAK Servers; the AryaOS egress hub. Deploy: [Relay & routing](../deploy/relay-routing.md)
+- :material-transit-connection-variant: **[CharonTAK](https://github.com/snstac/charontak)** - Bridges and relays CoT between networks and TAK Servers; the AryaOS egress hub. Deploy: [Relay & routing](../deploy/relay-routing.md)
 
 </div>
 
-## EFB — electronic flight bag
+## EFB - electronic flight bag
 
 <div class="grid cards" markdown>
 
-- :material-airplane-takeoff: **[GDLTAK](https://github.com/snstac/gdltak)** — Converts CoT into GDL90 so aircraft tracks appear in ForeFlight and other electronic flight bags (EFBs). Deploy: [ForeFlight & EFBs (GDL90)](../deploy/foreflight-gdl90.md)
+- :material-airplane-takeoff: **[GDLTAK](https://github.com/snstac/gdltak)** - Converts CoT into GDL90 so aircraft tracks appear in ForeFlight and other electronic flight bags (EFBs). Deploy: [ForeFlight & EFBs (GDL90)](../deploy/foreflight-gdl90.md)
 
 </div>
 
@@ -74,11 +74,11 @@ Deploy: [Own position (GPS)](../deploy/own-position-gps.md).
 
 <div class="grid cards" markdown>
 
-- :material-qrcode: **[QRTAK](https://github.com/snstac/qrtak)** — Onboard end-user devices to a TAK Server by scanning a QR code. See [Connect to a TAK Server](../deploy/connect-tak-server.md).
+- :material-qrcode: **[QRTAK](https://github.com/snstac/qrtak)** - Onboard end-user devices to a TAK Server by scanning a QR code. See [Connect to a TAK Server](../deploy/connect-tak-server.md).
 
 </div>
 
-## Web admin — Cockpit plugins
+## Web admin - Cockpit plugins
 
 Every gateway on AryaOS is managed from a browser UI built on [Cockpit](https://cockpit-project.org/) (HTTPS on port 9090, also reachable via the portal proxy). Each plugin edits its service's `/etc/default/<svc>`; the **AryaOS Site** plugin edits the site config and TAK TLS.
 
@@ -100,8 +100,8 @@ All plugins share the [@snstac/cockpit-shared](https://github.com/snstac/cockpit
 
 <div class="grid cards" markdown>
 
-- :material-book-open: **Glossary** — Definitions of every term above. [Glossary](glossary.md)
-- :material-console: **CLI helpers** — The `aryaos-*` commands behind the web cards. [CLI helpers](cli-helpers.md)
-- :material-view-dashboard: **AryaOS Site page** — The single admin surface. [AryaOS Site page](../admin/aryaos-site.md)
+- :material-book-open: **Glossary** - Definitions of every term above. [Glossary](glossary.md)
+- :material-console: **CLI helpers** - The `aryaos-*` commands behind the web cards. [CLI helpers](cli-helpers.md)
+- :material-view-dashboard: **AryaOS Site page** - The single admin surface. [AryaOS Site page](../admin/aryaos-site.md)
 
 </div>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap & next steps
 
-Outstanding work and follow-ups for whoever picks up AryaOS next — human or
+Outstanding work and follow-ups for whoever picks up AryaOS next - human or
 agent. Ordered by priority within each group. This is a living document: update
 it as items land, and see [Agent handoff](agent-handoff.md) for the running
 build/merge state and architecture invariants.
@@ -12,7 +12,7 @@ build/merge state and architecture invariants.
     factory reset, zeroize), and on-device offline docs. The items below are
     what remains.
 
-## Start here — hardware burn-in
+## Start here - hardware burn-in
 
 Several shipped features are verified only by `shellcheck`, `ansible
 --syntax-check`, `mkdocs --strict`, and `verify-image.sh` static asserts. They
@@ -20,7 +20,7 @@ have **not been exercised on real hardware**. Flash the latest dev image and
 run through them before relying on any of it in the field.
 
 - [ ] **Destructive lifecycle paths.** On a throwaway box: a
-      backup → restore round-trip, then `aryaos-factory-reset`, then
+      backup > restore round-trip, then `aryaos-factory-reset`, then
       `aryaos-zeroize` (confirm it reboots clean and the box stays usable). Watch
       the free-space overwrite duration. See [Factory reset](operations/factory-reset.md)
       and [Zeroize](operations/zeroize.md).
@@ -28,7 +28,7 @@ run through them before relying on any of it in the field.
       support bundle, Node-RED password, Radios (RTL-SDR re-serial), device role,
       hotspot password, Tailscale join, backup/restore, factory reset, zeroize.
 - [ ] **Expired-password first-login flow.** Confirm the Cockpit login handles
-      the first-boot `chage -d 0 pi` expiry cleanly — this is the prerequisite for
+      the first-boot `chage -d 0 pi` expiry cleanly - this is the prerequisite for
       the first-login wizard below.
 - [ ] **Media longevity.** Confirm zram swap activates (`swapon --show` shows a
       `/dev/zram0`), `fstrim.timer` is enabled, and logs are in RAM as expected.
@@ -40,28 +40,28 @@ run through them before relying on any of it in the field.
 ## Security follow-ups
 
 - [ ] **Stronger zeroize guarantees.** The shipped `aryaos-zeroize` is
-      best-effort by design (see [Zeroize](operations/zeroize.md)) — on
+      best-effort by design (see [Zeroize](operations/zeroize.md)) - on
       wear-leveled flash, overwrite/TRIM cannot guarantee erasure. Two stronger
       options were deferred:
-    - **Opt-in full-disk encryption (LUKS) → true crypto-erase.** The only hard
+    - **Opt-in full-disk encryption (LUKS) > true crypto-erase.** The only hard
       guarantee on flash. Requires boot/initramfs work and a key-management story;
       makes zeroize an instant key-destroy.
     - **Scorched-earth zeroize mode.** A second mode that also wipes the
       rootfs/boot so a captured box reveals nothing and will not boot (requires
       reflash to reuse).
 - [ ] **Dependabot backlog.** ~19 bot PRs across `aryaos`, `cockpit-aiscot`, and
-      `cockpit-lincot` (dependency bumps, some majors — TypeScript, PatternFly,
+      `cockpit-lincot` (dependency bumps, some majors - TypeScript, PatternFly,
       a Cockpit-lib refresh). Triage: merge safe patch/minor bumps, review majors.
 
 ## Platform & features
 
 - [ ] **amd64 support** ([#129](https://github.com/snstac/aryaos/issues/129)).
       The pipeline is arm64-only pi-gen. Recommended first step: an
-      `install-aryaos.sh` for any Debian 13 host — the signed apt repo + overlay
+      `install-aryaos.sh` for any Debian 13 host - the signed apt repo + overlay
       deb already carry almost everything. Then a debos/bdebstrap amd64 image and
       a VM appliance.
-- [ ] **First-login setup wizard.** A guided first-login flow (change password →
-      set callsign → import TAK data package / set COT_URL → pick device role).
+- [ ] **First-login setup wizard.** A guided first-login flow (change password >
+      set callsign > import TAK data package / set COT_URL > pick device role).
       All the pieces exist; blocked on the expired-password verification above.
 - [ ] **Unified COP map on the portal.** `tar1090` shows only ADS-B. A portal
       map fusing ADS-B + AIS + drones + own position + Mesh SA neighbors
@@ -71,13 +71,13 @@ run through them before relying on any of it in the field.
       ([#8](https://github.com/snstac/aryaos/issues/8),
       [#9](https://github.com/snstac/aryaos/issues/9)). Cleanest design: a
       Charontak recorder lane (it already sees all local CoT) writing rotating
-      logs, with a portal page to download and replay — directly useful for
+      logs, with a portal page to download and replay - directly useful for
       wildland-fire after-action review.
 - [ ] **SDR gain / PPM tuning UI.** The Radios card enumerates and re-serials
       dongles; gain and PPM are still file-only. Add them to the card.
 - [ ] **`cockpit-gdltak` page** and a live ForeFlight/EFB validation for the new
       [GDL90 gateway](deploy/foreflight-gdl90.md).
-- [ ] **CoT over BLE** ([#7](https://github.com/snstac/aryaos/issues/7)) — blocked
+- [ ] **CoT over BLE** ([#7](https://github.com/snstac/aryaos/issues/7)) - blocked
       on BLE advertising being broken image-wide on the trixie kernel / BCM4345C0
       ([#117](https://github.com/snstac/aryaos/issues/117)).
 
@@ -91,15 +91,15 @@ run through them before relying on any of it in the field.
 ## Housekeeping
 
 - [ ] **Close resolved issues.** [#21](https://github.com/snstac/aryaos/issues/21)
-      (SDR web UI — done via the Radios card),
-      [#51](https://github.com/snstac/aryaos/issues/51) (SBOM — done), and the
+      (SDR web UI - done via the Radios card),
+      [#51](https://github.com/snstac/aryaos/issues/51) (SBOM - done), and the
       image half of [#43](https://github.com/snstac/aryaos/issues/43)
       (ForeFlight/gdltak) are shipped and can be closed.
 - [ ] **Current bugs.** [#93](https://github.com/snstac/aryaos/issues/93) (ADSBCOT
-      Cockpit tab wrong header — quick fix) and
+      Cockpit tab wrong header - quick fix) and
       [#94](https://github.com/snstac/aryaos/issues/94) (AIS-catcher serial port).
-- [ ] **`python-networkmanager` → `python-sdbus-networkmanager`**
-      ([#54](https://github.com/snstac/aryaos/issues/54)) — live tech debt in
+- [ ] **`python-networkmanager` > `python-sdbus-networkmanager`**
+      ([#54](https://github.com/snstac/aryaos/issues/54)) - live tech debt in
       `stage-aryaos`.
 - [ ] **Chroot vs Ansible stage drift.** Each stage exists twice (pi-gen
       `00-run.sh` + Ansible `tasks/`) and can diverge. Add a CI job that

--- a/docs/security.md
+++ b/docs/security.md
@@ -3,7 +3,7 @@
 AryaOS units are field appliances: they must be administrable through a
 browser (Cockpit) by an operator wearing gloves, survive hostile LANs, and
 still be recoverable without key material. The hardening below reflects those
-trade-offs. Everything ships in both dev/lab and release images — the two
+trade-offs. Everything ships in both dev/lab and release images - the two
 flavors differ only in *access* (lab SSH key, passwordless sudo, password
 expiry), never in posture.
 
@@ -13,11 +13,11 @@ expiry), never in posture.
   release images (`chage -d 0`, `aryaos-firstboot.sh`).
 - **sshd** (`/etc/ssh/sshd_config.d/50-aryaos.conf`): root login disabled,
   empty passwords disabled, `MaxAuthTries 4`, `LoginGraceTime 30`, no X11
-  forwarding. Password authentication stays **enabled** by design — field
+  forwarding. Password authentication stays **enabled** by design - field
   operators may have no keys; see the default-password expiry above.
 - **fail2ban** (`/etc/fail2ban/jail.d/aryaos.local`): sshd jail, systemd
   backend, 15 min bans. Bluetooth PAN clients (`10.44.0.0/24`) are never
-  banned — that is the operator standing next to the box.
+  banned - that is the operator standing next to the box.
 - **sudo** is fully logged (JSON I/O logging, `/etc/sudoers.d/aryaos`); no
   NOPASSWD on release images (asserted by `scripts/verify-image.sh`).
 
@@ -29,7 +29,7 @@ expiry), never in posture.
   Mesh SA multicast (`6969/udp`), Node-RED (`1880`, adminAuth-protected),
   AIS-catcher dashboard (`8100`), comitup onboarding (`9080`). Custom service
   definitions live in `/etc/firewalld/services/aryaos-*.xml`.
-- Operators manage the firewall in **Cockpit → Networking → Firewall** (no
+- Operators manage the firewall in **Cockpit > Networking > Firewall** (no
   shell needed).
 - The AntSDR point-to-point link (`eth1`, `aryaos-antsdr.nmconnection`) is in
   the **trusted** zone so the sensor can reach the dronecot listener.
@@ -47,7 +47,7 @@ expiry), never in posture.
   first boot.
 - The web (portal/Cockpit) TLS key is also **regenerated per device** at
   first boot (`aryaos-firstboot.sh`, marker
-  `/etc/aryaos/.web-tls-regenerated`) — published images no longer share one
+  `/etc/aryaos/.web-tls-regenerated`) - published images no longer share one
   snakeoil key across the fleet.
 - Site TAK TLS material lives in `/etc/aryaos/tls` (`root:tak-certs`, key
   `0640`, dir `0750`). The Node-RED user owns only the site config file, not
@@ -57,21 +57,21 @@ expiry), never in posture.
 
 - **Debian security fixes install automatically** every day
   (unattended-upgrades; `/etc/apt/apt.conf.d/52unattended-upgrades-aryaos`).
-  No automatic reboots. The snstac sensor stack is *not* auto-upgraded —
+  No automatic reboots. The snstac sensor stack is *not* auto-upgraded -
   restarting sensors mid-operation is an operator decision.
-- **One-click updates**: Cockpit → AryaOS Site → *Software updates* checks
+- **One-click updates**: Cockpit > AryaOS Site > *Software updates* checks
   and installs everything (sensor stack included) from the signed
   [snstac apt repository](https://snstac.github.io/packages). The backend is
   `/usr/local/sbin/aryaos-update` (`check|apply|status`) run under
   `aryaos-update.service`, so an upgrade survives a closed browser session.
   `readsb` stays on `apt-mark hold` and is reported as held.
-- Per-package operations: Cockpit → Software updates (PackageKit).
+- Per-package operations: Cockpit > Software updates (PackageKit).
 
 ## Node-RED admin password
 
 Node-RED ships with a publicly known default admin password (`aryaos415`) and
-the editor can run arbitrary code as the `node-red` user — **rotate it before
-fielding a unit**. Cockpit → AryaOS Site → *Node-RED admin password* does
+the editor can run arbitrary code as the `node-red` user - **rotate it before
+fielding a unit**. Cockpit > AryaOS Site > *Node-RED admin password* does
 this in the browser; the backend is
 `/usr/local/sbin/aryaos-set-nodered-password` (reads the new password on
 stdin, bcrypt-hashes it with Node-RED's bundled bcryptjs, rewrites the
@@ -79,7 +79,7 @@ stdin, bcrypt-hashes it with Node-RED's bundled bcryptjs, rewrites the
 
 ## Support bundles
 
-Cockpit → AryaOS Site → *Support bundle* generates a downloadable diagnostics
+Cockpit > AryaOS Site > *Support bundle* generates a downloadable diagnostics
 tarball via `/usr/local/sbin/aryaos-support-bundle`: system/package/service
 state, capped journals, network and firewall state, and sensor-gateway
 configs. Values of keys matching `PASSWORD/TOKEN/SECRET/PASSPHRASE/PSK` and
@@ -90,16 +90,16 @@ or other private key material is included. Bundles land in
 ## Decommissioning
 
 When a unit is re-issued, retired, or at risk of capture, AryaOS gives you two
-levels of teardown — always **[back up](operations/backup-restore.md) first** if
+levels of teardown - always **[back up](operations/backup-restore.md) first** if
 you want the config back (a full backup carries private keys and Wi-Fi PSKs, so
 store it securely):
 
 - **[Factory reset](operations/factory-reset.md)**
-  (`/usr/local/sbin/aryaos-factory-reset`) — restores config to packaged
+  (`/usr/local/sbin/aryaos-factory-reset`) - restores config to packaged
   defaults, deletes uploaded TAK certs, clears device identity so first boot
   re-runs, and reboots. Keeps the OS, packages, and (by default) the network.
   This is for **re-use**; it does **not** securely erase anything.
-- **[Zeroize](operations/zeroize.md)** (`/usr/local/sbin/aryaos-zeroize`) — for
+- **[Zeroize](operations/zeroize.md)** (`/usr/local/sbin/aryaos-zeroize`) - for
   **decommission or capture**: shreds and overwrites all keys, credentials,
   logs, tracks, and identity, restores a secret-free config, overwrites free
   space, TRIMs, and reboots clean. The Cockpit card requires a typed
@@ -107,7 +107,7 @@ store it securely):
 
 !!! danger "Zeroize is best-effort on flash media"
     Wear-leveling on microSD/eMMC/NVMe means overwrite and TRIM **cannot
-    guarantee** prior contents are unrecoverable — the controller may have
+    guarantee** prior contents are unrecoverable - the controller may have
     written data to blocks software can't reach. For a hard guarantee, use
     full-disk encryption with crypto-erase (roadmap) or physically destroy the
     media. See [Zeroize](operations/zeroize.md).

--- a/docs/security/fips-stig.md
+++ b/docs/security/fips-stig.md
@@ -8,9 +8,9 @@ programs that need a formal posture (RMF / ATO).
 
 Two different things are often conflated:
 
-- **STIG** (DISA Security Technical Implementation Guide) — a **configuration
+- **STIG** (DISA Security Technical Implementation Guide) - a **configuration
   hardening baseline**. Achievable incrementally on the current image.
-- **FIPS 140-3** — use of **NIST-validated cryptographic modules**. Constrained
+- **FIPS 140-3** - use of **NIST-validated cryptographic modules**. Constrained
   by the Debian base and largely a business/re-base decision.
 
 ---
@@ -28,7 +28,7 @@ families (all in both dev and release images):
 | SI (System Integrity) | automatic Debian security updates; signed apt repo | `apt/52unattended-upgrades-aryaos` |
 | CM (Configuration Mgmt) | image content asserted every build; reproducible pi-gen | `scripts/verify-image.sh` |
 | MP (Media Protection) | factory-reset + zeroize (shred/TRIM/overwrite) | `aryaos-zeroize` |
-| AU (Audit) | sudo I/O logging, capped journald | partial — see gaps |
+| AU (Audit) | sudo I/O logging, capped journald | partial - see gaps |
 
 ## Known gaps vs a STIG baseline
 
@@ -40,10 +40,10 @@ Likely findings on a first scan, and the AryaOS disposition:
 - **CM (mount options)**: `/tmp`, `/var/tmp`, `/dev/shm` lack `nodev,nosuid,noexec`; unused kernel modules (cramfs, usb-storage, etc.) not blacklisted. *Fix* (Phase 1).
 - **AC (session)**: no shell idle timeout (`TMOUT`); no login-attempt lockout via `pam_faillock`. *Fix* (Phase 1).
 - **Waivered by the appliance model** (documented exceptions, not silent):
-  - **Password SSH auth stays enabled** — field operators may carry no keys; mitigated by first-boot expiry + `fail2ban` + `MaxAuthTries`. (SRG-OS SSH-key-only requirement.)
-  - **comitup AP / Bluetooth PAN onboarding** — attack surface, mitigated by EMCON (`aryaos-radio`) + firewall zone isolation.
-  - **No FDE by default** — zeroize is best-effort on flash; FDE + crypto-erase is on the roadmap.
-  - **Headless** — GUI/screen-lock STIGs are N/A.
+  - **Password SSH auth stays enabled** - field operators may carry no keys; mitigated by first-boot expiry + `fail2ban` + `MaxAuthTries`. (SRG-OS SSH-key-only requirement.)
+  - **comitup AP / Bluetooth PAN onboarding** - attack surface, mitigated by EMCON (`aryaos-radio`) + firewall zone isolation.
+  - **No FDE by default** - zeroize is best-effort on flash; FDE + crypto-erase is on the roadmap.
+  - **Headless** - GUI/screen-lock STIGs are N/A.
 
 ---
 
@@ -53,9 +53,9 @@ There is **no official DISA STIG for Debian**. The practical baselines are the
 **CIS Debian 12 Benchmark** and the **General Purpose OS SRG**, both shipped as
 OpenSCAP content in the **SCAP Security Guide** (`ssg-debian`). (If a program
 mandates a real DISA STIG, the closest validated path is a **Canonical Ubuntu
-STIG** — see the re-base note under FIPS.)
+STIG** - see the re-base note under FIPS.)
 
-**Phase 1 — measure (non-invasive, do first).**
+**Phase 1 - measure (non-invasive, do first).**
 Add an OpenSCAP scan to the test harness so every image gets a baseline score:
 
 ```bash
@@ -71,13 +71,13 @@ Triage findings into: already-met · will-fix · **waivered-with-rationale**
 (captured in an OpenSCAP **tailoring file**, `aryaos-stig-tailoring.xml`, so the
 appliance exceptions above are explicit and re-scored automatically).
 
-**Phase 2 — remediate.** Land the Phase-1 gap fixes (auditd, AIDE,
+**Phase 2 - remediate.** Land the Phase-1 gap fixes (auditd, AIDE,
 pam_pwquality/faillock, mount options, module blacklist, `TMOUT`) as
 hardening drop-ins, each asserted by `verify-image.sh`. Target a documented CIS
 score and publish the report + tailoring with each release.
 
-**Phase 3 — surface.** A Cockpit → *Compliance* card showing the last scan
-score, top open findings, and the waiver list — so an operator/assessor sees
+**Phase 3 - surface.** A Cockpit > *Compliance* card showing the last scan
+score, top open findings, and the waiver list - so an operator/assessor sees
 posture without a shell.
 
 ---
@@ -87,7 +87,7 @@ posture without a shell.
 **The honest reality:** Debian's OpenSSL/libgcrypt are **not NIST-validated**.
 Booting with `fips=1` does **not** confer compliance without validated modules.
 FIPS 140-3 is therefore a **module-sourcing** problem, and largely a re-base /
-procurement decision — not a config change.
+procurement decision - not a config change.
 
 **Options, roughly in order of effort:**
 
@@ -96,14 +96,14 @@ procurement decision — not a config change.
    primitives and document the inventory. This is immediately shippable and is
    usually a prerequisite line-item anyway:
    - **sshd**: pin `Ciphers`/`MACs`/`KexAlgorithms` to the FIPS set
-     (`aes256-gcm`, `hmac-sha2-512`, `ecdh-sha2-nistp384`, …) in
+     (`aes256-gcm`, `hmac-sha2-512`, `ecdh-sha2-nistp384`, ...) in
      `sshd/50-aryaos.conf`.
    - **lighttpd/cockpit TLS**: TLS 1.2+ only, FIPS cipher suites (AES-GCM,
      SHA-2, ECDHE-RSA/ECDSA).
-   - **pytak → TAK Server TLS**, **chrony**, **charontak**: confirm AES-GCM /
+   - **pytak > TAK Server TLS**, **chrony**, **charontak**: confirm AES-GCM /
      SHA-2 / RSA-2048+ or P-256/384 throughout.
-   - Deliverable: a **crypto inventory** table (component → library → algorithms
-     → key sizes) maintained in this repo.
+   - Deliverable: a **crypto inventory** table covering each component, library,
+     algorithm, and key size maintained in this repo.
 2. **OpenSSL 3 FIPS provider.** Build and activate the OpenSSL FIPS provider
    module. Gets the *architecture* right; a genuine certificate still requires a
    validated build.
@@ -114,7 +114,7 @@ procurement decision — not a config change.
 4. **Targeted commercial module (wolfSSL FIPS).** For a narrow validated crypto
    boundary (e.g. the TAK TLS path) without a full re-base.
 
-**Recommendation:** do (1) now — it is real hardening with no re-base — and hold
+**Recommendation:** do (1) now - it is real hardening with no re-base - and hold
 (3) behind an actual ATO requirement, since re-basing the whole image is a large
 program decision.
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -7,7 +7,7 @@ The technical specifications of AryaOS: operating system, supported hardware, pr
 | Item | Specification |
 |---|---|
 | Base | Debian **trixie** |
-| Architecture | `arm64` (Intel/amd64 planned — [#129](https://github.com/snstac/aryaos/issues/129)) |
+| Architecture | `arm64` (Intel/amd64 planned - [#129](https://github.com/snstac/aryaos/issues/129)) |
 | Image builder | pi-gen (Docker) |
 | Package source | [Signed snstac apt repository](https://snstac.github.io/packages) |
 | Updates | Debian-security unattended-upgrades; one-click full-upgrade via [`aryaos-update`](reference/cli-helpers.md#aryaos-update) |
@@ -29,7 +29,7 @@ See [Hardware & requirements](get-started/hardware.md).
 
 | Interface | Address / port | Notes |
 |---|---|---|
-| Web admin (Cockpit) | HTTPS 9090 | Also via portal proxy on 443 → `/admin` |
+| Web admin (Cockpit) | HTTPS 9090 | Also via portal proxy on 443 > `/admin` |
 | Wi-Fi hotspot | `10.41.0.1/24`, SSID `AryaOS-xxxx` | comitup portal on 9080 |
 | Bluetooth PAN | `10.44.0.1/24` (`pan0`) | Local NAP, DHCP, no NAT |
 | Local CoT hub | `udp://127.0.0.1:28087` | CharonTAK ingress |
@@ -41,15 +41,15 @@ Full list: [Ports & protocols](reference/ports.md).
 
 | Domain | Protocol / standard | On AryaOS via |
 |---|---|---|
-| Air | ADS-B (RTCA DO-260 family), 1090 MHz | `readsb` / `dump1090-fa` → [ADSBCOT](reference/software-suite.md) |
-| Air | UAT, 978 MHz | `dump978-fa` → ADSBCOT |
+| Air | ADS-B (RTCA DO-260 family), 1090 MHz | `readsb` / `dump1090-fa` > [ADSBCOT](reference/software-suite.md) |
+| Air | UAT, 978 MHz | `dump978-fa` > ADSBCOT |
 | Air | APRS | [APRSCOT](reference/software-suite.md) |
-| Maritime | AIS (VHF) | `ais-catcher` → [AISCOT](reference/software-suite.md) |
+| Maritime | AIS (VHF) | `ais-catcher` > [AISCOT](reference/software-suite.md) |
 | Drone | Remote ID / Open Drone ID (ASTM) | [DroneCOT](reference/software-suite.md) |
 | Drone | DJI DroneID | DJICOT |
 | Drone | MAVLink (SiK radio telemetry) | SiKW00FCOT |
 | Position | NMEA / `gpsd` | [GPSTAK](reference/software-suite.md), LINCOT |
-| TAK | Cursor on Target (CoT) — XML & Protobuf | [PyTAK](reference/software-suite.md#pytak) / all gateways |
+| TAK | Cursor on Target (CoT) - XML & Protobuf | [PyTAK](reference/software-suite.md#pytak) / all gateways |
 | TAK | Mesh SA multicast | [CharonTAK](reference/software-suite.md#charontak) |
 | TAK | TAK Server streaming (TLS/TCP) | CharonTAK lanes |
 | EFB | GDL90 | [GDLTAK](reference/software-suite.md) |
@@ -58,14 +58,14 @@ Definitions for each: [Glossary](reference/glossary.md).
 
 ## TAK compatibility
 
-Works with all TAK products: **ATAK, WinTAK, iTAK, TAKX, and TAK Server**. Devices onboard to a TAK Server by data package or `tak://` enrollment link — see [Connect to a TAK Server](deploy/connect-tak-server.md).
+Works with all TAK products: **ATAK, WinTAK, iTAK, TAKX, and TAK Server**. Devices onboard to a TAK Server by data package or `tak://` enrollment link - see [Connect to a TAK Server](deploy/connect-tak-server.md).
 
 ## Device identity
 
 | Item | Specification |
 |---|---|
 | Machine ID | RFC 4122 UUID (`/etc/machine-id`) |
-| Device suffix | [`DEVICE_SUFFIX`](reference/glossary.md#device_suffix) — 4 hex chars from machine-id (or MAC) |
+| Device suffix | [`DEVICE_SUFFIX`](reference/glossary.md#device_suffix) - 4 hex chars from machine-id (or MAC) |
 | Hostname / mDNS | `aryaos-xxxx` / `aryaos-xxxx.local` |
 | Wi-Fi SSID | `AryaOS-xxxx` |
 | CoT source id | `COT_HOST_ID=aryaos-xxxx` |
@@ -78,8 +78,8 @@ Per-device web TLS, hardened `sshd` (no root, `MaxAuthTries 4`), `fail2ban`, sys
 
 <div class="grid cards" markdown>
 
-- :material-cart: **Buy hardware** — The assembled AirTAK go-kit. [Buy hardware](purchase.md)
-- :material-package: **Software suite** — What ships in the box. [Software suite](reference/software-suite.md)
-- :material-lan: **Ports & protocols** — The network footprint. [Ports & protocols](reference/ports.md)
+- :material-cart: **Buy hardware** - The assembled AirTAK go-kit. [Buy hardware](purchase.md)
+- :material-package: **Software suite** - What ships in the box. [Software suite](reference/software-suite.md)
+- :material-lan: **Ports & protocols** - The network footprint. [Ports & protocols](reference/ports.md)
 
 </div>

--- a/docs/testing-dev-pi.md
+++ b/docs/testing-dev-pi.md
@@ -93,6 +93,6 @@ The runner exits **1** if any module reports failures; **0** if only warnings/sk
 
 ## Related docs
 
-- [dev-pi.md](dev-pi.md) — lab Pi setup, sync, portal deploy
-- [portal.md](portal.md) — portal JSON schema and TAK gateway list
-- [AGENTS.md](https://github.com/snstac/aryaos/blob/main/AGENTS.md) — agent workflow after portal or image changes
+- [dev-pi.md](dev-pi.md) - lab Pi setup, sync, portal deploy
+- [portal.md](portal.md) - portal JSON schema and TAK gateway list
+- [AGENTS.md](https://github.com/snstac/aryaos/blob/main/AGENTS.md) - agent workflow after portal or image changes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,10 +1,10 @@
 # Troubleshooting
 
-Symptom-to-fix checks for the problems you are most likely to hit in the field. Each section lists the likely cause and the concrete thing to check — most from the web admin, no shell required.
+Symptom-to-fix checks for the problems you are most likely to hit in the field. Each section lists the likely cause and the concrete thing to check - most from the web admin, no shell required.
 
 !!! tip "Two tools solve most cases"
-    - **Sensor services card** (Cockpit → AryaOS Site) shows at a glance which gateways are running.
-    - **Support bundle** (Cockpit → AryaOS Site → Support bundle, or `sudo aryaos-support-bundle`) captures redacted logs, service status, and config for support. See [Support bundles](operations/support-bundles.md).
+    - **Sensor services card** (Cockpit > AryaOS Site) lists the running gateways.
+    - **Support bundle** (Cockpit > AryaOS Site > Support bundle, or `sudo aryaos-support-bundle`) captures redacted logs, service status, and config for support. See [Support bundles](operations/support-bundles.md).
 
 ## No tracks in TAK
 
@@ -18,7 +18,7 @@ Check, in order:
 1. **Is the TAK client on the right network?** Confirm the phone/laptop is joined to `AryaOS-xxxx`, not another Wi-Fi.
 2. **Is Mesh SA enabled in the TAK client?** In ATAK, enable the Mesh SA / multicast input.
 3. **Is the sensor running?** Open the **Sensor services** card. The relevant gateway (`adsbcot`, `aiscot`, `dronecot`) should be active.
-4. **Is the right role selected?** The [device role](config/device-roles.md) must include your sensor — e.g. `air` or `multi` for aircraft. Set it in the **Device role** card.
+4. **Is the right role selected?** The [device role](config/device-roles.md) must include your sensor - e.g. `air` or `multi` for aircraft. Set it in the **Device role** card.
 5. **Is the radio decoding?** For ADS-B, the aircraft feed lives at `/run/adsb/aircraft.json`; if it is empty, the SDR or antenna is the problem (see [SDR not detected](#sdr-not-detected)).
 
 See [Aircraft (ADS-B)](deploy/air-adsb.md), [Maritime (AIS)](deploy/maritime-ais.md), [Counter-UAS](deploy/counter-uas.md).
@@ -30,8 +30,8 @@ See [Aircraft (ADS-B)](deploy/air-adsb.md), [Maritime (AIS)](deploy/maritime-ais
 1. **Give first boot time.** A new device needs ~120 seconds before the hotspot and web console come up.
 2. **Are you on the hotspot?** Join `AryaOS-xxxx` first.
 3. **Try the IP.** If `aryaos-xxxx.local` fails (mDNS resolver issue), use `https://10.41.0.1`.
-4. **Accept the certificate.** The per-device certificate is self-signed; the browser warning is expected — proceed. See [Security posture](security.md).
-5. **Try the direct Cockpit port.** The portal proxies 443 → Cockpit; you can also reach Cockpit directly on `https://<host>:9090`.
+4. **Accept the certificate.** The per-device certificate is self-signed; the browser warning is expected - proceed. See [Security posture](security.md).
+5. **Try the direct Cockpit port.** The portal proxies 443 > Cockpit; you can also reach Cockpit directly on `https://<host>:9090`.
 6. **Firewall.** If you changed the firewall, confirm Cockpit/portal are still allowed in [Firewall](networking/firewall.md).
 
 ## No Wi-Fi hotspot
@@ -39,7 +39,7 @@ See [Aircraft (ADS-B)](deploy/air-adsb.md), [Maritime (AIS)](deploy/maritime-ais
 The `AryaOS-xxxx` network never appears.
 
 1. **Wait out first boot** (~120 s on a new device).
-2. **Confirm the suffix.** The SSID is `AryaOS-xxxx` where `xxxx` matches the hostname; look carefully — it may not be the name you expect. See [`DEVICE_SUFFIX`](reference/glossary.md#device_suffix).
+2. **Confirm the suffix.** The SSID is `AryaOS-xxxx` where `xxxx` matches the hostname; look carefully - it may not be the name you expect. See [`DEVICE_SUFFIX`](reference/glossary.md#device_suffix).
 3. **Already joined to another Wi-Fi?** comitup runs the hotspot only when not connected as a client. If the box joined a known network, the AP may be down by design. See [Wi-Fi & onboarding hotspot](networking/wifi-hotspot.md).
 4. **Reach it another way.** Connect over Ethernet or the [Bluetooth PAN](bluetooth-pan.md) to investigate.
 
@@ -49,25 +49,25 @@ A radio is plugged in but the decoder sees nothing.
 
 1. **List the dongles.** In **Radios** (or `sudo aryaos-sdr list`) confirm the dongle enumerates.
 2. **Check the serial.** Each SDR needs a unique serial: `stx:1090:0` for ADS-B, `stx:978:0` for UAT. Two dongles with the same serial collide. Fix with **Radios** or [`aryaos-sdr set-serial`](reference/cli-helpers.md#aryaos-sdr), then **replug or reboot**.
-3. **Power.** Multiple SDRs can exceed the Pi's USB budget — use a powered hub and a stronger power supply. See [Hardware & requirements](get-started/hardware.md).
-4. **Antenna.** No detections despite a working dongle usually means an antenna/placement problem — check the connector and line of sight.
+3. **Power.** Multiple SDRs can exceed the Pi's USB budget - use a powered hub and a stronger power supply. See [Hardware & requirements](get-started/hardware.md).
+4. **Antenna.** No detections despite a working dongle usually means an antenna/placement problem - check the connector and line of sight.
 
 ## Box keeps rebooting, or all sensors are stopped (safe mode) {#safe-mode}
 
-If the box reboots in a loop, or comes up with every sensor stopped and USB peripherals dead, it has almost certainly **browned out under load on an under-spec'd power supply** — and AryaOS has latched **safe mode** to keep it reachable instead of crash-looping.
+If the box reboots in a loop, or comes up with every sensor stopped and USB peripherals dead, it has almost certainly **browned out under load on an under-spec'd power supply** - and AryaOS has latched **safe mode** to keep it reachable instead of crash-looping.
 
 1. **Confirm.** Run `aryaos-safe-mode status`, or look for the red banner on the **AryaOS Site** Cockpit page. `safe-mode: ON` with a `crash-loop` reason means it tripped after 3 consecutive short boots.
-2. **Fix the power** — nearly always the cause. See [Power & battery](get-started/hardware.md#power--battery-for-backpack-ops): a Pi 5 needs a **5V/5A (27&nbsp;W)** supply; a big GaN charger that only does 5V/3A, or a PoE HAT on plain 802.3af, will not sustain it.
-3. **Restore.** On a good supply, clear safe mode from **Cockpit → AryaOS Site → Safe mode** ("Restore now" or "Restore &amp; reboot"), or `sudo aryaos-safe-mode off` — this re-powers USB and restarts the sensors.
+2. **Fix the power** - nearly always the cause. See [Power & battery](get-started/hardware.md#power-battery-for-backpack-ops): a Pi 5 needs a **5V/5A (27&nbsp;W)** supply; a big GaN charger that only does 5V/3A, or a PoE HAT on plain 802.3af, will not sustain it.
+3. **Restore.** On a good supply, clear safe mode from **Cockpit > AryaOS Site > Safe mode** ("Restore now" or "Restore &amp; reboot"), or `sudo aryaos-safe-mode off` - this re-powers USB and restarts the sensors.
 4. **Check under-voltage** any time with `vcgencmd get_throttled` (`0x0` is clean); the AryaOS Site page also shows this as a live power-health warning.
 
 ## A service won't start
 
 A gateway shows as failed or keeps restarting.
 
-1. **Sensor services card** — identify which unit is down.
+1. **Sensor services card** - identify which unit is down.
 2. **Read the logs.** The support bundle includes each service's recent journal. Generate one from **Support bundle** (or `sudo aryaos-support-bundle`), which redacts secrets automatically. See [Support bundles](operations/support-bundles.md).
-3. **Check the role.** A unit disabled by the current [device role](config/device-roles.md) is expected to be stopped — that is not a failure. Switch roles in **Device role** if you need it running.
+3. **Check the role.** A unit disabled by the current [device role](config/device-roles.md) is expected to be stopped - that is not a failure. Switch roles in **Device role** if you need it running.
 4. **From a shell** (optional): `systemctl status <unit>` and `journalctl -u <unit>` show the failure reason.
 
 ## TAK Server won't connect
@@ -75,7 +75,7 @@ A gateway shows as failed or keeps restarting.
 Tracks reach Mesh SA but not your TAK Server.
 
 1. **Re-import the connection.** Import the TAK **data package** or `tak://` enrollment link again from the **TAK connection** card. AryaOS installs the certs and writes a CharonTAK lane. See [Connect to a TAK Server](deploy/connect-tak-server.md).
-2. **Certificate/CA.** A bad or expired client certificate, or the wrong CA in the package, stops the TLS handshake — get a fresh package from your TAK admin.
+2. **Certificate/CA.** A bad or expired client certificate, or the wrong CA in the package, stops the TLS handshake - get a fresh package from your TAK admin.
 3. **Reachability.** The device must be able to reach the server host and port (the connect string in the package). On a disconnected box, add a route: Ethernet, an upstream Wi-Fi client connection, or the [VPN](networking/vpn-tailscale.md).
 4. **CharonTAK lane.** Confirm the `lane:local-to-takserver` lane is enabled in the [Charontak lane editor](admin/charontak-lanes.md).
 
@@ -91,8 +91,8 @@ The device's own position is missing or wrong.
 
 <div class="grid cards" markdown>
 
-- :material-archive: **Support bundle** — Redacted diagnostics for support. [Support bundles](operations/support-bundles.md)
-- :material-frequently-asked-questions: **FAQ** — Quick answers. [FAQ](help/faq.md)
-- :material-github: **Report an issue** — [github.com/snstac/aryaos](https://github.com/snstac/aryaos/issues)
+- :material-archive: **Support bundle** - Redacted diagnostics for support. [Support bundles](operations/support-bundles.md)
+- :material-frequently-asked-questions: **FAQ** - Quick answers. [FAQ](help/faq.md)
+- :material-github: **Report an issue** - [github.com/snstac/aryaos](https://github.com/snstac/aryaos/issues)
 
 </div>

--- a/scripts/test_docs_style.py
+++ b/scripts/test_docs_style.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Style checks for published documentation and the repository README."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DocsStyleTestCase(unittest.TestCase):
+    def setUp(self):
+        self.docs = [ROOT / "README.md", *sorted((ROOT / "docs").rglob("*.md"))]
+
+    def test_docs_use_plain_ascii_punctuation(self):
+        forbidden = {
+            "\N{EM DASH}": "em dash",
+            "\N{EN DASH}": "en dash",
+            "\N{HORIZONTAL ELLIPSIS}": "ellipsis",
+            "\N{RIGHT SINGLE QUOTATION MARK}": "curly apostrophe",
+            "\N{RIGHTWARDS ARROW}": "right arrow",
+            "\N{MULTIPLICATION SIGN}": "multiplication sign",
+        }
+        failures = []
+        for path in self.docs:
+            source = path.read_text()
+            for character, name in forbidden.items():
+                if character in source:
+                    failures.append(f"{path.relative_to(ROOT)}: {name}")
+        self.assertEqual([], failures)
+
+    def test_docs_avoid_canned_marketing_phrases(self):
+        pattern = re.compile(
+            r"\b(?:at a glance|out of the box|simply|seamless(?:ly)?|"
+            r"revolutionary|next-generation|empowering|actionable insights?|"
+            r"exciting possibilities|delve|robust|comprehensive|leverage|"
+            r"in this guide|important to note|worth noting|that's it|"
+            r"what you'll see|everything you need)\b",
+            re.IGNORECASE,
+        )
+        failures = []
+        for path in self.docs:
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                if pattern.search(line):
+                    failures.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
+        self.assertEqual([], failures)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove em/en dashes, smart ellipses, curly apostrophes, decorative arrows, and multiplication glyphs from all Markdown documentation and the README
- rewrite canned marketing and machine-written phrases with direct operational language
- repair three stale power-section anchors found during the strict documentation build
- add a regression test that rejects the punctuation and phrase set

Vendored HTML/CSS design-system source assets remain unchanged because they are excluded from the generated documentation and must stay aligned with their upstream source.

## Validation

- all 45 tests on current `main` pass
- `mkdocs build --strict` builds 60 HTML pages without link-anchor warnings
- rendered site scan contains zero forbidden punctuation outside the excluded vendored design-guide asset
- source scan contains zero forbidden punctuation or flagged canned phrases
- `git diff --check` passes
